### PR TITLE
start app as # node server.js

### DIFF
--- a/source/lib/archetypes/app/default/package.json.mu
+++ b/source/lib/archetypes/app/default/package.json.mu
@@ -16,7 +16,7 @@
         "mojito": ">= 0.1.0"
     },
     "engines": {
-        "node": ">= 0.4.2 < 0.5.0"
+        "node": "0.6.x"
     },
     "scripts": {
         "start": "server.js"

--- a/source/lib/archetypes/app/default/package.json.mu
+++ b/source/lib/archetypes/app/default/package.json.mu
@@ -19,6 +19,6 @@
         "node": ">= 0.4.2 < 0.5.0"
     },
     "scripts": {
-        "start": "mojito start"
+        "start": "server.js"
     }
 }

--- a/source/lib/archetypes/app/default/server.js
+++ b/source/lib/archetypes/app/default/server.js
@@ -9,6 +9,7 @@
 
 
 /**
- * Returns a new Mojito server instance.
+ * Starts a new Mojito server instance.
  */
-module.exports = require('mojito').createServer();
+var mojito = require('mojito');
+new mojito.constructor().createServer().listen(80);

--- a/source/lib/archetypes/app/default/server.js
+++ b/source/lib/archetypes/app/default/server.js
@@ -12,4 +12,4 @@
  * Starts a new Mojito server instance.
  */
 var mojito = require('mojito');
-new mojito.constructor().createServer().listen(80);
+new mojito.constructor().createServer().listen(process.env.PORT || 8666);

--- a/source/lib/archetypes/app/full/package.json.mu
+++ b/source/lib/archetypes/app/full/package.json.mu
@@ -16,7 +16,7 @@
         "mojito": ">= 0.1.0"
     },
     "engines": {
-        "node": ">= 0.4.2 < 0.5.0"
+        "node": "0.6.x"
     },
     "scripts": {
         "start": "server.js"

--- a/source/lib/archetypes/app/full/package.json.mu
+++ b/source/lib/archetypes/app/full/package.json.mu
@@ -19,6 +19,6 @@
         "node": ">= 0.4.2 < 0.5.0"
     },
     "scripts": {
-        "start": "mojito start"
+        "start": "server.js"
     }
 }

--- a/source/lib/archetypes/app/full/server.js
+++ b/source/lib/archetypes/app/full/server.js
@@ -9,6 +9,7 @@
 
 
 /**
- * Returns a new Mojito server instance.
+ * Starts a new Mojito server instance.
  */
-module.exports = require('mojito').createServer();
+var mojito = require('mojito');
+new mojito.constructor().createServer().listen(80);

--- a/source/lib/archetypes/app/full/server.js
+++ b/source/lib/archetypes/app/full/server.js
@@ -12,4 +12,4 @@
  * Starts a new Mojito server instance.
  */
 var mojito = require('mojito');
-new mojito.constructor().createServer().listen(80);
+new mojito.constructor().createServer().listen(process.env.PORT || 8666);

--- a/source/lib/archetypes/app/simple/package.json.mu
+++ b/source/lib/archetypes/app/simple/package.json.mu
@@ -16,7 +16,7 @@
         "mojito": ">= 0.1.0"
     },
     "engines": {
-        "node": ">= 0.4.2 < 0.5.0"
+        "node": "0.6.x"
     },
     "scripts": {
         "start": "server.js"

--- a/source/lib/archetypes/app/simple/package.json.mu
+++ b/source/lib/archetypes/app/simple/package.json.mu
@@ -19,6 +19,6 @@
         "node": ">= 0.4.2 < 0.5.0"
     },
     "scripts": {
-        "start": "mojito start"
+        "start": "server.js"
     }
 }

--- a/source/lib/archetypes/app/simple/server.js
+++ b/source/lib/archetypes/app/simple/server.js
@@ -9,6 +9,7 @@
 
 
 /**
- * Returns a new Mojito server instance.
+ * Starts a new Mojito server instance.
  */
-module.exports = require('mojito').createServer();
+var mojito = require('mojito');
+new mojito.constructor().createServer().listen(80);

--- a/source/lib/archetypes/app/simple/server.js
+++ b/source/lib/archetypes/app/simple/server.js
@@ -12,4 +12,4 @@
  * Starts a new Mojito server instance.
  */
 var mojito = require('mojito');
-new mojito.constructor().createServer().listen(80);
+new mojito.constructor().createServer().listen(process.env.PORT || 8666);


### PR DESCRIPTION
This change allows apps to be started using
$ sudo node server.js

Also they can now be deployed to nodejitsu. I think server.js is a better start script than "mojito start", for example the latter only works if mojito was installed globally, which might not be the case in a lot of production environments. server.js is more portable.

This fixes issue #126.
