### PR TITLE
child to null should not break the ac.composite.done call

### DIFF
--- a/source/lib/app/addons/ac/composite.common.js
+++ b/source/lib/app/addons/ac/composite.common.js
@@ -211,6 +211,15 @@ callback({
                                 ' array. \'children\' must be an object.');
             }
 
+            // check to ensure children doesn't have a null child
+            // in which case it will be automatically discarded to
+            // facilitate disabling childs based on the context.
+            Y.Object.each(cfg.children, function(child, name) {
+                if (!child) {
+                    delete cfg.children[name];
+                }
+            });
+
             meta.children = cfg.children;
 
             buffer.__counter__ = Y.Object.size(cfg.children);

--- a/source/lib/mojits/HTMLFrameMojit/controller.server.js
+++ b/source/lib/mojits/HTMLFrameMojit/controller.server.js
@@ -51,8 +51,9 @@ YUI.add('HTMLFrameMojit', function(Y, NAME) {
             var child = ac.config.get('child'),
                 cfg;
 
-            // Map the action to the child
-            child.action = ac.action;
+            // Map the action to the child if the action
+            // is not specified as part of the child config.
+            child.action = child.action || ac.action;
 
             // Create a config object for the composite addon
             cfg = {

--- a/source/lib/tests/autoload/app/addons/ac/composite-tests.common.js
+++ b/source/lib/tests/autoload/app/addons/ac/composite-tests.common.js
@@ -251,7 +251,43 @@ YUI.add('mojito-composite-addon-tests', function(Y, NAME) {
             });
 
             A.isTrue(exeCbCalled, "execute callback never called");
+        },
+
+        'null or undefined child should be discarded': function() {
+            var command = {instance: {}},
+                adapter = null,
+                ac = {
+                    _dispatch: function(command, adapter) {
+                        A.isObject(command, "bad command object to dispatch");
+                        A.isNotUndefined(adapter, "bad adapter for dispatch");
+                        var id = command.instance.id;
+                        var meta = {};
+                        meta[id] = id + '__meta';
+                        adapter.done(id + '__data', meta);
+                    }, _notify: function() {}
+                },
+                c = new Y.mojito.addons.ac.composite(command, adapter, ac),
+                config = {
+                    children: {
+                        kid_a: null,
+                        kid_b: { id: 'kid_b', type: 'kidb' }
+                    }
+                },
+                exeCbCalled = false;
+
+            c.execute(config, function(data, meta) {
+                exeCbCalled = true;
+                A.isUndefined(data.kid_a, "unexpected kid_a data for null child");
+                A.isString(data.kid_b, "missing kid_b data");
+                A.areSame('kid_b__data', data.kid_b, "wrong kid_b data");
+                A.isUndefined(meta.kid_a, "unexpected kid_a meta for null child");
+                A.isString(meta.kid_b, "missing kid_b meta");
+                A.areSame('kid_b__meta', meta.kid_b, "wrong kid_b meta");
+            });
+
+            A.isTrue(exeCbCalled, "execute callback never called");
         }
+
     }));
     
     YUITest.TestRunner.add(suite);


### PR DESCRIPTION
disabling a child mojit by setting it to null in the children structure is now supported. Check issue #129 for more details.
