### PR TITLE
change array cp from splice (wrong) to slice. Thank you Vinit Jain [bz 5593789]

### DIFF
--- a/source/lib/app/addons/view-engines/mu.client.js
+++ b/source/lib/app/addons/view-engines/mu.client.js
@@ -386,7 +386,7 @@ YUI.add('mojito-mu', function(Y, NAME) {
 
             CACHE[tmpl] = obj.responseText;
 
-            queue = QUEUE_POOL[tmpl].splice(0);
+            queue = QUEUE_POOL[tmpl].slice(0);
             delete QUEUE_POOL[tmpl];
 
             for (i = 0, iC = queue.length; i < iC; i += 1) {


### PR DESCRIPTION
[].splice(0) is wrong, but happens to work except in IE <=8
