### PR TITLE
Fix mojito 'test' command for single/standalone(shared) mojit testing.

### DIFF
--- a/source/lib/management/commands/test.js
+++ b/source/lib/management/commands/test.js
@@ -665,9 +665,20 @@ runTests = function(opts) {
 
         testModuleNames = ['mojito', 'mojito-test'];
 
+        ResourceStore = require(pathlib.join(targetMojitoPath,
+                'lib/store.server.js'));
+
+    initStore = function (path) {
+        store = new ResourceStore(path);
+        store.preload({}, { env: 'test' });
+        configureYUI(YUI, store, testModuleNames);
+        return store;
+    };
+
     testRunner = function(testPath) {
         var testConfigs,
-            sourceConfigs;
+            sourceConfigs,
+            appPath;
 
         if (testType === 'mojit') {
             testConfigs = ymc(path);
@@ -676,26 +687,29 @@ runTests = function(opts) {
             Object.keys(sourceConfigs).forEach(function(k) {
                 testConfigs[k] = sourceConfigs[k];
             });
-            testConfigs['mojito-test'] = {
-                fullpath: pathlib.join(mojitoPath,
-                    'lib/app/autoload/mojito-test.common.js'),
-                requires: ['mojito']
-            };
-            testConfigs.mojito = {
-                fullpath: pathlib.join(mojitoPath,
-                    'lib/app/autoload/mojito.common.js')
-            };
-            YUI.applyConfig({
-                modules: testConfigs
-            });
+
+            //check if we can add app level stuff
+            appPath = pathlib.resolve(testPath, '../..');
+            if (fs.statSync(appPath).isDirectory()
+                    && utils.isMojitoApp(appPath)) {
+
+                store = initStore(appPath);
+                YUI.applyConfig({
+                    groups: {
+                        'mojito-mojits': { modules: testConfigs }
+                    }
+                });
+            } else {
+                store = initStore(testPath);
+                YUI.applyConfig({
+                    groups: {
+                        mojitTests: { modules: testConfigs }
+                    }
+                });
+            }
+
         } else {
-            ResourceStore = require(pathlib.join(targetMojitoPath,
-                'lib/store.server.js'));
-            store = new ResourceStore(testPath);
-
-            store.preload({}, { env: 'test' });
-
-            configureYUI(YUI, store, testModuleNames);
+            store = initStore(testPath);
 
             if (testType === 'fw') {
                 testConfigs = store.getYuiConfigApp('server', {}).modules;
@@ -736,7 +750,8 @@ runTests = function(opts) {
 
         if (!testModuleNames.length) {
             utils.error('No ' + testType + ' tests to run in ' + path +
-                ' with test name \'' + testName + '\'', null, true);
+                (testName !== undefined ? ' with test name \'' + testName + '\''
+                    : ''), null, true);
         }
 
         global.YUITest = YUITest;
@@ -744,35 +759,28 @@ runTests = function(opts) {
         // ensures all tests are run in the same order on any machine
         testModuleNames = testModuleNames.sort();
 
-        if (testType === 'app') {
-
-            // execute each test within new sandbox
-            testModuleNames.forEach(function(name) {
-                // only run tests, and not the frame mojit tests
-                if (/-tests$/.test(name) && name !== 'HTMLFrameMojit-tests') {
-                    testQueue.push(name);
-                }
-            });
-
-            runNext = function() {
-                var cb = runNext,
-                    next = testQueue.pop();
-
-                // only run next if there is a next
-                if (testQueue.length === 0) {
-                    cb = null;
-                }
-                executeTestsWithinY([next, 'mojito-test'], cb);
-            };
-
-            if (testQueue.length) {
-                runNext();
+        // execute each test within new sandbox
+        testModuleNames.forEach(function(name) {
+            // only run tests, and not the frame mojit tests
+            if (/-tests$/.test(name) && name !== 'HTMLFrameMojit-tests') {
+                testQueue.push(name);
             }
+        });
 
-        } else {
-            executeTestsWithinY(testModuleNames);
+        runNext = function() {
+            var cb = runNext,
+                next = testQueue.pop();
+
+            // only run next if there is a next
+            if (testQueue.length === 0) {
+                cb = null;
+            }
+            executeTestsWithinY([next, 'mojito-test'], cb);
+        };
+
+        if (testQueue.length) {
+            runNext();
         }
-
     };
 
     if (coverage) {


### PR DESCRIPTION
Fixed 'mojito test' to always use server store to load resources so 'app' and 'mojit' behave the same way.
This allows to test standalone mojits with their onw npm dependencies from node_modules, as well as testing mojits that require autload/yui_modules or addons.
