### PR TITLE
Fixed link to Mojito forum.

### DIFF
--- a/docs/dev_guide/resources/index.rst
+++ b/docs/dev_guide/resources/index.rst
@@ -78,7 +78,7 @@ Community
 Developer Forums
 ================
 
-`YDN: Mojito Forum <http://developer.yahoo.com/forum/Sports>`_
+`YDN: Mojito Forum <http://developer.yahoo.com/forum/Yahoo-Mojito/>`_
 
 Twitter
 =======


### PR DESCRIPTION
The link to the forum was created before the forum existed. After the forum was created, the link was never updated. I've updated the link to point to the Mojito forum on YDN.
