### PR TITLE
Set server runtime when handling tunnel calls.

### DIFF
--- a/source/lib/app/middleware/mojito-handler-tunnel.js
+++ b/source/lib/app/middleware/mojito-handler-tunnel.js
@@ -152,6 +152,14 @@ TunnelServer.prototype = {
             requestData = data.reqs[0],
             command = requestData.data;
 
+
+        // when taking in the client context on the server side, we have to
+        // override the runtime, because the runtime switches from client to server
+        if (!command.context) {
+            command.context = {};
+        }
+        command.context.runtime = 'server';
+
         // all we need to do is expand the instance given within the RPC call
         // and attach it within a "tunnelCommand", which will be handled by
         // Mojito instead of looking up a route for it.


### PR DESCRIPTION
The client supplies its context to the server when making a mojit proxy (tunnel call) and in this context the runtime is set to client. The server has to change the context runtime to server when reusing this context, for example to ensure proper loading of configs specified as runtime:server.

This fixes issue #236.
