### PR TITLE
Bug Fix: Use command-line context in "mojito build html5app" command

### DIFF
--- a/source/lib/management/commands/build.js
+++ b/source/lib/management/commands/build.js
@@ -154,9 +154,17 @@ exports.buildhtml5app = function(cmdOptions, store, config, destination,
         appConfig,
         tunnelPrefix;
 
+	// Convert the documented "mojito start --context" value from "key:val,key:val" to "key=val&key=val"
+    if (typeof cmdOptions.context === 'string') {
+        cmdOptions.context = cmdOptions.context.replace(/:/g, '=').replace(/,/g, '&');
+    }
+
     if (cmdOptions.context) {
         context = '?' + cmdOptions.context;
     }
+
+	// Add the provided context to the server config object so we start Mojito with the correct context.
+    config.context = libqs.parse(cmdOptions.context);
 
     urls['/' + context] = '/index.html';
 
@@ -397,7 +405,8 @@ writeWebPagesToFiles = function(type, store, destination, urls, config,
     }
 
     options = {
-        port: 11111
+        port: 11111,
+		context: config.context // Added so we can the context to app.start()
     };
 
     app = new utils.App(options);


### PR DESCRIPTION
This is a fix for where the command-line context was not being used by the "mojito build html5app" command.
