### PR TITLE
Fixed links to API docs. [bz 5622421]

### DIFF
--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -11,8 +11,8 @@ Mojito provides addons for accessing data from query string and routing paramete
 
 This section will provide an overview of the following addons that allow you to access data:
 
-- `Params addon <../../api/Params.common.html>`_
-- `Cookies addon <../../api/Cookie.client.html>`_
+- `Params addon <../../api/classes/Params.common.html>`_
+- `Cookies addon <../../api/classes/Cookie.server.html>`_
 
 To see examples using these addons to get data, see `Using Query Parameters <../code_exs/query_params.html>`_ and `Using Cookies <../code_exs/cookies.html>`_.
 


### PR DESCRIPTION
The links to API docs in the documentation on how to get data in Mojito were broken and have now been fixed.

YDN docs: http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html

Fixed links to Params addon and Cookies addon.
