### PR TITLE
Fix for a bug in "mojito build html5app" command.

### DIFF
--- a/source/lib/management/commands/build.js
+++ b/source/lib/management/commands/build.js
@@ -142,13 +142,8 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
         // files to fetch through the server
         serverFiles = { css: true, js: true, json: true },
         extension,
-// Removed manifest file from output
-//        manifest = 'CACHE MANIFEST\n',
-//        indexJs = "module.exports = require('express')." +
-//            "createServer(require('express')['static'](__dirname));",
         url,
         urls = {}, // from: to
-//        app,
         context = '',
         appConfig,
         tunnelPrefix;
@@ -183,10 +178,6 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
 
     console.log('...');
 
-// Removed manifest file from output
-    // Set the cachable files in the manifest
-//    manifest += 'CACHE:\n';
-
     // Copy all the files into the destination directory
     for (url in store._staticURLs) {
         if (store._staticURLs.hasOwnProperty(url)) {
@@ -195,9 +186,6 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
             extension = from.split('.').pop();
 
             mkdirP(libpath.dirname(to), MODE_755);
-
-// Removed manifest file from output
-//            manifest += url + '\n';
 
             if (serverFiles[extension] !== undefined) {
                 urls[url + context] = url;
@@ -216,21 +204,6 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
             mkdirP(libpath.dirname(libpath.join(destination, url)), MODE_755);
         }
     }
-
-// Removed manifest file from output
-//    for (url in urls) {
-//        if (urls.hasOwnProperty(url)) {
-//            manifest += (urls[url] === '/' ? '/index.html' : urls[url]) + '\n';
-//        }
-//    }
-
-// Removed manifest file from output
-    // Write the "cache.manifest" file
-//    fs.writeFileSync(libpath.join(destination, 'cache.manifest'), manifest,
-//        'utf8');
-// Removed manifest file from output
-    // Write a "quick test" index.js file
-//    fs.writeFileSync(libpath.join(destination, 'index.js'), indexJs, 'utf8');
 
     // Now use the server to generate some of the files
     writeWebPagesToFiles(type, store, destination, urls, config, callback);

--- a/source/lib/management/commands/build.js
+++ b/source/lib/management/commands/build.js
@@ -148,8 +148,11 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
         appConfig,
         tunnelPrefix;
 
+    // If the cmdOptions.context has a string value then;
     // Convert the documented "mojito start --context" value "key:val,key:val" to "key=val&key=val"
-    cmdOptions.context = cmdOptions.context.replace(/:/g, '=').replace(/,/g, '&')
+    if (typeof cmdOptions.context === 'string') {
+        cmdOptions.context = cmdOptions.context.replace(/:/g, '=').replace(/,/g, '&');
+    }
 
     if (cmdOptions.context) {
         context = '?' + cmdOptions.context;

--- a/source/lib/management/commands/build.js
+++ b/source/lib/management/commands/build.js
@@ -142,19 +142,27 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
         // files to fetch through the server
         serverFiles = { css: true, js: true, json: true },
         extension,
-        manifest = 'CACHE MANIFEST\n',
-        indexJs = "module.exports = require('express')." +
-            "createServer(require('express')['static'](__dirname));",
+// Removed manifest file from output
+//        manifest = 'CACHE MANIFEST\n',
+//        indexJs = "module.exports = require('express')." +
+//            "createServer(require('express')['static'](__dirname));",
         url,
         urls = {}, // from: to
-        app,
+//        app,
         context = '',
         appConfig,
         tunnelPrefix;
 
+    // Convert the documented "mojito start --context" value "key:val,key:val" to "key=val&key=val"
+    cmdOptions.context = cmdOptions.context.replace(/:/g, '=').replace(/,/g, '&')
+
     if (cmdOptions.context) {
         context = '?' + cmdOptions.context;
     }
+
+    // Add the provided context to the server config object so
+    // we start Mojito with the correct context.
+    config.context = libqs.parse(cmdOptions.context);
 
     urls['/' + context] = '/index.html';
 
@@ -175,8 +183,9 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
 
     console.log('...');
 
+// Removed manifest file from output
     // Set the cachable files in the manifest
-    manifest += 'CACHE:\n';
+//    manifest += 'CACHE:\n';
 
     // Copy all the files into the destination directory
     for (url in store._staticURLs) {
@@ -187,7 +196,8 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
 
             mkdirP(libpath.dirname(to), MODE_755);
 
-            manifest += url + '\n';
+// Removed manifest file from output
+//            manifest += url + '\n';
 
             if (serverFiles[extension] !== undefined) {
                 urls[url + context] = url;
@@ -207,18 +217,20 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
         }
     }
 
-    for (url in urls) {
-        if (urls.hasOwnProperty(url)) {
-            manifest += (urls[url] === '/' ? '/index.html' : urls[url]) + '\n';
-        }
-    }
+// Removed manifest file from output
+//    for (url in urls) {
+//        if (urls.hasOwnProperty(url)) {
+//            manifest += (urls[url] === '/' ? '/index.html' : urls[url]) + '\n';
+//        }
+//    }
 
+// Removed manifest file from output
     // Write the "cache.manifest" file
-    fs.writeFileSync(libpath.join(destination, 'cache.manifest'), manifest,
-        'utf8');
-
+//    fs.writeFileSync(libpath.join(destination, 'cache.manifest'), manifest,
+//        'utf8');
+// Removed manifest file from output
     // Write a "quick test" index.js file
-    fs.writeFileSync(libpath.join(destination, 'index.js'), indexJs, 'utf8');
+//    fs.writeFileSync(libpath.join(destination, 'index.js'), indexJs, 'utf8');
 
     // Now use the server to generate some of the files
     writeWebPagesToFiles(type, store, destination, urls, config, callback);
@@ -395,7 +407,8 @@ writeWebPagesToFiles = function(type, store, destination, urls, config,
     }
 
     options = {
-        port: 11111
+        port: 11111,
+        context: config.context // Added so we can pass the context to app.start()
     };
 
     app = new utils.App(options);


### PR DESCRIPTION
Here is small patch for a bug in "mojito build html5app" command which stopped the context from being used when the Mojito server is started as part of the build process. I have also commented out the "manifest" and "index.js" files as they are currently not working as expected.
