### PR TITLE
[Issue #7] Removed all instances of using a query string to represent routing parameters

### DIFF
--- a/docs/dev_guide/code_exs/query_params.rst
+++ b/docs/dev_guide/code_exs/query_params.rst
@@ -129,19 +129,17 @@ both HTTP GET and POST calls. Storing parameters in your routing configuration a
          "verbs": ["get"],
          "path": "/example3",
          "call": "frame.example3",
-         "params": "from=routing&foo=bar&bar=foo"
+         "params": { "from": "routing", "foo": "bar", "bar": "foo" }
        },
        "example4": {
          "verbs": ["get", "post"],
          "path": "/example4",
          "call": "frame.example4",
-         "params": "from=routing&foo3=bar3"
+         "params": { "from": "routing", "foo3": "bar3" }
        }
      }
    ]
    
-The query string parameters stored in the ``params`` property can be specified in an object as well. For example, the ``params`` property for ``example4`` routing object could
-also be specified in the following way: ``"params": { "from": "routing", "foo3": "bar3" }``
 
 In the ``example4`` function below, you find the parameters catch-all method ``params.getFromMerged``. Using ``params.getFromMerged``, you can get the query string parameters, the POST body parameters, 
 and the parameters set in ``routes.json`` at one time. You can also get a specific parameter by passing a key to ``params.getFromMerged(key)``. For example, ``params.getFromMerged("from")`` would 
@@ -229,13 +227,13 @@ To set up and run ``using_parameters``:
             "verbs": ["get"],
             "path": "/example3",
             "call": "frame.example3",
-            "params": "from=routing&foo=bar&bar=foo"
+            "params": { "from": "routing", "foo": "bar", "bar": "foo" }
           },
           "example4": {
             "verbs": ["get", "post"],
             "path": "/example4",
             "call": "frame.example4",
-            "params": "from=routing&foo3=bar3"
+            "params": { "from": "routing", "foo3": "bar3" }
           }
         }
       ]

--- a/docs/dev_guide/intro/mojito_configuring.rst
+++ b/docs/dev_guide/intro/mojito_configuring.rst
@@ -755,11 +755,11 @@ The table below describes the properties of the ``route`` object of  ``routes.js
 +----------------+----------------------+---------------+--------------------------------------------------------+
 | ``params``     | string               | No            | Query string parameters that developers can            |
 |                |                      |               | associate with a route path. The default value is an   | 
-|                |                      |               | empty string "". The query string parameters can be    |
-|                |                      |               | given as a string or as an object. For example, either |
-|                |                      |               | of the following could be used:                        |
-|                |                      |               | ``params: "name=Tom&age=23"``                          |
+|                |                      |               | empty string "". The query string parameters should    |
+|                |                      |               | be given an object:                                    |
 |                |                      |               | ``params: { "name": "Tom", "age": "23" }``             |
+|                |                      |               |                                                        |
+|                |                      |               | **Deprecated**:  ``params: "name=Tom&age=23"``         |
 +----------------+----------------------+---------------+--------------------------------------------------------+
 | ``path``       | string               | Yes           | The route path that is mapped to the action in the     |
 |                |                      |               | ``call`` property. The route path can have variable    |
@@ -828,7 +828,7 @@ In the ``routes.json`` below,  an anonymous instance of ``HelloMojit`` is made b
          "verbs": ["get"],
          "path": "/",
          "call": "@HelloMojit.index",
-         "params": "first_visit=true"
+         "params": { "first_visit": true }
        }
      }
    ]
@@ -882,7 +882,7 @@ You can configure a routing path to have routing parameters with the ``params`` 
 the `Params addon <../../api/Params.common.html>`_.
 
 In the example ``routes.json`` below, routing parameters are added with a query string. To get the value for the routing parameter ``page`` from a controller, you 
-would use ``ac.params.getFromRoute("page")``. The routing parameters can also be specified as an object: ``"params": { "page": 1, "log_request": true }``
+would use ``ac.params.getFromRoute("page")``. 
 
 .. code-block:: javascript
 
@@ -893,10 +893,12 @@ would use ``ac.params.getFromRoute("page")``. The routing parameters can also be
          "verb": ["get"],
          "path": "/*",
          "call": "foo-1.index",
-         "params": "page=1&log_request=true"
+         "params": { "page": 1, "log_request": true }
        }
      }
    ]
+   
+.. note::   **Deprecated**: The routing parameters can also be specified as a query string: ``"params": "page=1&log_request=true"``
    
 
 .. _parameterized_paths:

--- a/examples/developer-guide/using_parameters/routes.json
+++ b/examples/developer-guide/using_parameters/routes.json
@@ -20,13 +20,13 @@
       "verbs": ["get"],
       "path": "/example3",
       "call": "frame.example3",
-      "params": "from=routing&foo=bar&bar=foo"
+      "params": { "from": "routing", "foo": "bar", "bar": "foo" }
     },
     "example4": {
       "verbs": ["get", "post"],
       "path": "/example4",
       "call": "frame.example4",
-      "params": "from=routing&foo3=bar3"
+      "params": { "from": "routing", "foo3": "bar3" }
     }
   }
 ]


### PR DESCRIPTION
I removed the examples of using a query string for routing parameters, but left two deprecation notices as users can still do this. The preferred way to specify routing parameters is to use an object.
