### PR TITLE
Configurable Doctype - Based on User-Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yahoo! Mojito
+# GVaish mMojito (Gaurav's enhancements to Yahoo! Mojito)
 
 Mojito is the JavaScript library implementing Cocktails, a JavaScript-based
 on-line/off-line, multi-device, hosted application platform.
@@ -66,4 +66,9 @@ Please see the LICENSE.txt file for details.
 Mojito includes the Mulib software available here:
 
 https://github.com/raycmorgan/Mu
+
+## Gaurav's website
+
+http://www.mastergaurav.com
+
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GVaish mMojito (Gaurav's enhancements to Yahoo! Mojito)
+# Yahoo! Mojito
 
 Mojito is the JavaScript library implementing Cocktails, a JavaScript-based
 on-line/off-line, multi-device, hosted application platform.

--- a/examples/simple/part6/readme.md
+++ b/examples/simple/part6/readme.md
@@ -1,6 +1,6 @@
 Start the Mojito application;
 
-> mojito start
+    mojito start
 
 Then view in a browser;
 
@@ -14,9 +14,9 @@ Make a HTML5 Application
 
 From the Mojito application directory;
 
-> mojito build html5app
-> cd ./artifacts/builds/html5app/
-> mojito start
+    mojito build html5app
+    cd ./artifacts/builds/html5app/
+    mojito start
 
 Then view in a browser;
 
@@ -32,8 +32,8 @@ Note: You must have XCode installed.
 
 From the Mojito application directory;
 
-> mojito create project xcode ipad
-> open ./artifacts/projects/xcode/ipad/
+    mojito create project xcode ipad
+    open ./artifacts/projects/xcode/ipad/
 
 Double click on the "mojito-ios.xcodeproj" icon. Once the project has open click the "Build & Run" icon in XCode.
 

--- a/source/lib/mojits/HTMLFrameMojit/controller.server.js
+++ b/source/lib/mojits/HTMLFrameMojit/controller.server.js
@@ -76,6 +76,7 @@ YUI.add('HTMLFrameMojit', function(Y, NAME) {
                     'text/html; charset="utf-8"';
 
                 // Set the default data
+                data.doctype = ac.config.get('doctype') || '<!DOCTYPE HTML>';
                 data.title = ac.config.get('title') ||
                     'Powered by Mojito ' + Y.mojito.version;
                 data.mojito_version = Y.mojito.version;

--- a/source/lib/mojits/HTMLFrameMojit/views/index.iphone.mu.html
+++ b/source/lib/mojits/HTMLFrameMojit/views/index.iphone.mu.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+{{{doctype}}}
 <html>
 <head>
 <script type="text/javascript">var MOJITO_INIT=new Date().getTime();</script>

--- a/source/lib/mojits/HTMLFrameMojit/views/index.mu.html
+++ b/source/lib/mojits/HTMLFrameMojit/views/index.mu.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+{{{doctype}}}
 <html>
 <head>
 <script type="text/javascript">var MOJITO_INIT=new Date().getTime();</script>

--- a/source/package.json
+++ b/source/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mojito",
     "version": "0.3.1",
+	"mversion": "0.0.1",
     "description": "Mojito provides an architecture, components and tools for developers to build complex web applications faster.",
     "preferGlobal": true,
     "author": "Team Mojito (http://developer.yahoo.com/cocktails/mojito)",
@@ -9,7 +10,8 @@
         "Matt Taylor <mtaylor@yahoo-inc.com>",
         "Chris Klaiber <cklaiber@yahoo-inc.com>",
         "Drew Folta <folta@yahoo-inc.com>",
-        "Martin Cooper <mcooper@yahoo-inc.com>"
+        "Martin Cooper <mcooper@yahoo-inc.com>",
+        "Gaurav Vaish <gaurav.vaish-AT-gmail.com>"
     ],
     "### dependencies notes" : {
         "jsdom": "version 0.2.0 does not (directly) install a binary extension"

--- a/source/package.json
+++ b/source/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mojito",
     "version": "0.3.1",
-	"mversion": "0.0.1",
+	"mversion": "0.0.2",
     "description": "Mojito provides an architecture, components and tools for developers to build complex web applications faster.",
     "preferGlobal": true,
     "author": "Team Mojito (http://developer.yahoo.com/cocktails/mojito)",


### PR DESCRIPTION
Pull 121 (https://github.com/yahoo/mojito/pull/121) can be closed.

The updated version allows configurable DOCTYPE declaration based on User-Agent.

Actual code in commit #80bd20c4
(https://github.com/gvaish/mojito/commit/80bd20c4fb3997398991a4b0c0459aed71342175)
