### PR TITLE
[BZ 5495973] Support rollup of only core mojito files

### DIFF
--- a/source/lib/management/commands/compile.js
+++ b/source/lib/management/commands/compile.js
@@ -52,6 +52,8 @@ usage = 'mojito compile {options} {type}\n' +
     '\t  -e          :  short for --everything\n' +
     '\t --clean      :  clean up all compiled modules\n' +
     '\t  -c          :  short for --clean\n' +
+    '\t --core       :  compile only mojito core (only applies to rollups)\n' +
+    '\t  -o          :  short for --core\n' +
     '\t --verbose    :  for verbose output\n' +
     '\t  -v          :  short for --verbose\n' +
     '\t --port       :  if a server is started, specify the port\n' +
@@ -74,6 +76,11 @@ options = [
     {
         shortName: 'c',
         longName: 'clean',
+        hasValue: false
+    },
+    {
+        shortName: 'o',
+        longName: 'core',
         hasValue: false
     },
     {
@@ -425,7 +432,9 @@ compile.rollups = function(context, options, callback) {
         rollupBody = '';
         for (i = 0; i < rollup.srcs.length; i += 1) {
             src = rollup.srcs[i];
-            rollupBody += fs.readFileSync(src, 'utf-8');
+            if (!options['core'] || src.match(/\/mojito\//)) {
+                rollupBody += fs.readFileSync(src, 'utf-8');
+            }
         }
         fs.writeFileSync(rollup.dest, rollupBody, 'utf-8');
         if (options.verbose) {
@@ -434,7 +443,7 @@ compile.rollups = function(context, options, callback) {
         processed += 1;
     }
 
-    if (options.app) {
+    if (options.app || options.core) {
         rollup = store.getRollupsApp('client', context);
         rollOneUp(rollup);
         utils.log('All rollups have been ' +


### PR DESCRIPTION
It would be nice if mojito compile supported an option to create a rollup of
only mojito core. We can achieve the same by renaming a few of the app dirs so
files don't get picked up but that's pretty clunky.

Also, one issue I found once the rollup was generated is that autoload assets
are expected in the rollup and the corresponding /static URLs stop working even
if we include them explicitly. I experienced this issue with an appLevel mojit
so not sure if it happens with autoloads from the app root as well.
