### PR TITLE
Fix for mojito test app .

### DIFF
--- a/source/lib/management/commands/test.js
+++ b/source/lib/management/commands/test.js
@@ -126,7 +126,7 @@ function configureYUI(YUI, store, load) {
         groups: {
             'mojito-fw': store.getYuiConfigFw('server', {}),
             'mojito-app': store.getYuiConfigApp('server', {}),
-            'mojito-mojits': store.getYuiConfigAllMojits('server,', {})
+            'mojito-mojits': store.getYuiConfigAllMojits('server', {})
         }
     });
 }


### PR DESCRIPTION
[fix bz5649382] Removed nasty embedded comma causing context's environment lookup to fail.
