### PR TITLE
View Engine Code Example

### DIFF
--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -11,8 +11,8 @@ Creating and Using a View Engine Addon
 Summary
 #######
 
-This example shows how how to install a third-party rendering engine, create a view engine addon 
-that uses that rendering engine, and create a view template for the view engine.
+This example shows how to install a third-party rendering engine, create a view engine addon 
+that uses the installed rendering engine and a view template for the view engine. 
 
 The following topics will be covered:
 
@@ -31,25 +31,23 @@ What Is a View Engine?
 ----------------------
 
 A view engine is code that applies data returned by the controller to a view. This is most often done by interpreting the 
-view as a template. View engines in Mojito can be at either the application or mojit level. This example
-uses an application-level view engine addon that could theoretically be used by multiple mojits.
+view as a template. View engines in Mojito can function at either the application or mojit level. This example
+uses an application-level view engine addon, allowing multiple mojits to use it although the example only uses one mojit.
 
 
 Installing a Rendering Engine
 -----------------------------
 
 You could write your own rendering engine or copy code into your Mojito application, but this example 
-follows the typical use case of installing a rendering engine with ``npm``. We will be 
+follows the most common use case of installing a rendering engine with ``npm``. We will be 
 installing the rendering engine `Handlebars <http://handlebarsjs.com>`_ with ``npm``.
 
-Your Mojito application is simply a ``npm`` module that has a ``package.json`` file and
-can have a ``node_modules`` directory for locally installing other modules.
-
-From your application directory, you would use ``npm`` to install ``handlebars``:
+Because your Mojito application is simply a ``npm`` module, you can have a ``node_modules`` directory for locally
+installing other modules. Thus, from your application directory, you would use the following ``npm`` command to install ``handlebars``:
 
 ``app_dir/ $ npm install handlebars --local``
 
-After you have installed ``handlebars``, a ``node_modules`` directory will be created with the following contents:
+After you have installed ``handlebars``, a ``node_modules`` directory will be created with the contents similar to the following:
 
 ::
 
@@ -80,7 +78,7 @@ After you have installed ``handlebars``, a ``node_modules`` directory will be cr
 Creating the View Engine Addon
 ------------------------------
 
-The view engine addon is a YUI module like other addons that lives in the ``addons/view-engines`` directory. For the application-level view engine addons that
+The view engine addon like other addons is simply a YUI module that lives in the ``addons/view-engines`` directory. For the application-level view engine addons that
 this example is using, the view engine addon will be in ``{app_dir}/addons/view-engines``.
 
 Requirements
@@ -132,8 +130,8 @@ The view engine addon must have the following:
       
 
 
-render and compile Methods
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+render and compile
+~~~~~~~~~~~~~~~~~~
 
 The ``render`` method renders the template and sends the output to the methods ``adapter.flush`` or ``adapter.done``
 that execute and return the page to the client.
@@ -152,39 +150,34 @@ compile the view.
      * @param {object} data The data to render.
      * @param {string} mojitType The name of the mojit type.
      * @param {string} tmpl The name of the template to render.
-        * @param {object} adapter The output adapter to use.
-        * @param {object} meta Optional metadata.
-        * @param {boolean} more Whether there will be more content later.
-        */
-        render: function(data, mojitType, tmpl, adapter, meta, more) {
-            var me = this,
-                handleRender = function(output) {
+     * @param {object} adapter The output adapter to use.
+     * @param {object} meta Optional metadata.
+     * @param {boolean} more Whether there will be more content later.
+     */
+     render: function(data, mojitType, tmpl, adapter, meta, more) {
+       var me = this,
+       handleRender = function(output) {
 
-                    output.addListener('data', function(c) {
-                        adapter.flush(c, meta);
-                    });
+         output.addListener('data', function(c) {
+           adapter.flush(c, meta);
+         });
 
-                    output.addListener('end', function() {
-                        if (!more) {
-                            Y.log('render complete for view "' +
-                                me.viewId + '"',
-                                'mojito', 'qeperf');
-                            adapter.done('', meta);
-                        }
-                    });
-                };
-
-            /*
-             * We can't use pre-compiled Mu templates on the server :(
-             */
-
-            var template = hb.compile(this.compiler(tmpl));
-            var result = template(data);
-            console.log(result);
-            adapter.done(result,meta);
+         output.addListener('end', function() {
+           if (!more) {
+             Y.log('render complete for view "' +
+               me.viewId + '"',
+               'mojito', 'qeperf');
+             adapter.done('', meta);
+           }
+         });
+       };
+       var template = hb.compile(this.compiler(tmpl));
+       var result = template(data);
+       console.log(result);
+       adapter.done(result,meta);
  
-        },
-        ...
+     },
+     ...
         
 The ``compile`` method is required to run the command ``mojito compile views``. In our example, 
 the ``compile`` method also reads the view template file and returns a string to ``render``
@@ -205,7 +198,7 @@ Handlebar Templates
 Handlebars are similar to Mustache tags, but have some additional features such as registering help function and built-in block helpers. 
 Mustache templates are actually compatible with Handlebars, so both view templates used in the example could have been rendered by the view 
 engine addon for Handlebars. We're just going to look at some of the Handlebars expressions used in this example, so please see 
-`Handlebars expressions <http://handlebarsjs.com/expressions.html>`_ for more information.
+`Handlebars expressions <http://handlebarsjs.com/expressions.html>`_ for more comprehensive documentation.
 
 
 One of the things that we mentioned already is block helpers, which help you iterate through arrays. 
@@ -233,11 +226,11 @@ if the ``ul`` object is given, the property ``title`` is evaluated.
 Setting Up this Example
 #######################
 
-To set up and run ``view_engines``:
+To set up and run ``hb_view_engine_demo``:
 
 #. Create your application.
 
-   ``$ mojito create app view_engine``
+   ``$ mojito create app hb_view_engine_demo``
 
 #. Change to the application directory.
 
@@ -245,7 +238,7 @@ To set up and run ``view_engines``:
 
    ``$ mojito create mojit myMojit``
 
-#. To specify that your application use ``SimpleMojit``, replace the code in ``application.json`` with the following:
+#. To specify that your application use ``myMojit``, replace the code in ``application.json`` with the following:
 
    .. code-block:: javascript
 
@@ -260,7 +253,7 @@ To set up and run ``view_engines``:
         }
       ]
 
-#. To configure routing, create the file ``routes.json`` with the following:
+#. To configure routing so controller functions using different view templates are used, create the file ``routes.json`` with the following:
 
    .. code-block:: javascript
 
@@ -337,7 +330,7 @@ To set up and run ``view_engines``:
 		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
       }, '0.1.0', {requires: []});
 
-#. Change to your mojit ``myMojit`` directory.
+#. Change to the ``hb_view_engine_demo/mojits/myMojit`` directory.
 
 #. Replace the code in ``controller.server.js`` with the following:
 
@@ -422,13 +415,13 @@ To set up and run ``view_engines``:
 
    `http://localhost:8666/hb <http://localhost:8666/hb>`_
    
-#. Great, your application is using two different rendering engines. You should now be ready to add your own view engine such as Jade.   
+#. Great, your application is using two different rendering engines. You should now be ready to add your own view engine that uses a rendering engine such as Jade.   
 
 Source Code
 ###########
 
-- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/>`_
-- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/addons/view-engines/hb.server.js>`_
-- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/mojits/myMojit/views/>`_
+- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/>`_
+- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/addons/view-engines/hb.server.js>`_
+- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/mojits/myMojit/views/>`_
 
 

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
-﻿
-=======
-
->>>>>>> f3089d0... Adding view engines example.
 
 ======================================
 Creating and Using a View Engine Addon 
@@ -15,13 +10,11 @@ Creating and Using a View Engine Addon
 Summary
 #######
 
-<<<<<<< HEAD
 This example shows how to install a third-party rendering engine, create a view engine addon 
 that uses the installed rendering engine and a view template. 
-=======
+
 This example shows how how to install a third-party rendering engine, create a view engine addon 
 that uses that rendering engine, and create a view template for the view engine.
->>>>>>> f3089d0... Adding view engines example.
 
 The following topics will be covered:
 
@@ -30,7 +23,6 @@ The following topics will be covered:
 - using Handlebars in the view template
 
 
-<<<<<<< HEAD
 Implementation Notes
 ####################
 
@@ -38,28 +30,19 @@ Before you create your application, you should take a look at the following sect
 how the application works. The focus here is to give you a practical example that you can use
 to add your own view engines and also to show some of important points of using view engines in Mojito applications.
 For more comprehensive but less practical documentation, see `Mojito Topics: View Engines <../topics/mojito_extensions.html#view-engines>`_.
-=======
 
-Implementation Notes
-####################
-
->>>>>>> f3089d0... Adding view engines example.
 
 What Is a View Engine?
 ----------------------
 
-<<<<<<< HEAD
 A view engine is code that applies data returned by the controller to a view. This is most often done by interpreting the 
 view as a template. View engines in Mojito can function at either the application or mojit level. This example
 uses an application-level view engine addon, allowing multiple mojits to use it although the example only uses one mojit.
-=======
->>>>>>> f3089d0... Adding view engines example.
 
 
 Installing a Rendering Engine
 -----------------------------
 
-<<<<<<< HEAD
 You could write your own rendering engine or copy code into your Mojito application, but this example 
 follows the most common use case of installing a rendering engine with ``npm``. We will be 
 installing the rendering engine `Handlebars <http://handlebarsjs.com>`_ with ``npm``.
@@ -67,7 +50,7 @@ installing the rendering engine `Handlebars <http://handlebarsjs.com>`_ with ``n
 Because your Mojito application is simply a ``npm`` module, you can have a ``node_modules`` directory for locally
 installing other modules. Thus, from your application directory, you would use the following ``npm`` command to install ``handlebars``:
 
-``app_dir/ $ npm install handlebars --local``
+``app_dir/ $ npm install handlebars``
 
 After you have installed ``handlebars``, a ``node_modules`` directory will be created with the contents similar to the following:
 
@@ -199,7 +182,7 @@ compile the view.
         
 The ``compile`` method is required to run the command ``mojito compile views``. In our example, 
 the ``compile`` method also reads the view template file and returns a string to ``render``
-so that it can be compiled by ``handlebars``.
+so that it can be compiled by ``handlebars``. 
 
 .. code-block:: javascript
 
@@ -209,6 +192,12 @@ so that it can be compiled by ``handlebars``.
      return fs.readFileSync(tmpl, 'utf8');
    }
 
+The Mustache and Handlebars rendering engines compile templates into an executable JavaScript function, 
+but the implementation of the ``compile`` method in the view engine addon is up to the developer. 
+In the above code snippet, the ``compile`` method simply returns the template file to the
+``render`` method, where the instance of the Handlebars rendering engine calls ``compile`` to render 
+the template file into a JavaScript function. The implementation of the ``compile`` method in the 
+addon could have been written to call ``hb.compile`` and return the JavaScript function to ``render``.
 
 Handlebar Templates
 -------------------
@@ -240,30 +229,24 @@ if the ``ul`` object is given, the property ``title`` is evaluated.
    {{#with ul}}
      <h3>{{title}}</h3>
    {{/with}}
-=======
-Creating the View Engine Addon
-------------------------------
 
-Handlebar Template
-------------------
->>>>>>> f3089d0... Adding view engines example.
+
 
 Setting Up this Example
 #######################
 
-<<<<<<< HEAD
+
 To set up and run ``adding_view_engines``:
 
 #. Create your application.
 
    ``$ mojito create app adding_view_engines``
-=======
+
 To set up and run ``view_engines``:
 
 #. Create your application.
 
    ``$ mojito create app view_engine``
->>>>>>> f3089d0... Adding view engines example.
 
 #. Change to the application directory.
 
@@ -271,11 +254,7 @@ To set up and run ``view_engines``:
 
    ``$ mojito create mojit myMojit``
 
-<<<<<<< HEAD
 #. To specify that your application use ``myMojit``, replace the code in ``application.json`` with the following:
-=======
-#. To specify that your application use ``SimpleMojit``, replace the code in ``application.json`` with the following:
->>>>>>> f3089d0... Adding view engines example.
 
    .. code-block:: javascript
 
@@ -290,11 +269,8 @@ To set up and run ``view_engines``:
         }
       ]
 
-<<<<<<< HEAD
+
 #. To configure routing so controller functions using different view templates are used, create the file ``routes.json`` with the following:
-=======
-#. To configure routing, create the file ``routes.json`` with the following:
->>>>>>> f3089d0... Adding view engines example.
 
    .. code-block:: javascript
 
@@ -322,12 +298,7 @@ To set up and run ``view_engines``:
 
    ``$ mkdir -p addons/view-engines``
    
-<<<<<<< HEAD
 #. Change to the ``addons/view-engines`` directory that you created.
-=======
-#. Change to the ``view-engines`` directory that you created.
->>>>>>> f3089d0... Adding view engines example.
-
 
 #. Create the view engine addon file ``hb.server.js`` with the following code:
 
@@ -336,7 +307,6 @@ To set up and run ``view_engines``:
       YUI.add('addons-viewengine-hb', function(Y, NAME) {
 	
         var hb = require('handlebars'),
-<<<<<<< HEAD
         fs = require('fs');
         function HbAdapter(viewId) {
           this.viewId = viewId;
@@ -370,48 +340,6 @@ To set up and run ``view_engines``:
       }, '0.1.0', {requires: []});
 
 #. Change to the ``adding_view_engines/mojits/myMojit`` directory.
-=======
-			 fs = require('fs');
-		function HbAdapter(viewId) {
-			this.viewId = viewId;
-		}
-	
-		HbAdapter.prototype = {
-
-	      render: function(data, mojitType, tmpl, adapter, meta, more) {
-	        var me = this,
-		    handleRender = function(output) {
-		    
-			  output.addListener('data', function(c) {
-			    adapter.flush(c, meta);
-			  });
-	
-			  output.addListener('end', function() {
-			    if (!more) {
-				  Y.log('render complete for view "' +
-									me.viewId + '"',
-									'mojito', 'qeperf');
-				  adapter.done('', meta);
-				}
-              });
-			};
-		    Y.log('Rendering template "' + tmpl + '"', 'mojito', NAME);
-			var template = hb.compile(this.compiler(tmpl));
-			var result = template(data);
-			console.log(result);
-			adapter.done(result,meta);
-	 
-	      },
-	      compiler: function(tmpl) {
-		    return fs.readFileSync(tmpl, 'utf8');
-		  }
-		};
-	
-		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
-      }, '0.1.0', {requires: []});
-
-#. Change to your mojit ``myMojit`` directory.
->>>>>>> f3089d0... Adding view engines example.
 
 #. Replace the code in ``controller.server.js`` with the following:
 
@@ -494,25 +422,14 @@ To set up and run ``view_engines``:
    
 #. Now see the view template rendered by the Handlebars rendering engine at the following URL:
 
-   `http://localhost:8666/hb <http://localhost:8666/hb>`_
-   
-<<<<<<< HEAD
+   `http://localhost:8666/hb <http://localhost:8666/hb>`_   
+
 #. Great, your application is using two different rendering engines. You should now be ready to add your own view engine that uses a rendering engine such as Jade.   
-=======
-#. Great, your application is using two different rendering engines. You should now be ready to add your own view engine such as Jade.   
->>>>>>> f3089d0... Adding view engines example.
+
 
 Source Code
 ###########
 
-<<<<<<< HEAD
 - `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/>`_
 - `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/addons/view-engines/hb.server.js>`_
 - `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/mojits/myMojit/views/>`_
-=======
-- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/>`_
-- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/addons/view-engines/hb.server.js>`_
-- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/mojits/myMojit/views/>`_
->>>>>>> f3089d0... Adding view engines example.
-
-

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -164,9 +164,6 @@ compile the view.
 
          output.addListener('end', function() {
            if (!more) {
-             Y.log('render complete for view "' +
-               me.viewId + '"',
-               'mojito', 'qeperf');
              adapter.done('', meta);
            }
          });
@@ -308,9 +305,6 @@ To set up and run ``hb_view_engine_demo``:
 	
 			  output.addListener('end', function() {
 			    if (!more) {
-				  Y.log('render complete for view "' +
-									me.viewId + '"',
-									'mojito', 'qeperf');
 				  adapter.done('', meta);
 				}
               });

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -91,46 +91,45 @@ The view engine addon must have the following:
 - a ``YUI.add`` statement to register the addon. For example, we register the view engine addon with the
   name ``addons-viewengine-hb`` in our code example as seen below.
 
-.. code-block:: javascript
+   .. code-block:: javascript
 
-   YUI.add('addons-viewengine-hb', function(Y, NAME) {
+      YUI.add('addons-viewengine-hb', function(Y, NAME) {
     
-     // The addon name 'addons-viewengine-hb' is registered by YUI.add
+        // The addon name 'addons-viewengine-hb' is registered by YUI.add
     
-   }, '0.1.0', {requires: []});
+      }, '0.1.0', {requires: []});
       
 - a prototype of the object has the following two methods ``render`` and ``compiler`` as shown below. We will look
   at the ``render`` and ``compile`` methods more closely in the next section.
 
-.. code-block:: javascript
+   .. code-block:: javascript
    
-   ...
+      ...
         
-   HbAdapter.prototype = {
+      HbAdapter.prototype = {
        
-     render: function(data, mojitType, tmpl, adapter, meta, more) {
+        render: function(data, mojitType, tmpl, adapter, meta, more) {
           ...
-     },
-     compiler: function(tmpl) {
-       ...
-     }
-     ...      
-
+        },
+        compiler: function(tmpl) {
+          ...
+        }
+        ...      
+        
 - an object that is assigned to ``Y.mojito.addons.viewEngines.{view_engine_name}``. In our example,
   the constructor ``HbAdapter`` is assigned to the namespace ``Y.namespace('mojito.addons.viewEngines').hb`` or
   ``Y.mojito.addons.viewEngines.hb``.
    
-.. code-block:: javascript
+   .. code-block:: javascript
       
-   ...
+      ...
         
-   function HbAdapter(viewId) {
-     this.viewId = viewId;
-   }
-   ...
-   Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
+      function HbAdapter(viewId) {
+        this.viewId = viewId;
+      }
+      ...
+      Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
       
-
 
 render and compile
 ~~~~~~~~~~~~~~~~~~

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -12,7 +12,7 @@ Summary
 #######
 
 This example shows how to install a third-party rendering engine, create a view engine addon 
-that uses the installed rendering engine and a view template for the view engine. 
+that uses the installed rendering engine and a view template. 
 
 The following topics will be covered:
 
@@ -25,7 +25,9 @@ Implementation Notes
 ####################
 
 Before you create your application, you should take a look at the following sections to better understand
-how the application works. For more details about view engines in Mojito, see `Mojito Topics: View Engines <../topics/mojito_extensions.html#view-engines>`_.
+how the application works. The focus here is to give you a practical example that you can use
+to add your own view engines and also to show some of important points of using view engines in Mojito applications.
+For more comprehensive but less practical documentation, see `Mojito Topics: View Engines <../topics/mojito_extensions.html#view-engines>`_.
 
 What Is a View Engine?
 ----------------------
@@ -89,44 +91,44 @@ The view engine addon must have the following:
 - a ``YUI.add`` statement to register the addon. For example, we register the view engine addon with the
   name ``addons-viewengine-hb`` in our code example as seen below.
 
-   .. code-block:: javascript
+.. code-block:: javascript
 
-      YUI.add('addons-viewengine-hb', function(Y, NAME) {
+   YUI.add('addons-viewengine-hb', function(Y, NAME) {
     
-      // The addon name 'addons-viewengine-hb' is registered by YUI.add
+     // The addon name 'addons-viewengine-hb' is registered by YUI.add
     
-      }, '0.1.0', {requires: []});
+   }, '0.1.0', {requires: []});
       
 - a prototype of the object has the following two methods ``render`` and ``compiler`` as shown below. We will look
   at the ``render`` and ``compile`` methods more closely in the next section.
 
-   .. code-block:: javascript
+.. code-block:: javascript
    
-      ...
+   ...
         
-      HbAdapter.prototype = {
+   HbAdapter.prototype = {
        
-        render: function(data, mojitType, tmpl, adapter, meta, more) {
+     render: function(data, mojitType, tmpl, adapter, meta, more) {
           ...
-        },
-        compiler: function(tmpl) {
-          ...
-        }
-        ...      
+     },
+     compiler: function(tmpl) {
+       ...
+     }
+     ...      
 
 - an object that is assigned to ``Y.mojito.addons.viewEngines.{view_engine_name}``. In our example,
   the constructor ``HbAdapter`` is assigned to the namespace ``Y.namespace('mojito.addons.viewEngines').hb`` or
   ``Y.mojito.addons.viewEngines.hb``.
    
-   .. code-block:: javascript
+.. code-block:: javascript
       
-      ...
+   ...
         
-      function HbAdapter(viewId) {
-        this.viewId = viewId;
-      }
-      ...
-      Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
+   function HbAdapter(viewId) {
+     this.viewId = viewId;
+   }
+   ...
+   Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
       
 
 
@@ -288,39 +290,35 @@ To set up and run ``hb_view_engine_demo``:
       YUI.add('addons-viewengine-hb', function(Y, NAME) {
 	
         var hb = require('handlebars'),
-			 fs = require('fs');
-		function HbAdapter(viewId) {
-			this.viewId = viewId;
-		}
-	
-		HbAdapter.prototype = {
-
-	      render: function(data, mojitType, tmpl, adapter, meta, more) {
-	        var me = this,
-		    handleRender = function(output) {
+        fs = require('fs');
+        function HbAdapter(viewId) {
+          this.viewId = viewId;
+        }
+        HbAdapter.prototype = {
+        
+          render: function(data, mojitType, tmpl, adapter, meta, more) {
+            var me = this,
+            handleRender = function(output) {
 		    
-			  output.addListener('data', function(c) {
-			    adapter.flush(c, meta);
-			  });
-	
-			  output.addListener('end', function() {
-			    if (!more) {
-				  adapter.done('', meta);
-				}
-              });
-			};
+		      output.addListener('data', function(c) {
+		        adapter.flush(c, meta);
+		      });
+		      output.addListener('end', function() {
+		        if (!more) {
+		          adapter.done('', meta);
+		        }
+		      });
+		    };
 		    Y.log('Rendering template "' + tmpl + '"', 'mojito', NAME);
-			var template = hb.compile(this.compiler(tmpl));
-			var result = template(data);
-			console.log(result);
-			adapter.done(result,meta);
-	 
-	      },
-	      compiler: function(tmpl) {
+		    var template = hb.compile(this.compiler(tmpl));
+		    var result = template(data);
+		    console.log(result);
+		    adapter.done(result,meta);
+		  },
+		  compiler: function(tmpl) {
 		    return fs.readFileSync(tmpl, 'utf8');
 		  }
 		};
-	
 		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
       }, '0.1.0', {requires: []});
 

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -224,11 +224,11 @@ if the ``ul`` object is given, the property ``title`` is evaluated.
 Setting Up this Example
 #######################
 
-To set up and run ``hb_view_engine_demo``:
+To set up and run ``adding_view_engines``:
 
 #. Create your application.
 
-   ``$ mojito create app hb_view_engine_demo``
+   ``$ mojito create app adding_view_engines``
 
 #. Change to the application directory.
 
@@ -279,7 +279,7 @@ To set up and run ``hb_view_engine_demo``:
 
    ``$ mkdir -p addons/view-engines``
    
-#. Change to the ``view-engines`` directory that you created.
+#. Change to the ``addons/view-engines`` directory that you created.
 
 
 #. Create the view engine addon file ``hb.server.js`` with the following code:
@@ -321,7 +321,7 @@ To set up and run ``hb_view_engine_demo``:
 		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
       }, '0.1.0', {requires: []});
 
-#. Change to the ``hb_view_engine_demo/mojits/myMojit`` directory.
+#. Change to the ``adding_view_engines/mojits/myMojit`` directory.
 
 #. Replace the code in ``controller.server.js`` with the following:
 
@@ -411,8 +411,8 @@ To set up and run ``hb_view_engine_demo``:
 Source Code
 ###########
 
-- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/>`_
-- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/addons/view-engines/hb.server.js>`_
-- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/hb_view_engine_demo/mojits/myMojit/views/>`_
+- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/>`_
+- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/addons/view-engines/hb.server.js>`_
+- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/mojits/myMojit/views/>`_
 
 

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 ﻿
+=======
+
+>>>>>>> f3089d0... Adding view engines example.
 
 ======================================
 Creating and Using a View Engine Addon 
@@ -11,8 +15,13 @@ Creating and Using a View Engine Addon
 Summary
 #######
 
+<<<<<<< HEAD
 This example shows how to install a third-party rendering engine, create a view engine addon 
 that uses the installed rendering engine and a view template. 
+=======
+This example shows how how to install a third-party rendering engine, create a view engine addon 
+that uses that rendering engine, and create a view template for the view engine.
+>>>>>>> f3089d0... Adding view engines example.
 
 The following topics will be covered:
 
@@ -21,6 +30,7 @@ The following topics will be covered:
 - using Handlebars in the view template
 
 
+<<<<<<< HEAD
 Implementation Notes
 ####################
 
@@ -28,18 +38,28 @@ Before you create your application, you should take a look at the following sect
 how the application works. The focus here is to give you a practical example that you can use
 to add your own view engines and also to show some of important points of using view engines in Mojito applications.
 For more comprehensive but less practical documentation, see `Mojito Topics: View Engines <../topics/mojito_extensions.html#view-engines>`_.
+=======
+
+Implementation Notes
+####################
+
+>>>>>>> f3089d0... Adding view engines example.
 
 What Is a View Engine?
 ----------------------
 
+<<<<<<< HEAD
 A view engine is code that applies data returned by the controller to a view. This is most often done by interpreting the 
 view as a template. View engines in Mojito can function at either the application or mojit level. This example
 uses an application-level view engine addon, allowing multiple mojits to use it although the example only uses one mojit.
+=======
+>>>>>>> f3089d0... Adding view engines example.
 
 
 Installing a Rendering Engine
 -----------------------------
 
+<<<<<<< HEAD
 You could write your own rendering engine or copy code into your Mojito application, but this example 
 follows the most common use case of installing a rendering engine with ``npm``. We will be 
 installing the rendering engine `Handlebars <http://handlebarsjs.com>`_ with ``npm``.
@@ -220,15 +240,30 @@ if the ``ul`` object is given, the property ``title`` is evaluated.
    {{#with ul}}
      <h3>{{title}}</h3>
    {{/with}}
+=======
+Creating the View Engine Addon
+------------------------------
+
+Handlebar Template
+------------------
+>>>>>>> f3089d0... Adding view engines example.
 
 Setting Up this Example
 #######################
 
+<<<<<<< HEAD
 To set up and run ``adding_view_engines``:
 
 #. Create your application.
 
    ``$ mojito create app adding_view_engines``
+=======
+To set up and run ``view_engines``:
+
+#. Create your application.
+
+   ``$ mojito create app view_engine``
+>>>>>>> f3089d0... Adding view engines example.
 
 #. Change to the application directory.
 
@@ -236,7 +271,11 @@ To set up and run ``adding_view_engines``:
 
    ``$ mojito create mojit myMojit``
 
+<<<<<<< HEAD
 #. To specify that your application use ``myMojit``, replace the code in ``application.json`` with the following:
+=======
+#. To specify that your application use ``SimpleMojit``, replace the code in ``application.json`` with the following:
+>>>>>>> f3089d0... Adding view engines example.
 
    .. code-block:: javascript
 
@@ -251,7 +290,11 @@ To set up and run ``adding_view_engines``:
         }
       ]
 
+<<<<<<< HEAD
 #. To configure routing so controller functions using different view templates are used, create the file ``routes.json`` with the following:
+=======
+#. To configure routing, create the file ``routes.json`` with the following:
+>>>>>>> f3089d0... Adding view engines example.
 
    .. code-block:: javascript
 
@@ -279,7 +322,11 @@ To set up and run ``adding_view_engines``:
 
    ``$ mkdir -p addons/view-engines``
    
+<<<<<<< HEAD
 #. Change to the ``addons/view-engines`` directory that you created.
+=======
+#. Change to the ``view-engines`` directory that you created.
+>>>>>>> f3089d0... Adding view engines example.
 
 
 #. Create the view engine addon file ``hb.server.js`` with the following code:
@@ -289,6 +336,7 @@ To set up and run ``adding_view_engines``:
       YUI.add('addons-viewengine-hb', function(Y, NAME) {
 	
         var hb = require('handlebars'),
+<<<<<<< HEAD
         fs = require('fs');
         function HbAdapter(viewId) {
           this.viewId = viewId;
@@ -322,6 +370,48 @@ To set up and run ``adding_view_engines``:
       }, '0.1.0', {requires: []});
 
 #. Change to the ``adding_view_engines/mojits/myMojit`` directory.
+=======
+			 fs = require('fs');
+		function HbAdapter(viewId) {
+			this.viewId = viewId;
+		}
+	
+		HbAdapter.prototype = {
+
+	      render: function(data, mojitType, tmpl, adapter, meta, more) {
+	        var me = this,
+		    handleRender = function(output) {
+		    
+			  output.addListener('data', function(c) {
+			    adapter.flush(c, meta);
+			  });
+	
+			  output.addListener('end', function() {
+			    if (!more) {
+				  Y.log('render complete for view "' +
+									me.viewId + '"',
+									'mojito', 'qeperf');
+				  adapter.done('', meta);
+				}
+              });
+			};
+		    Y.log('Rendering template "' + tmpl + '"', 'mojito', NAME);
+			var template = hb.compile(this.compiler(tmpl));
+			var result = template(data);
+			console.log(result);
+			adapter.done(result,meta);
+	 
+	      },
+	      compiler: function(tmpl) {
+		    return fs.readFileSync(tmpl, 'utf8');
+		  }
+		};
+	
+		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
+      }, '0.1.0', {requires: []});
+
+#. Change to your mojit ``myMojit`` directory.
+>>>>>>> f3089d0... Adding view engines example.
 
 #. Replace the code in ``controller.server.js`` with the following:
 
@@ -406,13 +496,23 @@ To set up and run ``adding_view_engines``:
 
    `http://localhost:8666/hb <http://localhost:8666/hb>`_
    
+<<<<<<< HEAD
 #. Great, your application is using two different rendering engines. You should now be ready to add your own view engine that uses a rendering engine such as Jade.   
+=======
+#. Great, your application is using two different rendering engines. You should now be ready to add your own view engine such as Jade.   
+>>>>>>> f3089d0... Adding view engines example.
 
 Source Code
 ###########
 
+<<<<<<< HEAD
 - `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/>`_
 - `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/addons/view-engines/hb.server.js>`_
 - `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/adding_view_engines/mojits/myMojit/views/>`_
+=======
+- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/>`_
+- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/addons/view-engines/hb.server.js>`_
+- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/mojits/myMojit/views/>`_
+>>>>>>> f3089d0... Adding view engines example.
 
 

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -1,0 +1,244 @@
+
+
+======================================
+Creating and Using a View Engine Addon 
+======================================
+
+**Time Estimate:** 15 minutes
+
+**Difficulty Level:** Intermediate
+
+Summary
+#######
+
+This example shows how how to install a third-party rendering engine, create a view engine addon 
+that uses that rendering engine, and create a view template for the view engine.
+
+The following topics will be covered:
+
+- using ``npm`` to install the rendering engine
+- creating a view engine addon
+- using Handlebars in the view template
+
+
+
+Implementation Notes
+####################
+
+
+What Is a View Engine?
+----------------------
+
+
+
+Installing a Rendering Engine
+-----------------------------
+
+Creating the View Engine Addon
+------------------------------
+
+Handlebar Template
+------------------
+
+Setting Up this Example
+#######################
+
+To set up and run ``view_engines``:
+
+#. Create your application.
+
+   ``$ mojito create app view_engine``
+
+#. Change to the application directory.
+
+#. Create your mojit.
+
+   ``$ mojito create mojit myMojit``
+
+#. To specify that your application use ``SimpleMojit``, replace the code in ``application.json`` with the following:
+
+   .. code-block:: javascript
+
+      [
+        {
+          "settings": [ "master" ],
+          "specs": {
+            "myMojit": {
+              "type": "myMojit"
+            }
+          }
+        }
+      ]
+
+#. To configure routing, create the file ``routes.json`` with the following:
+
+   .. code-block:: javascript
+
+      [
+        {
+          "settings": [ "master" ],
+          "mu": {
+            "verbs": ["get"],
+            "path": "/",
+            "call": "myMojit.default_ve"
+          },
+          "hb": {
+            "verbs": ["get"],
+            "path": "/hb",
+            "call": "myMojit.added_ve"
+          }
+        }
+      ]
+
+#. Install the Handlebars module.
+
+   ``$ npm install handlebars --local``
+
+#. Create the addons directory for your view engine addon.
+
+   ``$ mkdir -p addons/view-engines``
+   
+#. Change to the ``view-engines`` directory that you created.
+
+
+#. Create the view engine addon file ``hb.server.js`` with the following code:
+
+   .. code-block:: javascript
+   
+      YUI.add('addons-viewengine-hb', function(Y, NAME) {
+	
+        var hb = require('handlebars'),
+			 fs = require('fs');
+		function HbAdapter(viewId) {
+			this.viewId = viewId;
+		}
+	
+		HbAdapter.prototype = {
+
+	      render: function(data, mojitType, tmpl, adapter, meta, more) {
+	        var me = this,
+		    handleRender = function(output) {
+		    
+			  output.addListener('data', function(c) {
+			    adapter.flush(c, meta);
+			  });
+	
+			  output.addListener('end', function() {
+			    if (!more) {
+				  Y.log('render complete for view "' +
+									me.viewId + '"',
+									'mojito', 'qeperf');
+				  adapter.done('', meta);
+				}
+              });
+			};
+		    Y.log('Rendering template "' + tmpl + '"', 'mojito', NAME);
+			var template = hb.compile(this.compiler(tmpl));
+			var result = template(data);
+			console.log(result);
+			adapter.done(result,meta);
+	 
+	      },
+	      compiler: function(tmpl) {
+		    return fs.readFileSync(tmpl, 'utf8');
+		  }
+		};
+	
+		Y.namespace('mojito.addons.viewEngines').hb = HbAdapter;
+      }, '0.1.0', {requires: []});
+
+#. Change to your mojit ``myMojit`` directory.
+
+#. Replace the code in ``controller.server.js`` with the following:
+
+   .. code-block:: javascript
+   
+      YUI.add('myMojit', function(Y, NAME) {
+
+        Y.mojito.controllers[NAME] = {
+  
+          init: function(config) {
+            this.config = config;
+          },
+          default_ve: function(ac) {
+            ac.done({
+              "title": "Mustache at work!",
+              "view_engines": [ 
+                { "name": "Handlebars"},
+                {"name": "EJS"},
+                {"name": "Jade"}, 
+                {"name": "dust"},
+                {"name": "underscore" }
+              ],
+              "ul": { "title": 'Here are some of the other available rendering engines:' },
+            });
+          },
+          added_ve: function(ac) {
+            ac.done({
+              "title": "Handlebars at work!",
+              "view_engines": [ "Mustache","EJS","Jade", "dust","underscore" ],
+              "ul": { "title": 'Here are some of the other available rendering engines:' }
+            });  
+          }
+        };
+      }, '0.0.1', {requires: ['mojito', 'myMojitModelFoo']});
+ 
+#. Create the view template ``views/default_ve.mu.html`` that uses Mustache tags with the following:
+
+   .. code-block:: html
+   
+      <h2>{{title}}</h2>
+      <div id="{{mojit_view_id}}">
+        <h3>
+        {{#ul}}
+          {{title}} 
+        {{/ul}}
+        {{^ul}}
+          Besides Mustache, here are some other rendering engines:
+        {{/ul}}  
+        </h3>
+        <ul>
+        {{#view_engines}}
+          <li>{{name}}</li>
+        {{/view_engines}} 
+        </ul>
+      </div>
+
+#. Create the view template ``views/added_ve.hb.html`` that uses Handlebars with the following:
+
+   .. code-block:: html
+   
+      <h2>{{title}}</h2>
+      <div id="{{mojit_view_id}}">
+      {{#with ul}}
+        <h3>{{title}}</h3>
+      {{/with}}
+        <ul>
+        {{#each view_engines}}
+          <li>{{this}}</li>
+        {{/each}} 
+        </ul>
+      </div>
+
+#. From your application directory, start Mojito.
+
+   ``$ mojito start``
+   
+#. Open the following URL in your browser to see the view template rendered by the Mustache rendering engine.   
+
+   `http://localhost:8666/ <http://localhost:8666/>`_
+   
+#. Now see the view template rendered by the Handlebars rendering engine at the following URL:
+
+   `http://localhost:8666/hb <http://localhost:8666/hb>`_
+   
+#. Great, your application is using two different rendering engines. You should now be ready to add your own view engine such as Jade.   
+
+Source Code
+###########
+
+- `View Engines <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/>`_
+- `View Engine Addon <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/addons/view-engines/hb.server.js>`_
+- `View Templates <http://github.com/yahoo/mojito/tree/master/examples/developer-guide/view_engines/mojits/myMojit/views/>`_
+
+

--- a/docs/dev_guide/code_exs/views.rst
+++ b/docs/dev_guide/code_exs/views.rst
@@ -10,4 +10,4 @@ These examples show you how to create view templates, use Mustache tags, and pas
    views_multiple_devices 
    htmlframe_view
    scroll_views
-
+   view_engines


### PR DESCRIPTION
Created a code example to show Mojito app developers how to add a view engine to their apps. The example takes users through the steps to install 'handlebars' and then create a view engine addon to use the Handlebars rendering engine. 
