### PR TITLE
Mojito test broken when using node modules

### DIFF
--- a/source/lib/management/commands/test.js
+++ b/source/lib/management/commands/test.js
@@ -649,7 +649,7 @@ runTests = function(opts) {
         targetTests,
         testName = opts.name,
         testType = opts.type || 'fw',
-        path = opts.path,
+        path = pathlib.resolve(opts.path),
         coverage = inputOptions.coverage,
         verbose = inputOptions.verbose,
         store,


### PR DESCRIPTION
### Summary

When running `mojito test app .` the tests fail because an npm module cannot be found.
### How to reproduce

Add an addon to your project. Say `addons/ac/addons-ac-logger.js`

In the addons file we'll use a module from npm [winston](http://search.npmjs.org/#/winston), this is installed via `npm install winston` and resides in the `node_modules/` of your project.

Now since paths don't quite work the same in YUI3-node as they do in node we'll use a relative path inside our logger.js file:

```
var winston = require('./../../node_modules/winston');
```

When we run `mojito test app .` it fails

```
error: (nodejsyui3): Error: Cannot find or access denied to the module 'addons/ac/../../node_modules/winston'
```
