### PR TITLE
[Issue #220] Fixing broken links to API docs.

### DIFF
--- a/docs/dev_guide/api_overview/mojito_action_context.rst
+++ b/docs/dev_guide/api_overview/mojito_action_context.rst
@@ -6,7 +6,7 @@ Action Context
 
 The Action Context is an essential element of the Mojito framework that gives you access to the frameworks features from within a controller function. To use the Action Context, 
 you create an instance of the ``ActionContext`` class, which we will call ``ac`` for short. From ``ac``, you can call methods to execute mojit actions within either a server or 
-client context. See the `Class Y.mojito.ActionContext <../../api/Y.mojito.ActionContext.html>`_ for the methods available from ``ac``.
+client context. See the `ActionContext Class <../../api/classes/ActionContext.html>`_ for the methods available from ``ac``.
 
 One of the most common methods used from an instance of the ``ActionContext`` class is ``done``, which lets you pass data from the controller to a view. In the example ``controller.server.js`` below, 
 the ``done`` method sends the ``data`` object to the ``index`` view template.

--- a/docs/dev_guide/reference/glossary.rst
+++ b/docs/dev_guide/reference/glossary.rst
@@ -18,7 +18,7 @@ Action Context
 
    The Action Context is an essential element of the Mojito framework that gives you access to the frameworks features from within a controller function. 
    See `Action Context <../api_overview/mojito_action_context.html>`_ in the `Mojito API Overview <../api_overview/>`_ 
-   and the `Class Y.mojito.ActionContext <../../api/Y.mojito.ActionContext.html>`_ in the `Mojito API documentation <../../api/>`_
+   and the `ActionContext Class <../../api/classes/ActionContext.html>`_ in the `Mojito API documentation <../../api/>`_
    for more detailed information.
 
 addon
@@ -82,7 +82,7 @@ mojitProxy
 ----------
 
    The proxy object given to binders that allows them to interact with the mojit it represents as well as with other mojits on the page.
-   See the `mojitProxy Object <../intro/mojito_binders.html#mojitproxy-object>`_ and the `Class Y.mojito.MojitProxy <../../api/Y.mojito.MojitProxy.html>`_
+   See the `mojitProxy Object <../intro/mojito_binders.html#mojitproxy-object>`_ and the `MojitProxy Class <../../api/classes/MojitProxy.html>`_
    for more information.
    
 Mojito


### PR DESCRIPTION
Some of the API classes were renamed, but the links and the names in the general documentation were not updated. I've fixed the links mentioned in issue #220, but there may be more class names to change in the docs. The documentation directory has a misspelling that has been corrected, but the source for that page is not on GitHub. I am waiting on the YDN team to push the updated documentation directory to YDN. I was not able to do this because of a server issue. 
