### PR TITLE
add node 0.8 compatibility 

### DIFF
--- a/lib/app/addons/rs/config.server.js
+++ b/lib/app/addons/rs/config.server.js
@@ -24,6 +24,7 @@ YUI.add('addon-rs-config', function(Y, NAME) {
 
     var libfs = require('fs'),
         libpath = require('path'),
+        existsSync = libfs.existsSync || libpath.existsSync,
         // TODO:  move YCB into a node module
         libycb = require(libpath.join(__dirname, '../../../libs/ycb'));
 
@@ -72,7 +73,7 @@ YUI.add('addon-rs-config', function(Y, NAME) {
         readConfigJSON: function(fullPath) {
             var json,
                 contents;
-            if (!libpath.existsSync(fullPath)) {
+            if (!existsSync(fullPath)) {
                 return {};
             }
             json = this._jsonCache[fullPath];
@@ -209,7 +210,7 @@ YUI.add('addon-rs-config', function(Y, NAME) {
          */
         _readYcbDimensions: function() {
             var path = libpath.join(this.appRoot, 'dimensions.json');
-            if (!libpath.existsSync(path)) {
+            if (!existsSync(path)) {
                 path = libpath.join(this.mojitoRoot, 'dimensions.json');
             }
             return this.readConfigJSON(path);

--- a/lib/app/addons/rs/url.server.js
+++ b/lib/app/addons/rs/url.server.js
@@ -20,6 +20,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
 
     var libfs = require('fs'),
         libpath = require('path'),
+        existsSync = libfs.existsSync || libpath.existsSync,
         URL_PARTS = ['frameworkName', 'appName', 'prefix'];
 
     function RSAddonUrl() {
@@ -225,7 +226,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
 
             urlParts.push(relativePath);
 
-            if (rollupFsPath && (this.assumeRollups || libpath.existsSync(rollupFsPath))) {
+            if (rollupFsPath && (this.assumeRollups || existsSync(rollupFsPath))) {
                 res.url = '/' + rollupParts.join('/');
                 fs.rollupPath = rollupFsPath;
             } else {

--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -10,6 +10,7 @@
 
 var libpath = require('path'),
     libfs = require('fs'),
+    existsSync = libfs.existsSync || libpath.existsSync,
     libutils = require(libpath.join(__dirname, '../../management/utils')),
 
     // private compilation function container
@@ -572,7 +573,7 @@ compile.rollups = function(context, options, callback) {
             }
 
             if (options.remove) {
-                if (libpath.existsSync(dest)) {
+                if (existsSync(dest)) {
                     try {
                         libfs.unlinkSync(dest);
                     } catch (err) {
@@ -1104,7 +1105,7 @@ getContentFromUrl = function(app, url, opts, callback) {
 
 
 removeFile = function(file) {
-    if (libpath.existsSync(file)) {
+    if (existsSync(file)) {
         try {
             libfs.unlinkSync(file);
         } catch (err) {

--- a/lib/app/commands/gv.js
+++ b/lib/app/commands/gv.js
@@ -18,6 +18,7 @@
 var run,
     libpath = require('path'),
     libfs = require('fs'),
+    existsSync = libfs.existsSync || libpath.existsSync,
     libutils = require(libpath.join(__dirname, '../../management/utils')),
     YUI = require('yui').YUI,
     Y = YUI(),
@@ -429,10 +430,10 @@ run = function(params, options) {
     }
 
     // make results dir
-    if (!libpath.existsSync(artifactsDir)) {
+    if (!existsSync(artifactsDir)) {
         libfs.mkdirSync(artifactsDir, MODE_ALL);
     }
-    if (!libpath.existsSync(resultsDir)) {
+    if (!existsSync(resultsDir)) {
         libfs.mkdirSync(resultsDir, MODE_ALL);
     }
 

--- a/lib/app/commands/jslint.js
+++ b/lib/app/commands/jslint.js
@@ -10,6 +10,7 @@
 
 var fs = require('fs'),
     path = require('path'),
+    existsSync = fs.existsSync || path.existsSync,
     utils = require(path.join(__dirname, '../../management/utils')),
     usage = 'mojito jslint [app | mojit] [<name>] {options}\n' +
             '\nOPTIONS: \n' +
@@ -34,7 +35,7 @@ var fs = require('fs'),
 function mkdirsSync(dir, mode) {
     var modeDefault = parseInt('755', 8); // Avoid octal per JSLint
 
-    if (path.existsSync(dir)) {
+    if (existsSync(dir)) {
         return;
     }
     mode = mode || modeDefault;
@@ -271,12 +272,12 @@ function getAppDir(appName) {
     // If appName was not supplied, see if we're in an app.
     if (!appName) {
         file = path.join(cwd, 'server.js');
-        return (path.existsSync(file) ? cwd : null);
+        return (existsSync(file) ? cwd : null);
     }
 
     // Look for the app where we are.
     dir = path.join(cwd, appName);
-    if (path.existsSync(dir)) {
+    if (existsSync(dir)) {
         stat = fs.statSync(dir);
         if (stat.isDirectory()) {
             return dir;

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -10,6 +10,7 @@
 
 var pathlib = require('path'),
     fs = require('fs'),
+    existsSync = fs.existsSync || pathlib.existsSync,
 
     utils = require('../../management/utils'),
     ymc = require('../../management/yui-module-configurator'),
@@ -606,7 +607,7 @@ run = function(params, opts) {
     inputOptions = opts || {};
 
     if (inputOptions.tmpdir) {
-        if (!pathlib.existsSync(inputOptions.tmpdir)) {
+        if (!existsSync(inputOptions.tmpdir)) {
             utils.warn('The temporary directory you specified does not exist.' +
                 ' It will be created.');
             fs.mkdirSync(inputOptions.tmpdir, MODE_ALL);
@@ -617,10 +618,10 @@ run = function(params, opts) {
 
     testStart = new Date().getTime();
 
-    if (!pathlib.existsSync(artifactsDir)) {
+    if (!existsSync(artifactsDir)) {
         fs.mkdirSync(artifactsDir, MODE_ALL);
     }
-    if (pathlib.existsSync(resultsDir)) {
+    if (existsSync(resultsDir)) {
         utils.removeDir(fs.realpathSync(resultsDir));
         fs.rmdirSync(fs.realpathSync(resultsDir));
     }

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -10,8 +10,9 @@
 
 var fs = require('fs'),
     util = require('util'),
-    hb = require('yui/handlebars').Handlebars,
     path = require('path'),
+    existsSync = fs.existsSync || path.existsSync,
+    hb = require('yui/handlebars').Handlebars,
     http = require('http'),
     tty = require('tty'),
     mojito = require('../index.js'),
@@ -335,7 +336,7 @@ function copyUsingMatcher(src, dest, excludeMatcher) {
     //console.log('copying ' + src + ' to ' + dest);
     /* check if source path exists */
 
-    if (!path.existsSync(src)) {
+    if (!existsSync(src)) {
         throw new Error(src + ' does not exist');
     }
 
@@ -352,7 +353,7 @@ function copyUsingMatcher(src, dest, excludeMatcher) {
 
     /* check if destination directory exists */
 
-    if (!path.existsSync(dest)) {
+    if (!existsSync(dest)) {
         fs.mkdirSync(dest, parseInt('755', 8));
     }
 
@@ -404,7 +405,7 @@ function removeDir(src) {
         count;
 
     /* check if source path exists */
-    if (!path.existsSync(src)) {
+    if (!existsSync(src)) {
         return;
     }
 
@@ -470,7 +471,7 @@ function isMojitoApp(dir, usage, die) {
 
         if (isMojito) { return; }
         filepath = path.join(dir, file);
-        if (path.existsSync(filepath)) {
+        if (existsSync(filepath)) {
             contents = fs.readFileSync(filepath, 'utf-8');
             isMojito = requiresMojito.test(contents);
         }

--- a/lib/package-walker.server.js
+++ b/lib/package-walker.server.js
@@ -12,6 +12,7 @@
 
 var libpath = require('path'),
     libfs = require('fs'),
+    existsSync = libfs.existsSync || libpath.existsSync,
     Y = require('yui').YUI({useSync: true}).use('json-parse', 'json-stringify');
 
 Y.applyConfig({useSync: false});
@@ -90,7 +91,7 @@ BreadthFirstPackageWalker.prototype._walkPackage = function(work, cb) {
     //console.log('--------------------------------------- WALK PACKAGE');
     var packagePath, pkg;
     packagePath = libpath.join(work.dir, 'package.json');
-    if (libpath.existsSync(packagePath)) {
+    if (existsSync(packagePath)) {
         try {
             pkg = libfs.readFileSync(packagePath, 'utf-8');
             pkg = Y.JSON.parse(pkg);

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -1567,7 +1567,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 dir = this._libs.path.join(this._config.root, dir);
             }
 
-            if (!this._libs.path.existsSync(dir)) {
+            if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
             }
 
@@ -1605,7 +1605,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 dir = this._libs.path.join(this._config.root, dir);
             }
 
-            if (!this._libs.path.existsSync(dir)) {
+            if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
             }
 
@@ -1850,7 +1850,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             subdir = _subdir || '.';
             fulldir = this._libs.path.join(dir, subdir);
-            if (!this._libs.path.existsSync(fulldir)) {
+            if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(fulldir)) {
                 return;
             }
 


### PR DESCRIPTION
test for node 0.8's fs.existsSync() or older path.existsSync() and
use the appropriate one. (async form not used in mojito). 

mojito test passes on node vers 0.8.6 and 0.6.19
