### PR TITLE
Allow jslint configuration to be overridden by cli.json config file

### DIFF
--- a/source/lib/management/commands/jslint.js
+++ b/source/lib/management/commands/jslint.js
@@ -31,7 +31,7 @@ OPTS = (function () {
 
     // Load options from cli.json
     try {
-        options = JSON.parse(fs.readFileSync(path.join(process.env.PWD, 'cli.json'), 'utf-8')).jslint.rules;
+        options = utils.getCliConfig().jslint.rules;
     } catch (e) {
         options = {};
     }

--- a/source/lib/management/commands/jslint.js
+++ b/source/lib/management/commands/jslint.js
@@ -31,7 +31,7 @@ OPTS = (function () {
 
     // Load options from cli.json
     try {
-        options = JSON.parse(fs.readFileSync(path.join(process.env.PWD, 'cli.json'), 'utf-8')).jslint;
+        options = JSON.parse(fs.readFileSync(path.join(process.env.PWD, 'cli.json'), 'utf-8')).jslint.rules;
     } catch (e) {
         options = {};
     }

--- a/source/lib/management/utils.js
+++ b/source/lib/management/utils.js
@@ -559,6 +559,22 @@ App.prototype = {
     }
 };
 
+/**
+ * Return cli.json config object used with mojito cli for custom configurations
+ */
+function getCliConfig() {
+    var ret = null,
+        config_file = path.join(process.env.PWD, 'cli.json');
+    
+    if (fs.statSync(config_file)) {
+        try {
+            ret = JSON.parse(fs.readFileSync(config_file, 'utf-8'));
+        } catch (err) {}
+    }
+
+    return ret;
+}
+
 
 /**
  */
@@ -623,3 +639,7 @@ exports.copyUsingMatcher = copyUsingMatcher;
 /**
  */
 exports.heir = heir;
+
+/**
+ */
+exports.getCliConfig = getCliConfig;


### PR DESCRIPTION
This allows applications to override the default jslint configurations via a new config file called cli.json. This file could also be used in the future to augment other mojito commands like "test".

The {app}/cli.json will look like this:

``` json
{
    "jslint": {
        "white": true,
        "sloppy": true
    }
}
```
