### PR TITLE
Adding meta config field for HTMLFrameMojit to create meta tags

### DIFF
--- a/source/lib/app/mojits/HTMLFrameMojit/controller.server.js
+++ b/source/lib/app/mojits/HTMLFrameMojit/controller.server.js
@@ -47,7 +47,64 @@ YUI.add('HTMLFrameMojit', function(Y, NAME) {
 
         return data;
     };
+    var renderMetaTagAttributes = function(arrayMeta) {
+        //if application.json contains
+        // "specs": {
+        //     "frame": {
+        //         "type": "HTMLFrameMojit",
+        //         "config": {
+        //             "title": "Hello App",
+        //------->     "meta": [{
+        //                 "name": "hello",
+        //                 "content": "hi"
+        //             }],
+        //             ...
+        //this function returns 
+        // [
+        //     {
+        //         "attributes": [
+        //             {
+        //                 "name": "name",
+        //                 "value": "hello"
+        //             },
+        //             {
+        //                 "name": "content",
+        //                 "value": "hi"
+        //             }
+        //         ]
+        //     }
+        // ]
 
+        var i = 0,
+        metaLen, metaTags = [],
+        attributeObj,
+        getAttributes = function (obj) {
+            var attrs = [],
+                name;
+            for (name in obj) {
+                if (obj.hasOwnProperty(name)) {
+                    attrs.push({
+                        "name": name,
+                        "value": obj[name],
+                    });
+                }
+            }
+            return attrs;
+        };
+
+        if (!Array.isArray(arrayMeta)) {
+            return undefined;
+        }
+
+        metaLen = arrayMeta.length;
+        for (i = 0; i < metaLen; i++) {
+            attributeObj = arrayMeta[i];
+            metaTags.push({
+                "attributes": getAttributes(attributeObj)
+            })
+        }
+        return metaTags;
+    };
 
     Y.mojito.controllers[NAME] = {
 
@@ -92,6 +149,10 @@ YUI.add('HTMLFrameMojit', function(Y, NAME) {
                 data.title = ac.config.get('title') ||
                     'Powered by Mojito ' + Y.mojito.version;
                 data.mojito_version = Y.mojito.version;
+
+                //set meta tags from app config
+                data.meta = renderMetaTagAttributes(ac.config.get('meta'));
+
 
                 // Add all the assets we have been given to our local store
                 ac.assets.addAssets(meta.assets);

--- a/source/lib/app/mojits/HTMLFrameMojit/views/index.iphone.mu.html
+++ b/source/lib/app/mojits/HTMLFrameMojit/views/index.iphone.mu.html
@@ -3,7 +3,7 @@
 <head>
 <script type="text/javascript">var MOJITO_INIT=new Date().getTime();</script>
 {{#meta}}
-<meta name="{{name}}" content="{{content}}">
+<meta {{#attributes}}"{{name}}"="{{value}}" {{/attributes}}>
 {{/meta}}
 {{^meta}}
 <meta name="creator" content="Yahoo! Mojito {{mojito_version}}">

--- a/source/lib/app/mojits/HTMLFrameMojit/views/index.mu.html
+++ b/source/lib/app/mojits/HTMLFrameMojit/views/index.mu.html
@@ -3,7 +3,7 @@
 <head>
 <script type="text/javascript">var MOJITO_INIT=new Date().getTime();</script>
 {{#meta}}
-<meta name="{{name}}" content="{{content}}">
+<meta {{#attributes}}"{{name}}"="{{value}}" {{/attributes}}>
 {{/meta}}
 {{^meta}}
 <meta name="creator" content="Yahoo! Mojito {{mojito_version}}">


### PR DESCRIPTION
Adding a config attribute meta for HTMLFrameMojit 
if application.json contains

<pre>        "specs": {
            "frame": {
                "type": "HTMLFrameMojit",
                "config": {
                    "title": "Hello App",
        ------->     "meta": [{
                        "name": "hello",
                        "content": "hi"
                    }],
         ...
</pre>

<pre>
&lt;!DOCTYPE HTML&gt;
&lt;html&gt;
&lt;head&gt;
&lt;script type=&quot;text/javascript&quot;&gt;var MOJITO_INIT=new Date().getTime();&lt;/script&gt;
&lt;meta &quot;name&quot;=&quot;hello&quot; &quot;content&quot;=&quot;hi&quot; &gt;

&lt;title&gt;Hello App&lt;/title&gt;
...
</pre>

