### PR TITLE
Migrating over to YUI 3.5.1 official install

### DIFF
--- a/source/lib/app/autoload/rest.common.js
+++ b/source/lib/app/autoload/rest.common.js
@@ -152,6 +152,6 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
     };
 
 }, '0.1.0', {requires: [
-    'io',
+    'io-base',
     'mojito'
 ]});

--- a/source/lib/app/autoload/route-maker.common.js
+++ b/source/lib/app/autoload/route-maker.common.js
@@ -439,8 +439,7 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
 
     Y.mojito.RouteMaker = Maker;
 
-}, '0.1.0', {requires: [
-    'querystring-stringify-simple',
-    'querystring-parse',
+}, '0.1.0', {  requires: [
+    'querystring',
     'mojito-util'
 ]});

--- a/source/lib/app/autoload/route-maker.common.js
+++ b/source/lib/app/autoload/route-maker.common.js
@@ -440,6 +440,7 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
     Y.mojito.RouteMaker = Maker;
 
 }, '0.1.0', {  requires: [
-    'querystring',
+    'querystring-stringify-simple',
+    'querystring-parse',
     'mojito-util'
 ]});

--- a/source/lib/config.json
+++ b/source/lib/config.json
@@ -6,7 +6,7 @@
         "routesFiles": [ "routes.json" ],
         "tunnelPrefix": "/tunnel",
         "yui": {
-            "dependencyCalculations": "ondemand"
+            "dependencyCalculations": "precomputed"
         },
         "specs": {
             "daliProxy": {

--- a/source/lib/config.json
+++ b/source/lib/config.json
@@ -6,7 +6,7 @@
         "routesFiles": [ "routes.json" ],
         "tunnelPrefix": "/tunnel",
         "yui": {
-            "dependencyCalculations": "precomputed"
+            "dependencyCalculations": "ondemand"
         },
         "specs": {
             "daliProxy": {

--- a/source/lib/index.js
+++ b/source/lib/index.js
@@ -27,7 +27,7 @@ var MOJITO_MIDDLEWARE = [
     CORE_MOJITO_MODULES = ['mojito', 'mojito-route-maker'],
 
     MOJITO_INIT = new Date().getTime(),
-    YUI = require('yui3').YUI,
+    YUI = require('yui').YUI,
     serverLog = require('./server-log'),
     requestCounter = 0, // used to scope logs per request
     logger;
@@ -176,16 +176,16 @@ MojitoServer.prototype = {
             }
         });
 
-        Y = YUI({ core: CORE_YUI_MODULES });
+        Y = YUI({ core: CORE_YUI_MODULES, useSync: true });
 
         // Load logger early so that we can plug it in before the other loading
         // happens.
-        Y.useSync('mojito-logger');
+        Y.use('mojito-logger');
         // TODO: extract function
         logger = new Y.mojito.Logger(serverLog.options);
         store.setLogger(logger);
 
-        Y.useSync.apply(Y, CORE_MOJITO_MODULES);
+        Y.use.apply(Y, CORE_MOJITO_MODULES);
 
         loader = new Y.mojito.Loader(appConfig);
 

--- a/source/lib/management/commands/compile.js
+++ b/source/lib/management/commands/compile.js
@@ -489,7 +489,7 @@ compile.views = function(context, options, callback) {
         source,
         engine,
         mojitViews = {},
-        YUI = require('yui3').YUI;
+        YUI = require('yui').YUI;
 
     // there are no views in the app, so no need to do this
     if (options.app) {
@@ -554,8 +554,9 @@ compile.views = function(context, options, callback) {
                         source = view['content-path'];
                         engine = view.engine;
                         yuiConfig = mojit.yui.config;
+                        yuiConfig.useSync = true;
 
-                        Y = YUI(yuiConfig).useSync('mojito-' + engine);
+                        Y = YUI(yuiConfig).use('mojito-' + engine);
                         renderer = new (Y.mojito.addons.viewEngines[engine])();
 
                         if (typeof renderer.compiler === 'function') {

--- a/source/lib/management/commands/test.js
+++ b/source/lib/management/commands/test.js
@@ -33,7 +33,7 @@ var pathlib = require('path'),
     coverageDir = pathlib.join(resultsDir, 'coverage'),
     coverageFile = pathlib.join(coverageDir, 'coverage.json'),
 
-    YUI = require('yui3').YUI,
+    YUI = require('yui').YUI,
     YUITest = require(pathlib.join(fwTestsRoot,
         'harness/lib/yuitest/javascript/build/yuitest/yuitest-node')).YUITest,
     TestRunner = YUITest.TestRunner,
@@ -119,12 +119,14 @@ function collectRunResults(results) {
 }
 
 function configureYUI(YUI, store, load) {
-    YUI.GlobalConfig.groups['mojito-fw'] = store.getYuiConfigFw('server', {});
-    YUI.GlobalConfig.groups['mojito-app'] = store.getYuiConfigApp('server', {});
-    YUI.GlobalConfig.groups['mojito-mojits'] = store.getYuiConfigAllMojits(
-        'server',
-        {}
-    );
+    YUI.applyConfig({
+        useSync: true,
+        groups: {
+            'mojito-fw': store.getYuiConfigFw('server', {}),
+            'mojito-app': store.getYuiConfigApp('server', {}),
+            'mojito-mojits': store.getYuiConfigAllMojits('server,', {})
+        }
+    });
 }
 
 

--- a/source/lib/store.server.js
+++ b/source/lib/store.server.js
@@ -3733,21 +3733,14 @@ ServerStore.prototype = {
             return { sorted: Object.keys(required), paths: sortedPaths };
         }
         
-        //TODO davglass USE resolve here!
+        //TODO davglass USE resolve her
         Y = YUI({ useSync: true }).use('loader-base');
-        loader = new Y.Loader({ lang: ctx.lang });
-
-        // We need to clear YUI's cached dependencies, since there's no
-        // guarantee that the previously calculated dependencies have been done
-        // using the same context as this calculation.
-        delete YUI.Env._renderedMods;
-
-        // This approach seems odd, but it's what the YUI Configurator is also
-        // doing.
+        //Use ignoreRegistered here instead of the old `delete YUI.Env._renderedMods` hack
+        loader = new Y.Loader({ lang: ctx.lang, ignoreRegistered: true });
+        
+        //Only override the default if it's required
         if (yuiConfig && yuiConfig.base) {
             loader.base = yuiConfig.base;
-        } else {
-            loader.base = Y.Env.meta.base + Y.Env.meta.root;
         }
         loader.addGroup({modules: modules}, mojitType);
         loader.calculate({required: required});

--- a/source/lib/store.server.js
+++ b/source/lib/store.server.js
@@ -40,11 +40,11 @@ var libfs = require('fs'),
     // nodejs-yui3 has global state about which modules are loaded. Use
     // multiple require()'d instances as a wall to prevent cross-contamination
     // when using loader for dependency calculations.
-    utilYUI = require('yui3').YUI,
-    serverYUI = require('yui3').YUI,
-    clientYUI = require('yui3').YUI,
+    utilYUI = require('yui').YUI,
+    serverYUI = require('yui').YUI,
+    clientYUI = require('yui').YUI,
 
-    Y = utilYUI().useSync('intl'),
+    Y = utilYUI({ useSync: true }).use('intl'),
 
     mojitoRoot = __dirname,
 
@@ -3732,8 +3732,9 @@ ServerStore.prototype = {
             }
             return { sorted: Object.keys(required), paths: sortedPaths };
         }
-
-        Y = YUI().useSync('loader-base');
+        
+        //TODO davglass USE resolve here!
+        Y = YUI({ useSync: true }).use('loader-base');
         loader = new Y.Loader({ lang: ctx.lang });
 
         // We need to clear YUI's cached dependencies, since there's no

--- a/source/lib/tests/autoload/app/autoload/loader-tests.common.js
+++ b/source/lib/tests/autoload/app/autoload/loader-tests.common.js
@@ -116,15 +116,15 @@ YUI.add('mojito-loader-tests', function(Y, NAME) {
             var got = loader.createYuiLibComboUrl(modules, filter);
             var expected = [
                 'http://yui.yahooapis.com/combo?' + 
-                '3.4.1/build/yui/yui-debug.js&' +
-                '3.4.1/build/yui-base/yui-base-debug.js&' + 
-                '3.4.1/build/collection/collection-debug.js&' +
-                '3.4.1/build/oop/oop-debug.js&' +
-                '3.4.1/build/features/features-debug.js&' +
-                '3.4.1/build/dom-core/dom-core-debug.js&' +
-                '3.4.1/build/dom-base/dom-base-debug.js&' +
-                '3.4.1/build/selector-native/selector-native-debug.js&' +
-                '3.4.1/build/selector-css2/selector-css2-debug.js'
+                Y.version + '/build/yui/yui-debug.js&' +
+                Y.version + '/build/yui-base/yui-base-debug.js&' + 
+                Y.version + '/build/collection/collection-debug.js&' +
+                Y.version + '/build/oop/oop-debug.js&' +
+                Y.version + '/build/features/features-debug.js&' +
+                Y.version + '/build/dom-core/dom-core-debug.js&' +
+                Y.version + '/build/dom-base/dom-base-debug.js&' +
+                Y.version + '/build/selector-native/selector-native-debug.js&' +
+                Y.version + '/build/selector-css2/selector-css2-debug.js'
             ];
             AA.itemsAreEqual(expected, got.js);
             A.isArray(got.css);

--- a/source/lib/tests/autoload/store.server-tests.js
+++ b/source/lib/tests/autoload/store.server-tests.js
@@ -806,16 +806,16 @@ YUI.add('mojito-store-server-tests', function(Y, NAME) {
             store.preload();
             var spec = { type: 'PagedFlickr' };
             store.expandInstance(spec, {}, function(err, instance) {
-                A.isUndefined(instance.views.index['binder-yui-sorted']['breg']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['dali-bean']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['dali-transport-base']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['io-facade']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['mojito-tunnel-client']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['request-handler']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['requestor']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['response-formatter']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['response-processor']);
-                A.isUndefined(instance.views.index['binder-yui-sorted']['simple-request-formatter']);
+                A.isUndefined(instance.views.index['binder-yui-sorted']['breg'], 'breg');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['dali-bean'], 'dali-bean');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['dali-transport-base'], 'dali-transport-base');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['io-facade'], 'io-facade');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['mojito-tunnel-client'], 'mojito-tunnel-client');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['request-handler'], 'request-handler');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['requestor'], 'requestor');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['response-formatter'], 'response-formatter');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['response-processor'], 'response-processor');
+                A.isUndefined(instance.views.index['binder-yui-sorted']['simple-request-formatter'], 'simple-request-formatter');
             });
         },
 

--- a/source/package.json
+++ b/source/package.json
@@ -18,9 +18,8 @@
     "dependencies": {
         "connect": "1.8.2",
         "express": "2.5.2",
-        "jsdom": "0.2.0",
         "mime": "1.2.4",
-        "yui3": "0.7.12"
+        "yui": "3.5.1"
     },
     "keywords": [
         "framework",


### PR DESCRIPTION
This supersedes the request #163 so that it comes from my branch and will be easier to merge in and test.

There is only one failing test now in "precompute" mode and zero in "ondemand" mode.

```
FAILURE DETAILS:
================
mojito-store-server-tests :: Store tests :: appConfig deferAllOptionalAutoloads
breg
Expected: undefined (undefined)
Actual: /static/mojito/autoload/transport/beanregistry/registry.client-optional.js (string)


Total tests: 331    ✔ Passed: 309 ⚑ Deferred: 21    ✖ Failed: 1   93% pass rate
```
