### PR TITLE
Add --print option to jslint usage message

### DIFF
--- a/source/lib/management/commands/jslint.js
+++ b/source/lib/management/commands/jslint.js
@@ -11,7 +11,10 @@
 var fs = require('fs'),
     path = require('path'),
     utils = require('../utils'),
-    usage = 'mojito jslint [app | mojit] [<name>]',
+    usage = 'mojito jslint [app | mojit] [<name>] {options}\n' +
+            '\nOPTIONS: \n' +
+            '\t  --print      :  print results to stdout \n' +
+            '\t   -p          :  short for --print\n',
     options = [
         {
             shortName: 'p',


### PR DESCRIPTION
This is just a small enhancement to the mojito jslint --print option that was added recently. Adding it to usage message to make it visible to users.
