### PR TITLE
Symlink mojito when installing from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ on-line/off-line, multi-device, hosted application platform.
 
     $ git clone git://github.com/yahoo/mojito.git
     $ cd mojito/source
-    $ npm install -g .
-    $ npm install .
+    $ npm install
+    $ npm ln
 
 ### via npm
 


### PR DESCRIPTION
Rather than install the full mojito package globally, just symlink the
cloned copy into the global npm path using `npm ln`.
