### PR TITLE
honoring context.lang in the loader

### DIFF
--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -116,9 +116,10 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
             appConfigClient = store.getAppConfig(contextClient);
             clientConfig.context = contextClient;
 
-            if (appConfigClient.yui && appConfigClient.yui.config) {
-                yuiConfig = appConfigClient.yui.config;
-            }
+            appConfigClient.yui = appConfigClient.yui || {};
+            appConfigClient.yui.config = appConfigClient.yui.config || {};
+
+            yuiConfig = appConfigClient.yui.config;
             yuiConfig.lang = contextServer.lang; // same as contextClient.lang
             yuiConfig.core = yuiConfig.core || [];
             yuiConfig.core = yuiConfig.core.concat(
@@ -127,13 +128,13 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
             );
 
             // If we have a "base" for YUI use it
-            if (appConfigClient.yui && appConfigClient.yui.base) {
+            if (appConfigClient.yui.base) {
                 yuiConfig.base = appConfigClient.yui.base;
                 yuiConfig.combine = false;
             }
 
             // If we know where yui "Loader" is tell YUI
-            if (appConfigClient.yui && appConfigClient.yui.loader) {
+            if (appConfigClient.yui.loader) {
                 yuiConfig.loaderPath = appConfigClient.yui.loader;
             }
 
@@ -157,7 +158,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
 
             // Set the YUI URL to use on the client (This has to be done
             // before any other scripts are added)
-            if (appConfigClient.yui && appConfigClient.yui.url) {
+            if (appConfigClient.yui.url) {
                 yuiJsUrls.push(appConfigClient.yui.url);
                 // Since the user has given their own rollup of YUI library
                 // modules, we need some way of knowing which YUI library
@@ -192,7 +193,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
                         yuiJsUrlContains[module] = true;
                     }
                 }
-                if (appConfigClient.yui && appConfigClient.yui.extraModules) {
+                if (appConfigClient.yui.extraModules) {
                     for (i = 0; i < appConfigClient.yui.extraModules.length;
                             i += 1) {
                         yuiModules.push(appConfigClient.yui.extraModules[i]);

--- a/lib/tests/autoload/app/addons/ac/deploy-tests.server.js
+++ b/lib/tests/autoload/app/addons/ac/deploy-tests.server.js
@@ -97,6 +97,83 @@ YUI.add('mojito-deploy-addon-tests', function(Y, NAME) {
         },
 
 
+        'honor context.lang as YUI_config.lang when application.json yui.config is undefined': function() {
+
+            var realLoader = Y.mojito.Loader,
+                finalLoaderConfig;
+            Y.mojito.Loader = function (config) {
+                finalLoaderConfig = config;
+            };
+            Y.mojito.Loader.prototype = {
+                createYuiLibComboUrl: function(yuiModules, yuiFilter) {
+                    return {
+                        'css': [],
+                        'js':  []
+                    };
+                }
+            };
+
+            var realRouteMaker = Y.mojito.RouteMaker;
+            Y.mojito.RouteMaker = function() {};
+            Y.mojito.RouteMaker.prototype = {
+                getComputedRoutes: function() {
+                    return ['routes'];
+                }
+            };
+
+            addon.ac = {
+                http: {
+                    getHeader: function(h) {
+                        return null;
+                    }
+                }
+            };
+            addon.ac.context = {
+                lang: 'es'
+            };
+            addon.setStore({
+                getAppConfig: function() {
+                    return {};
+                },
+                serializeClientStore: function() {
+                    return 'clientstore';
+                },
+                store: {
+                    getAllURLs: function() { return {}; },
+                    getFrameworkConfig: function() {
+                        return { ondemandBaseYuiModules:[] };
+                    },
+                    yui: {
+                        getConfigShared: function() { return {}; }
+                    }
+                }
+            });
+
+            var counts = {};
+            var assetHandler = {
+                    addCss: function(path, location) {
+                    },
+                    addAssets: function(args) {
+                    },
+                    addAsset: function(type, location, content) {
+                    }
+                };
+            var binderMap = {};
+
+            try {
+                addon.constructMojitoClientRuntime(assetHandler, binderMap);
+            }
+            finally {
+                Y.mojito.RouteMaker = realRouteMaker;
+                Y.mojito.Loader = realLoader;
+            }
+
+            A.isObject(finalLoaderConfig, 'loader is not receiving the appConfig');
+            A.areSame('es', finalLoaderConfig.yui.config.lang, 'the context.lang is not propagated correctly');
+        },
+
+
+
         'honor yui.config.fetchCSS=false in application.json': function() {
 
             var realLoader = Y.mojito.Loader;


### PR DESCRIPTION
It should ALWAYS be as part of the loader configuration, even when application.json >> yui.config is undefined

This solves the issue reported by @focuzz on issue #261.
