### PR TITLE
Fixed a typo in comments: getYiConfigApp => getYuiConfigApp

### DIFF
--- a/source/lib/store.server.js
+++ b/source/lib/store.server.js
@@ -801,7 +801,7 @@ ServerStore.prototype = {
      * Returns the YUI configuration object which tells YUI about the
      * YUI modules in the application (which aren't part of a mojit).
      *
-     * @method getYiConfigApp
+     * @method getYuiConfigApp
      * @param env {string} "client" or "server"
      * @param ctx {object} runtime context for YUI configuration
      * @return {object} YUI configuration for the app-level modules


### PR DESCRIPTION
The API docs had a typo, so I fixed the source code comments. I will manually edit the API docs on YDN for now, but fixing the source code comments will ensure future generated API docs won't have this error.
