### PR TITLE
use public URL instead of yahoo corp

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -42,7 +42,7 @@
 
                     <div class="summary description">
                       This is the API documentation for the 
-                      <a href="http://y.ahoo.it/mojito">Yahoo! Mojito Presentation Framework</a>.
+                      <a href="http://developer.yahoo.com/cocktails/mojito/">Yahoo! Mojito Presentation Framework</a>.
                       <p>Choose a module name from the list for more information.</p>
                     </div>
 


### PR DESCRIPTION
now y.ahoo.it/mojito points to developer.corp.yahoo.com and it's not expected
