### PR TITLE
Fixing bz #5572555: link to dimensions.json.

### DIFF
--- a/docs/dev_guide/topics/mojito_using_contexts.rst
+++ b/docs/dev_guide/topics/mojito_using_contexts.rst
@@ -83,7 +83,7 @@ following compound context: ``"environment:test,device:android"``
 - ``device:palm``
 - ``lang:{BCP 47 language tag}``
 
-You can view the supported BCP 47 language tags and default contexts in the `dimensions.json <http://github.com/yahoo/mojito/source/lib/dimensions.json>`_ file of Mojito.
+You can view the supported BCP 47 language tags and default contexts in the `dimensions.json <https://github.com/yahoo/mojito/blob/develop/source/lib/dimensions.json>`_ file of Mojito.
 
 Configuration Precedence
 ========================


### PR DESCRIPTION
Fixed the link in the context configuration docs to the dimensions.json file in the Mojito source.
