### PR TITLE
yui-lang modules error when pkg is bundle

### DIFF
--- a/source/lib/app/addons/rs/yui.server.js
+++ b/source/lib/app/addons/rs/yui.server.js
@@ -188,7 +188,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 if (!res.yui) {
                     res.yui = {};
                 }
-                if (fs.basename === mojitType) {
+                if (fs.basename === mojitType || mojitType === 'shared') {
                     res.yui.lang = '';
                 } else if (mojitType === fs.basename.substr(0, mojitType.length)) {
                     res.yui.lang = fs.basename.substr(mojitType.length + 1);


### PR DESCRIPTION
When you define your package as a "bundle", 
the mojitType value is "shared" for the yui-lang modules, 
which makes mojito raise a invalid YUI lang error since basename !== mojitType

I just add a check so when the mojitType is shared, 
we accept as well the lang module as valid.

I think it shouldnt have any imlpications further, and al the tests pass perfectly.
