### PR TITLE
Repair obsolete yuitest require()

### DIFF
--- a/source/lib/app/mojits/HTMLFrameMojit/tests/controller.server-tests.js
+++ b/source/lib/app/mojits/HTMLFrameMojit/tests/controller.server-tests.js
@@ -12,9 +12,7 @@ YUI.add('HTMLFrameMojit-tests', function(Y, NAME) {
         mojitoPath = pathlib.join(__dirname, '../..'),
         targetMojitoPath = mojitoPath,
         fwTestsRoot = pathlib.join(targetMojitoPath, 'tests'),
-        YUITest = require(pathlib.join(fwTestsRoot,
-            'harness/lib/yuitest/javascript/build/yuitest/yuitest-node'
-            )).YUITest,
+        YUITest = require('yuitest').YUITest,
         suite = new YUITest.TestSuite(NAME),
         A = YUITest.Assert;
 


### PR DESCRIPTION
This test doesn't use the new yuitest npm module. Repaired that problem so we are using the same test harness for all tests and don't invite copy/paste errors in other test files.
