### PR TITLE
skip "nodejs" modules when calculating requirements for the client

### DIFF
--- a/source/lib/store.server.js
+++ b/source/lib/store.server.js
@@ -3752,6 +3752,10 @@ ServerStore.prototype = {
             module = loader.sorted[j];
             info = loader.moduleInfo[module];
             if (info) {
+                // modules with "nodejs" in their name are tweaks on other modules
+                if ('client' === env && module.indexOf('nodejs') !== -1) {
+                    continue;
+                }
                 sortedPaths[module] = info.fullpath || loader._url(info.path);
             }
         }


### PR DESCRIPTION
YUI's module structure is a little different in 3.5.1, and includes some nodejs-specific fixup modules.
