### PR TITLE
Handlebars support in mojito.

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -15,10 +15,6 @@ Currently Deprecated
 
 ### Deprecated but Available
 
-* (2012-04-23) The `autoload/` directory is going away in favor of
-`yui_modules/`, which better reflects its contents.  Everthing else about it is
-the same, only the name has changed.  You can start using `yui_modules/` today.
-
 * (2012-04-23) The `.guid` member of Mojito metadata (such as binder metadata)
 is going away.  Often there's an associated member which more specifically
 expresses the intent of the unique ID (for example `.viewId` or `.instanceId`).

--- a/source/lib/app/addons/ac/partial.common.js
+++ b/source/lib/app/addons/ac/partial.common.js
@@ -72,6 +72,32 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
             }, meta);
         },
 
+        /**
+         * This method compiles the "view" specified.
+         * The "view" must be the name of one of the files in the current
+         * Mojits "views" folder.
+         * @param {string} view The view name to be used for rendering.
+         * @param {Object} opts Optional argument depending on the engine.
+         * @return {string} compiled view.
+         */
+        compiler: function(view, opts) {
+            var renderer,
+                mojitView,
+                instance = this.command.instance;
+
+            if (!instance.views[view]) {
+                Y.log('View "' + view + '" not found', 'debug', NAME);
+                return;
+            }
+
+            mojitView = instance.views[view];
+            renderer = new Y.mojito.ViewRenderer(mojitView.engine);
+
+            Y.log('Compiling "' + view + '" view for "' + (instance.id || '@' +
+                instance.type) + '"', 'debug', NAME);
+
+            return renderer.compiler(mojitView['content-path'], opts);
+        },
 
         /**
          * This method calls the current mojit's controller with the "action"

--- a/source/lib/app/addons/view-engines/hb.server.js
+++ b/source/lib/app/addons/view-engines/hb.server.js
@@ -61,7 +61,18 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * that can be sent to the client side.
          */
         compiler: function(tmpl, opts) {
-            return HB.precompile(fs.readFileSync(tmpl, 'utf8'));
+            // this is a little bit of black magic. We return an object
+            // that can be transformed into a string to facilitate the
+            // use of this compiled view through mojito compile view command.
+            // This is the way to differenciate regular strings 
+            // (like mustache compiled views) from handlebars javascript 
+            // functions.
+            return {
+                _d: HB.precompile(fs.readFileSync(tmpl, 'utf8')),
+                toString: function () {
+                    return this._d;
+                }
+            };
         }
     };
 

--- a/source/lib/app/addons/view-engines/hb.server.js
+++ b/source/lib/app/addons/view-engines/hb.server.js
@@ -54,21 +54,13 @@ YUI.add('mojito-hb', function(Y, NAME) {
         },
 
         /**
-         * Stringify the handlebars template.
+         * Precompiles the handlebars template.
          * @param {string} tmpl The name of the template to render.
+         * @param {Object} opts Optional argument depending on the engine.
          * @return {string} the string representation of the template
          * that can be sent to the client side.
          */
-        compiler: function(tmpl) {
-            return JSON.stringify(fs.readFileSync(tmpl, 'utf8'));
-        },
-
-        /**
-         * Precompiles the handlebars template.
-         * @param {string} tmpl The name of the template to render.
-         * @return {string} the precompiled template that can be sent to the client side.
-         */
-        precompile: function(tmpl) {
+        compiler: function(tmpl, opts) {
             return HB.precompile(fs.readFileSync(tmpl, 'utf8'));
         }
     };

--- a/source/lib/app/addons/view-engines/hb.server.js
+++ b/source/lib/app/addons/view-engines/hb.server.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true, nomen:true, node:true*/
+/*global YUI*/
+
+
+YUI.add('mojito-hb', function(Y, NAME) {
+
+    var fs = require('fs'),
+        HB = require('yui/handlebars').Handlebars,
+        cache = YUI.namespace('Env.Handlebars');
+
+    /**
+     * Class text.
+     * @class HandleBarsAdapterServer
+     * @private
+     */
+    function HandleBarsAdapter(viewId) {
+        this.viewId = viewId;
+    }
+
+    HandleBarsAdapter.prototype = {
+
+        /**
+         * Renders the handlebars template using the data provided.
+         * @param {object} data The data to render.
+         * @param {string} mojitType The name of the mojit type.
+         * @param {string} tmpl The name of the template to render.
+         * @param {object} adapter The output adapter to use.
+         * @param {object} meta Optional metadata.
+         * @param {boolean} more Whether there will be more content later.
+         */
+        render: function(data, mojitType, tmpl, adapter, meta, more) {
+            var str, precompiled, template, result;
+
+            // apply a very dummy cache
+            if (!cache[tmpl] || !meta.view.cacheTemplates) {
+                str = fs.readFileSync(tmpl, 'utf8');
+                cache[tmpl] = {
+                    raw: str,
+                    template: HB.compile(str)
+                };
+            }
+            adapter.flush(cache[tmpl].template(data), meta);
+            Y.log('render complete for view "' +
+                                this.viewId + '"',
+                                'mojito', 'qeperf');
+            adapter.done('', meta);
+        },
+
+        /**
+         * Stringify the handlebars template.
+         * @param {string} tmpl The name of the template to render.
+         * @return {string} the string representation of the template
+         * that can be sent to the client side.
+         */
+        compiler: function(tmpl) {
+            return JSON.stringify(fs.readFileSync(tmpl, 'utf8'));
+        },
+
+        /**
+         * Precompiles the handlebars template.
+         * @param {string} tmpl The name of the template to render.
+         * @return {string} the precompiled template that can be sent to the client side.
+         */
+        precompile: function(tmpl) {
+            return HB.precompile(fs.readFileSync(tmpl, 'utf8'));
+        }
+    };
+
+    Y.namespace('mojito.addons.viewEngines').hb = HandleBarsAdapter;
+
+}, '0.1.0', {requires: []});

--- a/source/lib/app/autoload/view-renderer.common.js
+++ b/source/lib/app/autoload/view-renderer.common.js
@@ -40,7 +40,19 @@ YUI.add('mojito-view-renderer', function(Y) {
          */
         render: function(data, mojitType, tmpl, adapter, meta, more) {
             this._renderer.render(data, mojitType, tmpl, adapter, meta, more);
+        },
+
+        /*
+         * Compiles a view into an string representation.
+         * @param {String} tmpl path to template to be precompiled
+         *     engine.
+         * @param {Object} opts Optional argument depending on the engine.
+         * @return {String} the precompiled view.
+         */
+        compiler: function(tmpl, opts) {
+            return this._renderer.compiler(tmpl, opts);
         }
+
     };
 
     Y.mojito.ViewRenderer = Renderer;

--- a/source/package.json
+++ b/source/package.json
@@ -19,7 +19,8 @@
         "express": "2.5.2",
         "jsdom": "0.2.0",
         "mime": "1.2.4",
-        "yui3": "0.7.12"
+        "yui3": "0.7.12",
+        "yui": "3.5.0"
     },
     "keywords": [
         "framework",


### PR DESCRIPTION
Let's get the ball rolling for the handlebars support in mojito. This is just a preliminary job, I plan to add all the missing features into this branch to match the current mustache support. Feel free to reject the pull request for now.

For now, I also added the new yui->3.5.0 to the dependency list although only used by the handlebars engine implementation who requires yui/handlebars. Eventually, when the transition to the new YUI node package happens, should be easy to merge this changes.

Client side is mostly covered by yui 3.5.0, we just need to create the mojito wrapper for it.

TODO: 
- tests
- figure out how to call done and composite.done without specifying the content-path as part of the view object.
- create view-engines/hb.client.js as a wrapper for YUI 3.5.0 handlebars implementation

I don't plan to add support for {{> partial}} since that requires some extra machinery to resolves paths etc.
