### PR TITLE
Fixed links to the API docs from the general documentation

### DIFF
--- a/docs/dev_guide/code_exs/binding_events.rst
+++ b/docs/dev_guide/code_exs/binding_events.rst
@@ -387,7 +387,7 @@ The controller for ``PagerMojit`` performs several functions:
 - calls the ``getData`` function in the model to get photo data
 - creates URLs for the **next** and **prev** links
 
-The `Params addon <../../api/Params.common.html>`_ allows you to access variables from the query string parameters, the POST request bodies, or the routing systems URLs. 
+The `Params addon <../../api/classes/Params.common.html>`_ allows you to access variables from the query string parameters, the POST request bodies, or the routing systems URLs. 
 In this code example, you use the ``getFromMerged`` method, which merges the parameters from the query string, POST request body, and the routing system URLs to give you access to 
 all of the parameters. In the code snippet taken from ``controller.server.js`` below, the ``getFromMerged`` method is used to get the value for the ``page`` parameter and then calculate 
 the index of the first photo to display:

--- a/docs/dev_guide/code_exs/calling_yql.rst
+++ b/docs/dev_guide/code_exs/calling_yql.rst
@@ -140,7 +140,7 @@ Calling the Model from the Controller
 
 The controller in this code example performs the following functions:
 
-- gets the query string parameters using the `Params addon <../../api/Params.common.html>`_
+- gets the query string parameters using the `Params addon <../../api/classes/Params.common.html>`_
 - passes the query string parameters to the ``search`` function of the model
 - receives the ``photos`` array from the ``search`` function and sends an object to the view template
 

--- a/docs/dev_guide/code_exs/cookies.rst
+++ b/docs/dev_guide/code_exs/cookies.rst
@@ -15,7 +15,7 @@ This example shows how to read and write cookies in a Mojito application.
 
 The following topics will be covered:
 
-- using the `Params addon <../../api/Params.common.html>`_ from the ``actionContext`` object
+- using the `Params addon <../../api/classes/Params.common.html>`_ from the ``actionContext`` object
 - getting and setting cookies from the mojit controller
 - using the `Cookie addon <../../api/Cookie.server.html>`_ and the `YUI Cookie module <http://developer.yahoo.com/yui/3/cookie/>`_ to get and set cookies
 

--- a/docs/dev_guide/code_exs/generating_urls.rst
+++ b/docs/dev_guide/code_exs/generating_urls.rst
@@ -16,7 +16,7 @@ This example shows you a way to generate URLs to a particular view independent o
 The following topics will be covered:
 
 - configuring routing paths to call actions from mojit instances
-- creating a URL in the mojit controller with the `Url addon <../../api/Url.common.html>`_
+- creating a URL in the mojit controller with the `Url addon <../../api/classes/Url.common.html>`_
 
 Implementation Notes
 ####################

--- a/docs/dev_guide/code_exs/query_params.rst
+++ b/docs/dev_guide/code_exs/query_params.rst
@@ -15,7 +15,7 @@ This example shows how to access query parameters from the URL, the POST body, a
 
 The following topics will be covered:
 
-- using the `Params addon <../../api/Params.common.html>`_ to access parameters
+- using the `Params addon <../../api/classes/Params.common.html>`_ to access parameters
 - setting and getting parameters from your route configuration
 
 Implementation Notes
@@ -169,7 +169,7 @@ return the value "routing" from the parameters set in the ``routes.json`` shown 
      }
    ...
 
-For more information, see the `Params addon <../../api/Params.common.html>`_ in the Mojito API documentation.
+For more information, see the `Params addon <../../api/classes/Params.common.html>`_ in the Mojito API documentation.
 
 Setting Up this Example
 #######################

--- a/docs/dev_guide/code_exs/simple_view_template.rst
+++ b/docs/dev_guide/code_exs/simple_view_template.rst
@@ -30,7 +30,7 @@ In the following screenshot, you see the HTML page that was rendered from the vi
    :width: 226px
 
 In Mojito applications, the controller is responsible for passing data to the view template. From the below code snippet taken from ``controller.server.js``, you see the ``index`` function 
-creating a ``data`` object and passing it to the ``done`` method. The ``done`` method called on ``ac``, the `ActionContext <../../api/Y.mojito.ActionContext.html>`_ object, sends the ``data`` object to the view template ``index.mu.html``.
+creating a ``data`` object and passing it to the ``done`` method. The ``done`` method called on ``ac``, the `ActionContext <../../api/classes/ActionContext.html>`_ object, sends the ``data`` object to the view template ``index.mu.html``.
 
 .. code-block:: javascript
 

--- a/docs/dev_guide/faq/index.rst
+++ b/docs/dev_guide/faq/index.rst
@@ -442,7 +442,7 @@ Views
 
     Mojito does not support Mustache partials, but you do have the following options for rendering data through a template:
       * use a child mojit instead of a view partial 
-      * render data from a binder through a specific template with the `render <../../api/Y.mojito.MojitProxy.html#method_render>`_ method. 
+      * render data from a binder through a specific template with the `render <../../api/classes/MojitProxy.html#method_render>`_ method. 
       * render data from the controller using `ac.partial.render <../../api/Y.mojito.lib.Partial.common.html#method_render>`_.     
   
     Not clear what view partials are? See `view partial <../reference/glossary.html#view-partial>`_ in the `Mojito: Glossary <../reference/glossary.html>`_.

--- a/docs/dev_guide/intro/mojito_binders.rst
+++ b/docs/dev_guide/intro/mojito_binders.rst
@@ -1,5 +1,4 @@
 
-
 ==============
 Mojito Binders
 ==============
@@ -15,7 +14,7 @@ Each mojit you create can have some specific code called binders that is only de
 
 A mojit may have zero, one, or many binders within the ``binders`` directory. Each binder will be deployed to the browser along with the rest of the mojit code, 
 where the client-side Mojito runtime will call it appropriately. The view used to generate output determines which binder is used. Thus, if the ``simple`` view is used,
-the binder ``simple.js`` is used. This can be overridden by setting  ``view.binder`` in the ``meta`` argument to `ac.done <../../api/Y.mojito.ActionContext.html#method_done>`_. 
+the binder ``simple.js`` is used. This can be overridden by setting  ``view.binder`` in the ``meta`` argument to `ac.done <../../api/classes/ActionContext.html#method_done>`_. 
 If no binder matches the view, then no binder is used.
 
 Anatomy of the Binder
@@ -169,7 +168,7 @@ The code snippet below uses the ``destroyChild`` method to remove the child node
 Class MojitProxy
 ================
 
-See the `Class MojitProxy <../../api/Y.mojito.MojitProxy.html>`_ in the Mojito API Reference.
+See the `Class MojitProxy <../../api/classes/MojitProxy.html>`_ in the Mojito API Reference.
 
 Binder Examples
 ###############

--- a/docs/dev_guide/intro/mojito_configuring.rst
+++ b/docs/dev_guide/intro/mojito_configuring.rst
@@ -243,7 +243,7 @@ specs Object
 | `config <#config-obj>`_      | object        | This is user-defined information that allows you to configure the       |
 |                              |               | controller. Mojito does not interpret any part of this object. You can  |
 |                              |               | access your defined ``config`` in the controller using the `Config      |
-|                              |               | addon <../../api/Config.common.html>`_. For example:                    |
+|                              |               | addon <../../api/classes/Config.common.html>`_. For example:            |
 |                              |               | ``ac.config.get('message')``                                            |
 +------------------------------+---------------+-------------------------------------------------------------------------+
 | ``defer``                    | boolean       | If true and the mojit instance is a child of the ``HTMLFrameMojit``,    |
@@ -608,7 +608,7 @@ Configuring Metadata
 The ``definition.json`` file in the mojit directory is used to specify metadata about the mojit type. The contents of the file override the mojit type metadata that Mojito generates 
 from the contents of the file system.
 
-The information is available from the controller using the `Config addon <../../api/Config.common.html>`_. For example, you would 
+The information is available from the controller using the `Config addon <../../api/classes/Config.common.html>`_. For example, you would 
 use ``ac.config.getDefinition('version')`` to get the version information.
 
 The table below describes the ``configuration`` object in ``definition.json``.
@@ -879,7 +879,7 @@ Adding Routing Parameters
 -------------------------
 
 You can configure a routing path to have routing parameters with the ``params`` property. Routing parameters are accessible from the ``ActionContext`` object using 
-the `Params addon <../../api/Params.common.html>`_.
+the `Params addon <../../api/classes/Params.common.html>`_.
 
 In the example ``routes.json`` below, routing parameters are added with an object. To get the value for the routing parameter ``page`` from a controller, you 
 would use ``ac.params.getFromRoute("page")``. 
@@ -947,7 +947,7 @@ The following URLs call the ``index`` and ``myAction`` functions in the controll
 Generate URLs from the Controller
 ---------------------------------
 
-The Mojito JavaScript library contains the `Url addon <../../api/Url.common.html>`_ that allows you to create a URL with the mojit instance, the action, and parameters 
+The Mojito JavaScript library contains the `Url addon <../../api/classes/Url.common.html>`_ that allows you to create a URL with the mojit instance, the action, and parameters 
 from the controller.
 
 In the code snippet below from ``routes.json``,  the mojit instance, the HTTP method, and the action are specified in the ``"foo_default"`` object.
@@ -960,7 +960,7 @@ In the code snippet below from ``routes.json``,  the mojit instance, the HTTP me
      "call": "foo-1.index"
    }
 
-In this code snippet from ``controller.js``,  the `Url addon <../../api/Url.common.html>`_ with the ``make`` method use the mojit instance and 
+In this code snippet from ``controller.js``,  the `Url addon <../../api/classes/Url.common.html>`_ with the ``make`` method use the mojit instance and 
 function specified in the ``routes.json`` above to create the URL ``/foo`` with the query string parameters ``?foo=bar``.
 
 .. code-block:: javascript
@@ -1034,7 +1034,7 @@ Controller
 ----------
 
 In the controller, the mojit-level configurations are passed to the ``init`` function. In other controller functions, you can access mojit-level configurations from the ``actionContext`` object using 
-the `Config addon <../../api/Config.common.html>`_. Use ``ac.config.get`` to access configuration values from ``application.json`` and ``defaults.json`` and ``ac.config.getDefinition`` 
+the `Config addon <../../api/classes/Config.common.html>`_. Use ``ac.config.get`` to access configuration values from ``application.json`` and ``defaults.json`` and ``ac.config.getDefinition`` 
 to access definition values from ``definition.json``.
 
 Model


### PR DESCRIPTION
The latest version of the API docs were generated with yuidoc.js, which changed the URLs to the API classes and methods; this broke some links in the general documentation. I have corrected the links and will push the new version of the docs to YDN after the merge.
