### PR TITLE
minor: narrow glob.js dep range

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "connect": "1.8.2",
         "express": "2.5.2",
-        "glob": "~3",
+        "glob": "~3.1.10",
         "mime": "1.2.4",
         "yui": "~3.5.1",
         "yuitest": "~0.7.4"


### PR DESCRIPTION
mojito needs[1] glob.js >= 3.1.10, that should be the
lower range, and patch level ranges are in line
with other deps. TODO: whitelist, update license
[1] https://github.com/isaacs/node-glob/issues/46
