### PR TITLE
Added client-side unescape of escaped content.

### DIFF
--- a/source/lib/app/autoload/mojito-client.client.js
+++ b/source/lib/app/autoload/mojito-client.client.js
@@ -240,7 +240,12 @@ YUI.add('mojito-client', function(Y, NAME) {
         this.yuiConsole = null;
         this._pauseQueue = [];
         if (config) {
-            this.init(config);
+            // Note the server sends cleased config data directly to the
+            // constructor from the deploy.server.js initializer to allow markup
+            // to move over the wire in config strings without triggering
+            // injection attacks. We need to undo that here so the strings
+            // return to their original format before we try to use them.
+            this.init(Y.mojito.util.uncleanse(config));
         }
     }
 
@@ -1047,7 +1052,6 @@ YUI.add('mojito-client', function(Y, NAME) {
                 }
             });
         }
-
     };
 
     Y.mojito.Client = MojitoClient;

--- a/source/lib/app/autoload/util.common.js
+++ b/source/lib/app/autoload/util.common.js
@@ -78,8 +78,11 @@ YUI.add('mojito-util', function(Y) {
          * that an entire object or array is escaped use the util.cleanse() call.
          * @param {Object} obj The object to encode/escape.
          */
-        unicodeEscape: function(obj) {
+        htmlEntitiesToUnicode: function(obj) {
 
+            // Note that we convert to an "escaped" unicode representation here
+            // which ensures that when the JSON string we're ultimately creating
+            // hits a browser it's not interpreted as the original character.
             if (Y.Lang.isString(obj)) {
                 return obj.replace(/</g, '\\u003C').
                     replace(/>/g, '\\u003E').
@@ -93,12 +96,34 @@ YUI.add('mojito-util', function(Y) {
 
 
         /**
+         * Converts unicode escapes for the HTML characters (<, >, ', ", and &)
+         * back into their original HTML form. Note that only strings are
+         * escaped by this routine. If you want to ensure that an entire object
+         * or array is escaped use the util.cleanse() call.
+         * @param {Object} obj The object to encode/escape.
+         */
+        unicodeToHtmlEntities: function(obj) {
+
+            // Note we convert the form produced by htmlEntitiesToUnicode.
+            if (Y.Lang.isString(obj)) {
+                return obj.replace(/\\u003C/g, '<').
+                    replace(/\\u003E/g, '>').
+                    replace(/\\u0026/g, '&').
+                    replace(/\\u0027/g, '\'').
+                    replace(/\\u0022/g, '"');
+            }
+
+            return obj;
+        },
+
+
+        /**
          * Cleanses string keys and values in an object, returning a new object
          * whose strings are escaped using the escape function provided. The
-         * default escape function is the util.unicodeEscape function.
+         * default escape function is the util.htmlEntitiesToUnicode function.
          * @param {Object} obj The object to cleanse.
          * @param {Function} escape The escape function to run. Default is
-         *     util.unicodeEscape.
+         *     util.htmlEntitiesToUnicode.
          * @return {Object} The cleansed object.
          */
         cleanse: function(obj, escape) {
@@ -115,7 +140,7 @@ YUI.add('mojito-util', function(Y) {
                     throw new Error('Invalid escape function: ' + escape);
                 }
             }
-            func = func || this.unicodeEscape;
+            func = func || this.htmlEntitiesToUnicode;
 
             // How we proceed depends on what type of object we received. If we
             // got a String or RegExp they're not strictly mutable, but we can
@@ -149,6 +174,18 @@ YUI.add('mojito-util', function(Y) {
             }
 
             return obj;
+        },
+
+
+        /**
+         * Uncleanses string keys and values in an object, returning a new
+         * object whose strings are unescaped via the unicodeToHtmlEntities
+         * routine. 
+         * @param {Object} obj The object to cleanse.
+         * @return {Object} The cleansed object.
+         */
+        uncleanse: function(obj) {
+            return this.cleanse(obj, this.unicodeToHtmlEntities);
         },
 
 

--- a/source/lib/tests/autoload/util-tests.js
+++ b/source/lib/tests/autoload/util-tests.js
@@ -14,7 +14,7 @@ YUI.add('mojito-util-tests', function(Y, NAME) {
         
         name: 'others',
 
-        'unicodeEscape cleanses a string': function() {
+        'htmlEntitiesToUnicode cleanses a string': function() {
             A.areSame(
                 '\\u003Cscript\\u003Ealert(\\u0022hi, i\\u0027m a squid \\u0026 a happy one!\\u0022)\\u003C/script\\u003E',
                 Y.mojito.util.cleanse(
@@ -97,6 +97,80 @@ YUI.add('mojito-util-tests', function(Y, NAME) {
             AA.itemsAreEqual(a2, Y.mojito.util.cleanse(a1));
         },
         
+        'unicodeToHtmlEntities uncleanses a string': function() {
+            A.areSame(
+                '<script>alert("hi, i\'m a squid & a happy one!")</script>',
+                Y.mojito.util.cleanse(
+                    '\\u003Cscript\\u003Ealert(\\u0022hi, i\\u0027m a squid \\u0026 a happy one!\\u0022)\\u003C/script\\u003E',
+                    Y.mojito.util.unicodeToHtmlEntities));
+        },
+
+        'uncleanse uncleanses a string': function() {
+            A.areSame(
+                '<script>alert("hi, i\'m a squid & a happy one!")</script>',
+                Y.mojito.util.uncleanse(
+                    '\\u003Cscript\\u003Ealert(\\u0022hi, i\\u0027m a squid \\u0026 a happy one!\\u0022)\\u003C/script\\u003E'));
+        },
+
+        'uncleanse uncleanses an empty array': function() {
+            var a = [];
+            AA.itemsAreEqual(a, Y.mojito.util.uncleanse(a),
+                'Empty array should cleanse properly as empty array.');
+        },
+        
+        'uncleanse cleanses an array with single array child': function() {
+            var a = [[]];
+            // AA.itemsAreEqual is brain-damaged and doesn't maintain Array
+            // semantics for content checks so we hack around it with JSON.
+            A.areSame(Y.JSON.stringify(a),
+                Y.JSON.stringify(Y.mojito.util.uncleanse(a)),
+                'Array with single (empty) array child should uncleanse properly.');
+        },
+
+        'uncleanse uncleanses an array': function() {
+            var a1, 
+                a2;
+
+            a1 = ['<script>I\'m a hack attempt</script>'];
+            a2 = ['\\u003Cscript\\u003EI\\u0027m a hack attempt\\u003C/script\\u003E'];
+            AA.itemsAreEqual(a1, Y.mojito.util.uncleanse(a2),
+                'array uncleanse should work');
+        },
+
+        'uncleanse uncleanses an object': function() {
+            var o1, 
+                o2;
+
+            o1 = {'key': '<script>I\'m a hack attempt</script>'};
+            o2 = {'key': 
+                '\\u003Cscript\\u003EI\\u0027m a hack attempt\\u003C/script\\u003E'};
+
+            OA.areEqual(o1, Y.mojito.util.uncleanse(o2),
+                'object uncleanse should work');
+        },
+
+        'uncleanse uncleanses a nested array': function() {
+            var a1, 
+                a2;
+
+            a1 = [['<script>I\'m a hack attempt</script>']];
+            a2 = [['\\u003Cscript\\u003EI\\u0027m a hack attempt\\u003C/script\\u003E']];
+            AA.itemsAreEqual(a1[0], Y.mojito.util.uncleanse(a2)[0],
+                'nested array uncleanse should work');
+        },
+
+        'uncleanse uncleanses a nested object': function() {
+            var a1, 
+                a2;
+
+            a1 = [{'key': '<script>I\'m a hack attempt</script>'}];
+            a2 = [{'key': 
+                '\\u003Cscript\\u003EI\\u0027m a hack attempt\\u003C/script\\u003E'}];
+
+            OA.areEqual(a1[0], Y.mojito.util.uncleanse(a2)[0],
+                'object uncleanse should work');
+        },
+
         'copy() deep copies an object': function() {
             var obj = {
                     inner: {
@@ -356,4 +430,4 @@ YUI.add('mojito-util-tests', function(Y, NAME) {
     
     YUITest.TestRunner.add(suite);
     
-}, '0.0.1', {requires: ['mojito-util']});
+}, '0.0.1', {requires: ['mojito-util','json']});


### PR DESCRIPTION
Applications which were relying on HTML entities in thier configs were still
seeing issues with the escape routine. This patch added unescape logic to the
util routines, adds unit tests for those routines, and puts unescape logic on
the config data passed to the MojitoClient constructor function. This function
is only invoked in one place, the deploy.server.js file's initializer block.
