### PR TITLE
Fix a bug on mustache that prevents page rendering (crashes) when binding data contains null

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -15,10 +15,6 @@ Currently Deprecated
 
 ### Deprecated but Available
 
-* (2012-04-23) The `autoload/` directory is going away in favor of
-`yui_modules/`, which better reflects its contents.  Everthing else about it is
-the same, only the name has changed.  You can start using `yui_modules/` today.
-
 * (2012-04-23) The `.guid` member of Mojito metadata (such as binder metadata)
 is going away.  Often there's an associated member which more specifically
 expresses the intent of the unique ID (for example `.viewId` or `.instanceId`).

--- a/source/lib/app/libs/Mulib/Mu.js
+++ b/source/lib/app/libs/Mulib/Mu.js
@@ -188,7 +188,7 @@ Mu.enumerable = function Mu_enumerable(context, val, fn) {
         return result;
     }
     
-    if (typeof val === 'object') {
+    if (typeof val === 'object' && val) {
         var oproto = insertProto(val, context);
         var ret = fn(val);
         oproto.__proto__ = baseProto;

--- a/source/lib/tests/fixtures/gsg5/mojits/FlickrDetail/controller.common.js
+++ b/source/lib/tests/fixtures/gsg5/mojits/FlickrDetail/controller.common.js
@@ -44,15 +44,12 @@ YUI.add('FlickrDetail', function(Y) {
                 details.intl.posted = ac.intl.formatDate(new Date(1000 * Number(details.dates.posted)));
 
                 // The mustache library we're using is a little finicky.
-                details.title = details.title || false;
                 if (details.title) {
                     details.have_title = true;
                 }
-                details.description = details.description || false;
                 if (details.description) {
                     details.have_description = true;
                 }
-                details.tags = details.tags || false;
 
                 ac.assets.addCss('./index.css');
                 ac.done(details);


### PR DESCRIPTION
Fix a bug on mustache that prevents page rendering (crashes) when binding data contains null.
