### PR TITLE
Bug Fix: i13n.common addon depended on http.server addon which broke client only deployments

### DIFF
--- a/source/lib/app/addons/ac/i13n.common.js
+++ b/source/lib/app/addons/ac/i13n.common.js
@@ -217,10 +217,12 @@ YUI.add('mojito-i13n-addon', function(Y, NAME) {
         }
     };
 
-    I13nAddon.dependsOn = ['config', 'http', 'url'];
+    I13nAddon.dependsOn = ['config', 'url'];
 
     Y.mojito.addons.ac.i13n = I13nAddon;
 
 }, '0.1.0', {requires: [
-    'mojito'
+    'mojito',
+	'mojito-url-addon',
+	'mojito-http-addon'
 ]});


### PR DESCRIPTION
I removed the hard dependency a replaced it with a YUI require. This will still throw a warning but will not generate an error that stops the client from executing.
