### PR TITLE
support for custom binders when calling ac.done

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -15,10 +15,6 @@ Currently Deprecated
 
 ### Deprecated but Available
 
-* (2012-04-23) The `autoload/` directory is going away in favor of
-`yui_modules/`, which better reflects its contents.  Everthing else about it is
-the same, only the name has changed.  You can start using `yui_modules/` today.
-
 * (2012-04-23) The `.guid` member of Mojito metadata (such as binder metadata)
 is going away.  Often there's an associated member which more specifically
 expresses the intent of the unique ID (for example `.viewId` or `.instanceId`).

--- a/source/lib/app/addons/ac/output-adapter.common.js
+++ b/source/lib/app/addons/ac/output-adapter.common.js
@@ -92,8 +92,37 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         // We want to know the view name, id, and binder used later so make sure
         // "meta" is up-to-date
         meta.view.name = meta.view.name || action;
-        // TODO: Use a different binder
-        meta.view.binder = meta.view.binder || meta.view.name;
+        // a custom binder was invoke
+        if (meta.view.binder) {
+            if (instance.views[meta.view.binder]) {
+                // merging the selected view with the precomputed binder structure.
+                // keep in mind that this is the binder path/filename, and based on that
+                // we can capture the rest of the meta data from the binders collection.
+                // Something like this:
+                /*
+                    bar/foo:  {
+                        'binder-url': '/App/binders/bar/foo.js',
+                        'binder-path': '/path/to/mojits/App/binders/bar/foo.js',
+                        'binder-module': 'MojitBinderBarFoo',
+                        'binder-yui-sorted': {}
+                    }
+                */
+                Y.log('Customizing binder "' + meta.view.binder + '" for view "' + meta.view.name + '"', 'mojito', 'qeperf');
+                // TODO: I don't like to have this whitelist of binder-* properties, but since
+                //       there is not a clear distintion on how to resolve a custom binder, there
+                //       is not much we can do. Remember that the actual binder lookup is based on
+                //       the binder path rather than the binder module name.
+                Y.mix(instance.views[meta.view.name], (instance.views[meta.view.binder] || {}),
+                      true, ['binder-url', 'binder-path', 'binder-module', 'binder-yui-sorted'], 0, false);
+            }
+            else {
+                Y.log ('Trying to attach an undefined binder with name='+meta.view.binder, 'error', NAME);
+            }
+        }
+        else {
+            // default binder is based on the view name.
+            meta.view.binder = meta.view.name;
+        }
         mojitView = instance.views[meta.view.name];
         if (!meta.view.id) {
             meta.view.id = Y.guid();


### PR DESCRIPTION
having a structure like this at the mojit level:

```
/mojitName
   /binders/foo.js
   /binders/bar.js
   /views/index.mu.html
   /views/baz.mu.html
```

you can invoke ac.done in your action to customize which binder to use:

```
ac.done(data, { 
    view: {
        name: "index",
        binder: "foo"
    }
});
```

or more customization

```
ac.done(data, { 
    view: {
        name: "baz",
        binder: "bar"
    }
});
```

in general, if there is a file defining a binder, you can now attach it to any view.
