### PR TITLE
Fixed test descriptors to work on server side

### DIFF
--- a/tests/base/mojito-test.html
+++ b/tests/base/mojito-test.html
@@ -5,7 +5,6 @@
   <title>Mojito Arrow Unit Test Page</title>
   <script src="./yui-3.5.1.js"></script>
   <script src="./yui-test.js"></script>
-  <script src="./mojito-test.js"></script>
 </head>
 <body></body>
 </html>

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -42,6 +42,11 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
 
 /*
  */
+YUI.add('mojito-http-addon', function(Y, NAME) {
+});
+
+/*
+ */
 YUI.add('mojito-client-store', function(Y, NAME) {
 });
 

--- a/tests/unit/lib/app/addons/ac/test-cookie.server.js
+++ b/tests/unit/lib/app/addons/ac/test-cookie.server.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true, nomen:true, node:true*/
+/*global YUI*/
+
+
+/*
+ * Test suite for the cookie.server.js file functionality.
+ */
+YUI().use('mojito-cookie-addon', 'test', function(Y) {
+
+    var suite = new Y.Test.Suite('mojito-analytics-addon server tests'),
+        A = Y.Assert;
+
+    suite.add(new Y.Test.Case({
+
+        'test set cookie': function() {
+            var headerAdded = false,
+                c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        addHeader: function(name, cookie) {
+                            headerAdded = true;
+                            A.areSame('Set-Cookie', name, 'bad cookie header name');
+                            A.areSame('key=val', cookie, 'wrong cookie value');
+                        },
+                        getRequest: function() {}
+                    }
+                });
+
+            c.set('key', 'val');
+
+            A.isTrue(headerAdded, 'cookie not set');
+        },
+
+        'test set cookie with options': function() {
+            var headerAdded = false,
+                c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        addHeader: function(name, cookie) {
+                            headerAdded = true;
+                            A.areSame('Set-Cookie', name, 'bad cookie header name');
+                            A.areSame('key=val; Path=path; Domain=domain', cookie, 'wrong cookie value');
+                        },
+                        getRequest: function() {}
+                    }
+                });
+
+            c.set('key', 'val', {path: 'path', domain: 'domain'});
+
+            A.isTrue(headerAdded, 'cookie not set');
+        },
+
+        'test get cookie by key': function() {
+            var c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        getRequest: function() {
+                            return {
+                                cookies: {one: 1}
+                            };
+                        }
+                    }
+                }),
+                value = c.get('one');
+
+            A.areSame(1, value, 'bad cookie value');
+        },
+
+        'test get all cookies': function() {
+            var c = new Y.mojito.addons.ac.cookie(null, null, {
+                    http: {
+                        getRequest: function() {
+                            return {
+                                cookies: 'COOKIES'
+                            };
+                        }
+                    }
+                }),
+                value = c.get();
+
+            A.areSame('COOKIES', value, 'bad cookie value');
+        }
+
+    }));
+
+    Y.Test.Runner.add(suite);
+
+});

--- a/tests/unit/lib/app/addons/ac/test_descriptor.json
+++ b/tests/unit/lib/app/addons/ac/test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../source/lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.lib$$/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../source/lib/app/autoload/util.common.js",
         "dataprovider": {
             "analytics.common": {
                 "params": {
@@ -55,6 +55,13 @@
                     "page": "$$config.base$$/mojito-test.html"
                 },
                 "group": "fw,client"
+            },
+            "cookie.server": {
+                "params": {
+                    "lib": "$$config.lib$$/app/addons/ac/cookie.server.js",
+                    "test": "./test-cookie.server.js"
+                },
+                "group": "fw,server"
             },
             "url.common": {
                 "params": {

--- a/tests/unit/lib/app/addons/view-engines/test_descriptor.json
+++ b/tests/unit/lib/app/addons/view-engines/test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../source/lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.lib$$/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../source/lib/app/autoload/util.common.js",
         "dataprovider" : {
             "hb.client" : {
                 "params" : {

--- a/tests/unit/lib/app/autoload/test_descriptor.json
+++ b/tests/unit/lib/app/autoload/test_descriptor.json
@@ -6,7 +6,8 @@
             "lib": "../../../../../source/lib",
             "base": "../../../../base"
         },
-        "commonlib": "$$config.lib$$/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../source/lib/app/autoload/util.common.js",
+        "dataprovider" : {
             "mojito-client.client": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",


### PR DESCRIPTION
Now that the new Arrow has been released, the commonlibs are now included before the test libs. This allows us to specify mojito-test.js in the commonlibs so that it is loaded on both the client and server side. I removed the script tag for mojito-test.js in the mojito-test.html page since it is no longer needed.

This also includes a port of the cookie.server.js tests as well.

Note: Update Arrow to get these tests to run.
