### PR TITLE
Bug Fix: Only apply the "pathToRoot" if the "contentPath" is *not* relative

### DIFF
--- a/source/lib/app/addons/ac/output-adapter.common.js
+++ b/source/lib/app/addons/ac/output-adapter.common.js
@@ -189,11 +189,20 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
                 (instance.id || '@' + instance.type) + '"', 'info', NAME);
 
             contentPath = mojitView['content-path'];
-            // this is mainly used by html5app
-            if (this.app.config.pathToRoot) {
+
+			/*
+             * This is mainly used by the build step "html5app" (is this true)?
+             *
+             * Only apply the "pathToRoot" if the "contentPath" is not relative.
+             * This is tested by checking if the first char of "contentPath" is
+             * a period i.e.
+             *
+             *  ./path/to/template.mu.html
+             *  ../path/to/template.hb.html
+             */
+            if (this.app.config.pathToRoot && contentPath[0] !== '.') {
                 contentPath = this.app.config.pathToRoot + contentPath;
             }
-
 
             renderer = new Y.mojito.ViewRenderer(
                 mojitView.engine,


### PR DESCRIPTION
When running 100% client side from static files the "output-adapter.common.js" prefixes the value of "pathToRoot" (found in application.json) to all template file paths.

This bug fix stops that process if the template file path is relative. Meaning it starts with either "../" or "./".
