### PR TITLE
Fixed a line of code accessing the requestor URL. [fixes #5077325]

### DIFF
--- a/docs/dev_guide/code_exs/route_config.rst
+++ b/docs/dev_guide/code_exs/route_config.rst
@@ -159,7 +159,7 @@ To set up and run ``configure_routing``:
           var methods = "";
           var name = "";
           var action = ac.action;
-          var path = ac.cookie.req.url;
+          var path = ac.http.getRequest().url;
           if(path==="/" && action==="index"){
             name = ac.app.routes.root_route.name;
             Object.keys(ac.app.routes.root_route.verbs).forEach(function(n) {

--- a/examples/developer-guide/configure_routing/mojits/RoutingMojit/controller.server.js
+++ b/examples/developer-guide/configure_routing/mojits/RoutingMojit/controller.server.js
@@ -21,7 +21,7 @@ YUI.add('RoutingMojit', function(Y, NAME) {
     var methods = "";
     var name=""; 
     var action = ac.action;
-    var path = ac.cookie.req.url;
+    var path = ac.http.getRequest().url;
     if(action==="index" && path==="/"){
       name = ac.app.routes.root_route.name;
       Object.keys(ac.app.routes.root_route.verbs).forEach(function(n) {


### PR DESCRIPTION
The routing code example and the source code for the example did not used the prescribed method for getting the request URL.
