### PR TITLE
Error http reasonphrase

### DIFF
--- a/source/lib/app/autoload/action-context.common.js
+++ b/source/lib/app/autoload/action-context.common.js
@@ -47,7 +47,11 @@ YUI.add('mojito-action-context', function(Y, NAME) {
      * @param {Error} err A normal JavaScript Error object is expected, but you
      *     may add a "code" property to the error if you want the framework to
      *     report a certain HTTP status code for the error. For example, if the
-     *     status code is 404, Mojito will generate a 404 page.
+     *     status code is 404, Mojito will generate a 404 page. Additionally you
+     *     might provide a reasonPhrase property, to override the default humran
+     *     readable description for this status code with one specific to your
+     *     application. For example for the status code 404 you could provide
+     *     "This does not exist in my app".
      */
 
     /**

--- a/source/lib/app/autoload/action-context.common.js
+++ b/source/lib/app/autoload/action-context.common.js
@@ -48,7 +48,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
      *     may add a "code" property to the error if you want the framework to
      *     report a certain HTTP status code for the error. For example, if the
      *     status code is 404, Mojito will generate a 404 page. Additionally you
-     *     might provide a reasonPhrase property, to override the default humran
+     *     might provide a reasonPhrase property, to override the default human
      *     readable description for this status code with one specific to your
      *     application. For example for the status code 404 you could provide
      *     "This does not exist in my app".

--- a/source/lib/output-handler.server.js
+++ b/source/lib/output-handler.server.js
@@ -91,6 +91,7 @@ OutputHandler.prototype = {
         this.done(out, {
             http: {
                 code: err.code,
+                reasonPhrase: err.reasonPhrase,
                 headers: {
                     'content-type': 'text/html'
                 }
@@ -110,12 +111,21 @@ OutputHandler.prototype = {
         }
 
         this.statusCode = meta.http.code;
+        this.reasonPhrase = meta.http.reasonPhrase;
     },
 
 
     _writeHeaders: function() {
         if (!this.headersSent) {
-            this.res.writeHead(this.statusCode || 200, this.headers);
+
+            // passing a falsy reason phrase would break, because node uses every non-string arguments[1]
+            // as header object/array
+            if (this.reasonPhrase && typeof this.reasonPhrase === 'string') {
+                this.res.writeHead(this.statusCode || 200, this.reasonPhrase, this.headers);
+            } else {
+                this.res.writeHead(this.statusCode || 200, this.headers);
+            }
+
             this.headersSent = true;
         }
     }

--- a/source/lib/tests/autoload/output-handler-tests.server.js
+++ b/source/lib/tests/autoload/output-handler-tests.server.js
@@ -69,6 +69,37 @@ YUI.add('mojito-output-handler-tests', function(Y, NAME) {
             A.isTrue(writeCalled, 'write never called');
         },
 
+        'test error call with reasonPhrase and status code': function () {
+            var headWritten = false;
+            var writeCalled = false;
+            var nextCalled = false;
+
+            var oh = new OutputHandler(null, {
+                writeHead: function(code, statusPhrase, headers) {
+                    headWritten = true;
+                    A.areSame(501, code, 'bad status code');
+                    A.areSame('Help me, Obi-Wan Kenobi.', statusPhrase, 'bad reason phrase');
+                    OA.areEqual({'content-type':'text/html'}, headers, 'bad headers');
+                },
+                end: function(data) {
+                    writeCalled = true;
+                    A.areSame('<html><body><h1>Error: 501</h1><p>Error details are not available.</p></body></html>', data);
+                }
+            }, function() {
+                nextCalled = true;
+            });
+            oh.setLogger({log: function() {}});
+
+            oh.error({
+                'code': 501,
+                'reasonPhrase': 'Help me, Obi-Wan Kenobi.'
+            });
+
+            A.isTrue(headWritten, 'headers never written');
+            A.isTrue(writeCalled, 'write never called');
+            A.isFalse(nextCalled, 'next() should not be called on error()');
+        },
+
         'TODO: error call': function() {
             // TODO: [Issue 99] this is deferred until we get build environments working
             A.skip();


### PR DESCRIPTION
Providing the ability to provide a reasonPhrase property when calling ac.error. Mentioning this in the API doc and also adding a UT. This addresses issue #273.
