### PR TITLE
updated controller.server.js and controller.server-tests.js code examples

### DIFF
--- a/docs/dev_guide/getting_started/mojito_getting_started_tutorial.rst
+++ b/docs/dev_guide/getting_started/mojito_getting_started_tutorial.rst
@@ -122,35 +122,51 @@ You will now modify the controller, so that the ``index`` function called in the
 
    .. code-block:: javascript
 
-      YUI.add('HelloMojit', function(Y) {
-        /**
-        * The HelloMojit module.
-        *
-        * @module HelloMojit
-        */
-        /**
+   YUI.add('HelloMojit', function(Y, NAME) {
+
+   /**
+    * The HelloMojit module.
+    *
+    * @module HelloMojit
+    */
+
+       /**
         * Constructor for the Controller class.
         *
         * @class Controller
         * @constructor
         */
-        Y.mojito.controller = {
-          init: function(config) {
-            this.config = config;
-          },
-          /**
-          * Method corresponding to the 'index' action.
-          *
-          * @param ac {Object} The action context that
-          * provides access to the Mojito API.
-          */
-          index: function(actionContext) {
-            actionContext.done('Hello World!');
-          }
-        };
-      }, '0.0.1', {requires: []});
+       Y.mojito.controllers[NAME] = {
 
-   As you can see the "controller" is just a JavaScript object, and the "action" is just a method called on that object. 
+           init: function(config) {
+               this.config = config;
+           },
+
+           /**
+            * Method corresponding to the 'index' action.
+            *
+            * @param ac {Object} The ActionContext that provides access
+            *        to the Mojito API.
+            */
+           index: function(ac) {
+               ac.models.HelloMojitModelFoo.getData(function(err, data) {
+                   if (err) {
+                       ac.error(err);
+                       return;
+                   }
+                   ac.assets.addCss('./index.css');
+                   ac.done({
+                       status: 'Hello World!',
+                       data: data
+                   });
+               });
+           }
+
+       };
+
+   }, '0.0.1', {requires: ['mojito', 'HelloMojitModelFoo']});
+
+   As you can see the "controllers" are just an array of JavaScript objects, and the "action" is just a method called on the controller object. 
    The result of the method are communicated back to Mojito through the ``actionContext`` object. 
 
 #. Change to the ``tests`` directory.
@@ -159,32 +175,62 @@ You will now modify the controller, so that the ``index`` function called in the
 
    .. code-block:: javascript
 
-      YUI.add('HelloMojit-tests', function(Y) {
-        var suite = new YUITest.TestSuite('HelloMojit-tests'), controller = null, A = YUITest.Assert;
-        suite.add(new YUITest.TestCase(
-          {
-            name: 'HelloMojit user tests',
-            setUp: function() {
-              controller = Y.mojito.controller;
-            },
-            tearDown: function() {
-              controller = null;
-            },
-            'test mojit': function() {
-              var actionContext, results;
-              A.isNotNull(controller);
-              A.isFunction(controller.index);
-              actionContext = {
-                     done: function(data) {
-                       results = data;
-                     }
-                   };
-              controller.index(actionContext);
-              A.areSame('Hello World!', results);
-            }
-          }
-        )
-      );
+   YUI.add('HelloMojit-tests', function(Y) {
+
+       var suite = new YUITest.TestSuite('HelloMojit-tests'),
+           controller = null,
+           A = YUITest.Assert;
+
+       suite.add(new YUITest.TestCase({
+
+           name: 'HelloMojit user tests',
+
+           setUp: function() {
+               controller = Y.mojito.controllers.HelloMojit;
+           },
+           tearDown: function() {
+               controller = null;
+           },
+
+           'test mojit': function() {
+               var ac,
+                   modelData,
+                   assetsResults,
+                   doneResults;
+               modelData = { x:'y' };
+               ac = {
+                   assets: {
+                       addCss: function(css) {
+                           assetsResults = css;
+                       }
+                   },
+                   models: {
+                       HelloMojitModelFoo: {
+                           getData: function(cb) {
+                               cb(null, modelData);
+                           }
+                       }
+                   },
+                   done: function(data) {
+                       doneResults = data;
+                   }
+               };
+
+               A.isNotNull(controller);
+               A.isFunction(controller.index);
+               controller.index(ac);
+               A.areSame('./index.css', assetsResults);
+               A.isObject(doneResults);
+               A.areSame('Hello World!', doneResults.status);
+               A.areSame('{"x":"y"}', doneResults.data);
+
+           }
+
+       }));
+
+       YUITest.TestRunner.add(suite);
+
+   }, '0.0.1', {requires: ['mojito-test', 'HelloMojit']});
 
    Mojito has the unit test given in ``controller.server-tests.js`` confirms that the output from the action index is the same as the 
    string given in the assert statement.

--- a/source/lib/archetypes/mojit/default/tests/controller.server-tests.js.mu
+++ b/source/lib/archetypes/mojit/default/tests/controller.server-tests.js.mu
@@ -49,8 +49,10 @@ YUI.add('{{name}}-tests', function(Y) {
             A.areSame('./index.css', assetsResults);
             A.isObject(doneResults);
             A.areSame('Mojito is working.', doneResults.status);
-            A.areSame(modelData, doneResults.data);
-
+            A.isObject(doneResults.data);
+            A.isTrue(doneResults.data.hasOwnProperty('x'));
+            A.areEqual('y', doneResults.data['x']);
+            
         }
         
     }));


### PR DESCRIPTION
updated controller.server.js and controller.server-tests.js code examples in getting_started to reflect the files generated by mojito 0.3.26.  Currently, what you see in the generated files is out of sync with what you are supposed to see according to the examples in http://developer.yahoo.com/cocktails/mojito/docs/getting_started/mojito_getting_started_tutorial.html#make-the-sample-mojit

I could not generated the documentation with sphinx-build due to the error:
Theme error:
no theme named 'ydntheme' found (missing theme.conf?)
