### PR TITLE
Performance Optimization: Defer RouteMaker Instantiation in URL Addon

### DIFF
--- a/source/lib/app/addons/ac/url.common.js
+++ b/source/lib/app/addons/ac/url.common.js
@@ -70,7 +70,7 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
                 query = query + '?' + routeParams;
             }
 
-            url = this._getRouteMaker().make(query, verb);
+            url = this.getRouteMaker().make(query, verb);
 
             if (urlParams) {
                 urlParams = objectToQueryStr(urlParams, true);
@@ -112,14 +112,14 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
                 url = url.slice(0, url.indexOf('?'));
             }
 
-            return this._getRouteMaker().find(url, verb);
+            return this.getRouteMaker().find(url, verb);
         },
 
-        _getRouteMaker: function() {
-            if (!this._maker) {
-                this._maker = new Y.mojito.RouteMaker(this.routeConfig);
+        getRouteMaker: function() {
+            if (!this.maker) {
+                this.maker = new Y.mojito.RouteMaker(this.routeConfig);
             }
-            return this._maker;
+            return this.maker;
         }
     };
 

--- a/source/lib/app/addons/ac/url.common.js
+++ b/source/lib/app/addons/ac/url.common.js
@@ -38,7 +38,7 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
      * @class Url.common
      */
     function UrlAcAddon(command, adapter, ac) {
-        this.maker = new Y.mojito.RouteMaker(ac.app.routes);
+        this.routeConfig = ac.app.routes;
         this.appConfig = ac.app.config;
     }
 
@@ -70,7 +70,7 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
                 query = query + '?' + routeParams;
             }
 
-            url = this.maker.make(query, verb);
+            url = this._getRouteMaker().make(query, verb);
 
             if (urlParams) {
                 urlParams = objectToQueryStr(urlParams, true);
@@ -112,7 +112,14 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
                 url = url.slice(0, url.indexOf('?'));
             }
 
-            return this.maker.find(url, verb);
+            return this._getRouteMaker().find(url, verb);
+        },
+
+        _getRouteMaker: function() {
+            if (!this._maker) {
+                this._maker = new Y.mojito.RouteMaker(this.routeConfig);
+            }
+            return this._maker;
         }
     };
 


### PR DESCRIPTION
The URL addon is one of the default addons that gets added to the Action Context whether or not that addon is actually used. The URL addon builds out a RouteMaker in it's constructor, which for our application is roughly 4ms for each instantiation. With 20 mojits in the main loading this change of deferring this part of the addons instantiation saves roughly 72ms for us. 
