### PR TITLE
Adding namespacing to Mojito components

### DIFF
--- a/source/lib/app/addons/ac/analytics.common.js
+++ b/source/lib/app/addons/ac/analytics.common.js
@@ -99,7 +99,7 @@ YUI.add('mojito-analytics-addon', function(Y, NAME) {
 
     AnalyticsAddon.dependsOn = ['meta'];
 
-    Y.mojito.addons.ac.analytics = AnalyticsAddon;
+    Y.namespace('mojito.addons.ac').analytics = AnalyticsAddon;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/addons/ac/assets.common.js
+++ b/source/lib/app/addons/ac/assets.common.js
@@ -235,7 +235,7 @@ YUI.add('mojito-assets-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.assets = AssetsAcAddon;
+    Y.namespace('mojito.addons.ac').assets = AssetsAcAddon;
 
 }, '0.1.0', {requires: [
     'mojito-util'

--- a/source/lib/app/addons/ac/carrier.server.js
+++ b/source/lib/app/addons/ac/carrier.server.js
@@ -67,7 +67,7 @@ YUI.add('mojito-carrier-addon', function(Y, NAME) {
 
     CarrierAddon.dependsOn = ['config', 'http'];
 
-    Y.mojito.addons.ac.carrier = CarrierAddon;
+    Y.namespace('mojito.addons.ac').carrier = CarrierAddon;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/addons/ac/composite.common.js
+++ b/source/lib/app/addons/ac/composite.common.js
@@ -326,7 +326,7 @@ callback({
         }
     };
 
-    Y.mojito.addons.ac.composite = Addon;
+    Y.namespace('mojito.addons.ac').composite = Addon;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/addons/ac/config.common.js
+++ b/source/lib/app/addons/ac/config.common.js
@@ -78,7 +78,7 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.config = Addon;
+    Y.namespace('mojito.addons.ac').config = Addon;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/addons/ac/cookie.client.js
+++ b/source/lib/app/addons/ac/cookie.client.js
@@ -46,7 +46,7 @@ YUI.add('mojito-cookie-addon', function(Y, NAME) {
         namespace: 'cookie'
     };
 
-    Y.mojito.addons.ac.cookie = Addon;
+    Y.namespace('mojito.addons.ac').cookie = Addon;
 
 }, '0.1.0', {requires: [
     'cookie',

--- a/source/lib/app/addons/ac/cookie.server.js
+++ b/source/lib/app/addons/ac/cookie.server.js
@@ -77,7 +77,7 @@ YUI.add('mojito-cookie-addon', function(Y, NAME) {
 
     Addon.dependsOn = ['http'];
 
-    Y.mojito.addons.ac.cookie = Addon;
+    Y.namespace('mojito.addons.ac').cookie = Addon;
 
 }, '0.1.0', {requires: [
     'mojito',

--- a/source/lib/app/addons/ac/deploy.server.js
+++ b/source/lib/app/addons/ac/deploy.server.js
@@ -402,7 +402,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.deploy = Addon;
+    Y.namespace('mojito.addons.ac').deploy = Addon;
 
 }, '0.1.0', {requires: [
     'mojito-loader',

--- a/source/lib/app/addons/ac/device.server.js
+++ b/source/lib/app/addons/ac/device.server.js
@@ -62,7 +62,7 @@ YUI.add('mojito-device-addon', function(Y, NAME) {
 
     DeviceAddon.dependsOn = ['config', 'http'];
 
-    Y.mojito.addons.ac.device = DeviceAddon;
+    Y.namespace('mojito.addons.ac').device = DeviceAddon;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/addons/ac/http.server.js
+++ b/source/lib/app/addons/ac/http.server.js
@@ -202,7 +202,7 @@ YUI.add('mojito-http-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.http = Addon;
+    Y.namespace('mojito.addons.ac').http = Addon;
 
 }, '0.1.0', {requires: [
     'mojito-util'

--- a/source/lib/app/addons/ac/i13n.common.js
+++ b/source/lib/app/addons/ac/i13n.common.js
@@ -219,7 +219,7 @@ YUI.add('mojito-i13n-addon', function(Y, NAME) {
 
     I13nAddon.dependsOn = ['config', 'http', 'url'];
 
-    Y.mojito.addons.ac.i13n = I13nAddon;
+    Y.namespace('mojito.addons.ac').i13n = I13nAddon;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/addons/ac/intl.common.js
+++ b/source/lib/app/addons/ac/intl.common.js
@@ -62,7 +62,7 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
 
     IntlAddon.dependsOn = ['config'];
 
-    Y.mojito.addons.ac.intl = IntlAddon;
+    Y.namespace('mojito.addons.ac').intl = IntlAddon;
 
 }, '0.1.0', {requires: [
     'intl',

--- a/source/lib/app/addons/ac/meta.common.js
+++ b/source/lib/app/addons/ac/meta.common.js
@@ -81,7 +81,7 @@ YUI.add('mojito-meta-addon', function(Y, NAME) {
 
     MetaAddon.dependsOn = ['core'];
 
-    Y.mojito.addons.ac.meta = MetaAddon;
+    Y.namespace('mojito.addons.ac').meta = MetaAddon;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/addons/ac/output-adapter.common.js
+++ b/source/lib/app/addons/ac/output-adapter.common.js
@@ -346,7 +346,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         ac.error = error;
     }
 
-    Y.mojito.addons.ac.core = Addon;
+    Y.namespace('mojito.addons.ac').core = Addon;
 
 }, '0.1.0', {requires: [
     'json-stringify',

--- a/source/lib/app/addons/ac/params.common.js
+++ b/source/lib/app/addons/ac/params.common.js
@@ -218,7 +218,7 @@ YUI.add('mojito-params-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.params = Addon;
+    Y.namespace('mojito.addons.ac').params = Addon;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/addons/ac/partial.common.js
+++ b/source/lib/app/addons/ac/partial.common.js
@@ -140,7 +140,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.partial = Addon;
+    Y.namespace('mojito.addons.ac').partial = Addon;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/addons/ac/url.common.js
+++ b/source/lib/app/addons/ac/url.common.js
@@ -123,7 +123,7 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.url = UrlAcAddon;
+    Y.namespace('mojito.addons.ac').url = UrlAcAddon;
 
 }, '0.1.0', {requires: [
     'querystring-stringify-simple',

--- a/source/lib/app/addons/view-engines/mu.client.js
+++ b/source/lib/app/addons/view-engines/mu.client.js
@@ -488,7 +488,7 @@ YUI.add('mojito-mu', function(Y, NAME) {
             YUI._mojito._cache.compiled[ns].views[meta.view.name];
     };
 
-    Y.mojito.addons.viewEngines.mu = MuAdapter;
+    Y.namespace('mojito.addons.viewEngines').mu = MuAdapter;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/autoload/action-context.common.js
+++ b/source/lib/app/autoload/action-context.common.js
@@ -324,7 +324,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         controller[actionFunction](this);
     }
 
-    Y.mojito.ActionContext = ActionContext;
+    Y.namespace('mojito').ActionContext = ActionContext;
 
 }, '0.1.0', {requires: [
     // following are ACPs are always available

--- a/source/lib/app/autoload/controller-context.common.js
+++ b/source/lib/app/autoload/controller-context.common.js
@@ -157,7 +157,7 @@ YUI.add('mojito-controller-context', function(Y, NAME) {
         }
     };
 
-    Y.mojito.ControllerContext = ControllerContext;
+    Y.namespace('mojito').ControllerContext = ControllerContext;
 
 }, '0.1.0', {requires: [
     'mojito-action-context',

--- a/source/lib/app/autoload/dispatch.common.js
+++ b/source/lib/app/autoload/dispatch.common.js
@@ -376,7 +376,7 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
      * order to have consistent logging, the Mojito logger is passed in and we
      * use it.
      */
-    Y.mojito.Dispatcher = {
+    Y.namespace('mojito').Dispatcher = {
 
         init: function(resourceStore, coreMojitoYuiModules, globalLogger,
                 globalLoader) {

--- a/source/lib/app/autoload/loader.common.js
+++ b/source/lib/app/autoload/loader.common.js
@@ -160,7 +160,7 @@ YUI.add('mojito-loader', function(Y, NAME) {
         }
     };
 
-    Y.mojito.Loader = Loader;
+    Y.namespace('mojito').Loader = Loader;
 
 }, '0.1.0', {requires: [
     'get',

--- a/source/lib/app/autoload/logger.common.js
+++ b/source/lib/app/autoload/logger.common.js
@@ -208,7 +208,7 @@ YUI.add('mojito-logger', function(Y, NAME) {
         }
     };
 
-    Y.mojito.Logger = Logger;
+    Y.namespace('mojito').Logger = Logger;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/autoload/mojit-proxy.client.js
+++ b/source/lib/app/autoload/mojit-proxy.client.js
@@ -390,7 +390,7 @@ YUI.add('mojito-mojit-proxy', function(Y, NAME) {
 
     };
 
-    Y.mojito.MojitProxy = MojitProxy;
+    Y.namespace('mojito').MojitProxy = MojitProxy;
 
 }, '0.1.0', {requires: [
     'mojito-util'

--- a/source/lib/app/autoload/mojito-client.client.js
+++ b/source/lib/app/autoload/mojito-client.client.js
@@ -1050,7 +1050,7 @@ YUI.add('mojito-client', function(Y, NAME) {
 
     };
 
-    Y.mojito.Client = MojitoClient;
+    Y.namespace('mojito').Client = MojitoClient;
 
 }, '0.1.0', {requires: [
     'io-base',

--- a/source/lib/app/autoload/mojito-test.common.js
+++ b/source/lib/app/autoload/mojito-test.common.js
@@ -119,8 +119,8 @@ YUI.add('mojito-test', function(Y, NAME) {
         return mock;
     }
 
-    Y.mojito.MockActionContext = MockActionContext;
-    Y.mojito.EasyMock = EasyMock;
+    Y.namespace('mojito').MockActionContext = MockActionContext;
+    Y.namespace('mojito').EasyMock = EasyMock;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/autoload/mojito.common.js
+++ b/source/lib/app/autoload/mojito.common.js
@@ -11,8 +11,7 @@
 
 YUI.add('mojito', function(Y, NAME) {
 
-    Y.namespace('mojito');
-    Y.mojito.version = '0.2';
+    Y.namespace('mojito').version = '0.2';
     Y.namespace('mojito.trans');
     Y.namespace('mojito.actions');
     Y.namespace('mojito.binders');

--- a/source/lib/app/autoload/output-handler.client.js
+++ b/source/lib/app/autoload/output-handler.client.js
@@ -169,7 +169,7 @@ YUI.add('mojito-output-handler', function(Y, NAME) {
         }
     };
 
-    Y.mojito.OutputHandler = OutputHandler;
+    Y.namespace('mojito').OutputHandler = OutputHandler;
 
 }, '0.1.0', {requires: [
     'mojito',

--- a/source/lib/app/autoload/resource-store-adapter.common.js
+++ b/source/lib/app/autoload/resource-store-adapter.common.js
@@ -22,7 +22,7 @@ YUI.add('mojito-resource-store-adapter', function(Y, NAME) {
         logger;
 
 
-    Y.mojito.ResourceStoreAdapter = {
+    Y.namespace('mojito').ResourceStoreAdapter = {
 
         ENV: '',
 

--- a/source/lib/app/autoload/rest.common.js
+++ b/source/lib/app/autoload/rest.common.js
@@ -50,7 +50,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
      * @class REST
      * @namespace Y.mojito.lib
      */
-    Y.mojito.lib.REST = {
+    Y.namespace('mojito.lib').REST = {
 
         /**
          * @private

--- a/source/lib/app/autoload/route-maker.common.js
+++ b/source/lib/app/autoload/route-maker.common.js
@@ -437,7 +437,7 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
         }
     };
 
-    Y.mojito.RouteMaker = Maker;
+    Y.namespace('mojito').RouteMaker = Maker;
 
 }, '0.1.0', {  requires: [
     'querystring-stringify-simple',

--- a/source/lib/app/autoload/store.client.js
+++ b/source/lib/app/autoload/store.client.js
@@ -204,7 +204,7 @@ YUI.add('mojito-client-store', function(Y, NAME) {
         }
     };
 
-    Y.mojito.ResourceStore = ClientStore;
+    Y.namespace('mojito').ResourceStore = ClientStore;
 
 }, '0.1.0', {requires: [
     'mojito-util',

--- a/source/lib/app/autoload/tunnel.client-optional.js
+++ b/source/lib/app/autoload/tunnel.client-optional.js
@@ -63,7 +63,7 @@ YUI.add('mojito-tunnel-client', function(Y, NAME) {
         }
     };
 
-    Y.mojito.TunnelClient = TunnelClient;
+    Y.namespace('mojito').TunnelClient = TunnelClient;
 
 }, '0.1.0', {requires: [
     'breg',

--- a/source/lib/app/autoload/util.common.js
+++ b/source/lib/app/autoload/util.common.js
@@ -46,7 +46,7 @@ YUI.add('mojito-util', function(Y) {
     }
 
 
-    Y.mojito.util = {
+    Y.namespace('mojito').util = {
 
         array: {
 

--- a/source/lib/app/autoload/view-renderer.common.js
+++ b/source/lib/app/autoload/view-renderer.common.js
@@ -44,7 +44,7 @@ YUI.add('mojito-view-renderer', function(Y) {
         }
     };
 
-    Y.mojito.ViewRenderer = Renderer;
+    Y.namespace('mojito').ViewRenderer = Renderer;
 
 }, '0.1.0', {requires: [
     'mojito'

--- a/source/lib/app/mojits/DaliProxy/autoload/store-provider.server.js
+++ b/source/lib/app/mojits/DaliProxy/autoload/store-provider.server.js
@@ -42,6 +42,6 @@ YUI.add('dali-store-provider-addon', function(Y, NAME) {
         }
     };
 
-    Y.mojito.addons.ac.store = Addon;
+    Y.namespace('mojito.addons.ac').store = Addon;
 
 }, '0.1.0');

--- a/source/lib/app/mojits/DaliProxy/controller.server.js
+++ b/source/lib/app/mojits/DaliProxy/controller.server.js
@@ -81,7 +81,7 @@ YUI.add('DaliProxy', function(Y, NAME) {
     }
 
 
-    Y.mojito.controllers[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = {
 
         init: function(config) {
             this.config = config;

--- a/source/lib/app/mojits/HTMLFrameMojit/controller.server.js
+++ b/source/lib/app/mojits/HTMLFrameMojit/controller.server.js
@@ -49,7 +49,7 @@ YUI.add('HTMLFrameMojit', function(Y, NAME) {
     };
 
 
-    Y.mojito.controllers[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = {
 
         index: function(ac) {
             this.__call(ac);

--- a/source/lib/app/mojits/LazyLoad/controller.common.js
+++ b/source/lib/app/mojits/LazyLoad/controller.common.js
@@ -11,7 +11,7 @@
 
 YUI.add('LazyLoad', function(Y) {
 
-    Y.mojito.controller = {
+    Y.namespace('mojito').controller = {
 
         /*
          * Initially, renders a bar node

--- a/source/lib/archetypes/mojit/default/controller.server.js.mu
+++ b/source/lib/archetypes/mojit/default/controller.server.js.mu
@@ -16,7 +16,7 @@ YUI.add('{{name}}', function(Y, NAME) {
      * @class Controller
      * @constructor
      */
-    Y.mojito.controllers[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = {
 
         init: function(config) {
             this.config = config;

--- a/source/lib/archetypes/mojit/default/models/foo.server.js.mu
+++ b/source/lib/archetypes/mojit/default/models/foo.server.js.mu
@@ -16,7 +16,7 @@ YUI.add('{{name}}ModelFoo', function(Y, NAME) {
      * @class {{name}}ModelFoo
      * @constructor
      */
-    Y.mojito.models[NAME] = {
+    Y.namespace('mojito.models')[NAME] = {
 
         init: function(config) {
             this.config = config;

--- a/source/lib/archetypes/mojit/full/controller.server.js.mu
+++ b/source/lib/archetypes/mojit/full/controller.server.js.mu
@@ -16,7 +16,7 @@ YUI.add('{{name}}', function(Y, NAME) {
      * @class Controller
      * @constructor
      */
-    Y.mojito.controllers[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = {
 
         init: function(config) {
             this.config = config;

--- a/source/lib/archetypes/mojit/full/models/foo.server.js.mu
+++ b/source/lib/archetypes/mojit/full/models/foo.server.js.mu
@@ -16,7 +16,7 @@ YUI.add('{{name}}ModelFoo', function(Y, NAME) {
      * @class {{name}}ModelFoo
      * @constructor
      */
-    Y.mojito.models[NAME] = {
+    Y.namespace('mojito.models')[NAME] = {
 
         init: function(config) {
             this.config = config;

--- a/source/lib/archetypes/mojit/simple/controller.server.js.mu
+++ b/source/lib/archetypes/mojit/simple/controller.server.js.mu
@@ -4,7 +4,7 @@
 /*jslint anon:true, sloppy:true, nomen:true*/
 YUI.add('{{name}}', function(Y, NAME) {
 
-    Y.mojito.controllers[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = {
 
         index: function(ac) {
             ac.done('Mojito is working.');


### PR DESCRIPTION
Adds Y.namespace() calls to all declared Y.mojito components. This avoids issues where a component tries do declare itself in a namespace that is undefined (something that we've been seeing in our unit tests). 

I avoided changes to mojito.common.js for now due to BC breaks. All application code does `Y.mojito.controller[NAME] = ...` so we would break if we remove mojito.common.js. I did fix the archetypes to avoid this in the future, but this may be something we need to phase out or never remove.

Passed functional tests in mojito-github-fork/62 job
