### PR TITLE
Allow user-provided middlewares with a name starting with 'mojito-' to gain access to the resource store, YUI instance, logger, context, etc.

### DIFF
--- a/source/lib/index.js
+++ b/source/lib/index.js
@@ -111,6 +111,7 @@ MojitoServer.prototype = {
             middleware,
             m,
             midName,
+            midBase,
             midPath,
             midFactory,
             hasMojito,
@@ -294,7 +295,7 @@ MojitoServer.prototype = {
                     // We assume the middleware is a factory function
                     // and pass in the following config object when
                     // calling said function.
-                    // 
+                    //
                     // midConfig = {
                     //    Y: Y,
                     //    store: store,
@@ -308,7 +309,16 @@ MojitoServer.prototype = {
                 // specified by path
                 midPath = libpath.join(options.dir, midName);
                 //console.log("======== MIDDLEWARE user " + midPath);
-                app.use(require(midPath));
+                midBase = libpath.basename(midPath);
+                if (0 === midBase.indexOf('mojito-')) {
+                    // Same as above (case of Mojito's special middlewares)
+                    // Gives a user-provided middleware access to the YUI
+                    // instance, resource store, logger, context, etc.
+                    midFactory = require(midPath);
+                    app.use(midFactory(midConfig));
+                } else {
+                    app.use(require(midPath));
+                }
             }
         }
 


### PR DESCRIPTION
this pull request is same as Julien's pull #187 applied to develop.
