### PR TITLE
Fixed descriptors to work for server side tests using nodejs driver

### DIFF
--- a/tests/base/mojito-test.html
+++ b/tests/base/mojito-test.html
@@ -5,7 +5,6 @@
   <title>Mojito Arrow Unit Test Page</title>
   <script src="./yui-3.5.1.js"></script>
   <script src="./yui-test.js"></script>
-  <script src="./mojito-test.js"></script>
 </head>
 <body></body>
 </html>

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -42,6 +42,16 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
 
 /*
  */
+YUI.add('mojito-cookie-addon', function(Y, NAME) {
+});
+
+/*
+ */
+YUI.add('mojito-http-addon', function(Y, NAME) {
+});
+
+/*
+ */
 YUI.add('mojito-client-store', function(Y, NAME) {
 });
 

--- a/tests/unit/lib/app/addons/ac/test-composite.common.js
+++ b/tests/unit/lib/app/addons/ac/test-composite.common.js
@@ -40,7 +40,8 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                         doneCalled = true;
                         OA.areEqual(datamock, data, "wrong data value");
                         OA.areEqual(metamock, meta, "wrong meta value");
-                    }, _notify: function() {}
+                    },
+                    _notify: function() {}
                 },
                 c = new Y.mojito.addons.ac.composite(command, adapter, ac),
                 doneCalled = false;

--- a/tests/unit/lib/app/addons/ac/test-config.common.js
+++ b/tests/unit/lib/app/addons/ac/test-config.common.js
@@ -10,7 +10,7 @@
 
 
 /*
- * Test suite for the analytics.common.js file functionality.
+ * Test suite for the config.common.js file functionality.
  */
 YUI().use('mojito-config-addon', 'test', function(Y) {
 

--- a/tests/unit/lib/app/addons/ac/test-cookie.server.js
+++ b/tests/unit/lib/app/addons/ac/test-cookie.server.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true, nomen:true, node:true*/
+/*global YUI*/
+
+
+/*
+ * Test suite for the cookie.server.js file functionality.
+ */
+YUI().use('mojito-cookie-addon', 'test', function(Y) {
+
+    var suite = new Y.Test.Suite('mojito-analytics-addon server tests'),
+        A = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+
+        'test set cookie': function() {
+            var headerAdded = false,
+                c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        addHeader: function(name, cookie) {
+                            headerAdded = true;
+                            A.areSame('Set-Cookie', name, 'bad cookie header name');
+                            A.areSame('key=val', cookie, 'wrong cookie value');
+                        },
+                        getRequest: function() {}
+                    }
+                });
+
+            c.set('key', 'val');
+
+            A.isTrue(headerAdded, 'cookie not set');
+        },
+
+        'test set cookie with options': function() {
+            var headerAdded = false,
+                c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        addHeader: function(name, cookie) {
+                            headerAdded = true;
+                            A.areSame('Set-Cookie', name, 'bad cookie header name');
+                            A.areSame('key=val; Path=path; Domain=domain', cookie, 'wrong cookie value');
+                        },
+                        getRequest: function() {}
+                    }
+                });
+
+            c.set('key', 'val', {path: 'path', domain: 'domain'});
+
+            A.isTrue(headerAdded, 'cookie not set');
+        },
+
+        'test get cookie by key': function() {
+            var c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        getRequest: function() {
+                            return {
+                                cookies: {one: 1}
+                            };
+                        }
+                    }
+                }),
+                value = c.get('one');
+
+            A.areSame(1, value, 'bad cookie value');
+        },
+
+        'test get all cookies': function() {
+            var c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        getRequest: function() {
+                            return {
+                                cookies: 'COOKIES'
+                            };
+                        }
+                    }
+                }),
+                value = c.get();
+
+            A.areSame('COOKIES', value, 'bad cookie value');
+        }
+
+    }));
+
+    Y.Test.Runner.add(suite);
+
+});

--- a/tests/unit/lib/app/addons/ac/test_descriptor.json
+++ b/tests/unit/lib/app/addons/ac/test_descriptor.json
@@ -2,6 +2,7 @@
     {
         "settings": [ "master" ],
         "name" : "ac-addon-unit-tests",
+        "commonlib": "$$config.base$$/mojito-test.js",
         "config" : {
             "lib": "../../../../../../source/lib",
             "base": "../../../../../base"
@@ -38,6 +39,13 @@
                     "test" : "./test-cookie.client.js"
                 },
                 "group" : "fw,client"
+            },
+            "cookie.server" : {
+                "params" : {
+                    "lib": "$$config.lib$$/app/addons/ac/cookie.server.js",
+                    "test" : "./test-cookie.server.js"
+                },
+                "group" : "fw,server"
             }
         }
     },

--- a/tests/unit/lib/app/autoload/test_descriptor.json
+++ b/tests/unit/lib/app/autoload/test_descriptor.json
@@ -1,38 +1,41 @@
 [
     {
         "settings": [ "master" ],
-        "name" : "mojito-unit-tests",
+        "name" : "autoload-unit-tests",
+        "commonlib": "$$config.base$$/mojito-test.js",
         "config" : {
+            "lib": "../../../../../source/lib",
+            "base": "../../../../base"
         },
         "dataprovider" : {
             "mojito-client.client" : {
                 "params" : {
-                    "page": "../../../../base/mojito-test.html",
-                    "lib": "../../../../../source/lib/app/autoload/mojito-client.client.js",
+                    "page": "$$config.base$$/mojito-test.html",
+                    "lib": "$$config.lib$$/app/autoload/mojito-client.client.js",
                     "test" : "./test-mojito-client.client.js"
                 },
                 "group" : "fw,unit,client"
             },
             "mojit-proxy.client" : {
                 "params" : {
-                    "page": "../../../../base/mojito-test.html",
-                    "lib": "../../../../../source/lib/app/autoload/mojit-proxy.client.js",
+                    "page": "$$config.base$$/mojito-test.html",
+                    "lib": "$$config.lib$$/app/autoload/mojit-proxy.client.js",
                     "test" : "./test-mojit-proxy.client.js"
                 },
                 "group" : "fw,unit,client"
             },
             "output-handler.client" : {
                 "params" : {
-                    "page": "../../../../base/mojito-test.html",
-                    "lib": "../../../../../source/lib/app/autoload/output-handler.client.js",
+                    "page": "$$config.base$$/mojito-test.html",
+                    "lib": "$$config.lib$$/app/autoload/output-handler.client.js",
                     "test" : "./test-output-handler.client.js"
                 },
                 "group" : "fw,unit,client"
             },
             "tunnel.client" : {
                 "params" : {
-                    "page": "../../../../base/mojito-test.html",
-                    "lib": "../../../../../source/lib/app/autoload/tunnel.client-optional.js",
+                    "page": "$$config.base$$/mojito-test.html",
+                    "lib": "$$config.lib$$/app/autoload/tunnel.client-optional.js",
                     "test" : "./test-tunnel.client-optional.js"
                 },
                 "group" : "fw,unit,client"


### PR DESCRIPTION
Also, cookie.server.js tests ported.

This commit will allow us to run both server and client tests (previously running server tests didn't include the mojito-test.js file, so it failed).

**Important**: This can only be pulled once arrow includes commonlib files before test lib files. I have submitted a patch so I'm hoping it can be pulled in soon. Otherwise we are blocked on getting server side tests running with arrow.
