### PR TITLE
Fix for handlebar renderer when ac.flush() is called more than once

### DIFF
--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -35,8 +35,9 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * @param {string} tmpl The name of the template to render.
          * @param {object} adapter The output adapter to use.
          * @param {object} meta Optional metadata.
+         * @param {boolean} more
          */
-        render: function (data, mojitType, tmpl, adapter, meta) {
+        render: function (data, mojitType, tmpl, adapter, meta, more) {
             var handler = function (err, obj) {
                 if (err) {
                     adapter.error(err);
@@ -49,8 +50,13 @@ YUI.add('mojito-hb', function(Y, NAME) {
                         tmpl + '"',
                         'mojito', 'qeperf');
                 }
-                adapter.done('', meta);
+
+                // adapter.done('', meta);
+                if (!more || false === more) {
+                    adapter.done('', meta);
+                }
             };
+
             this._getTemplateObj(tmpl, !meta.view.cacheTemplates, handler);
         },
 

--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -51,7 +51,6 @@ YUI.add('mojito-hb', function(Y, NAME) {
                         'mojito', 'qeperf');
                 }
 
-                // adapter.done('', meta);
                 if (!more || false === more) {
                     adapter.done('', meta);
                 }


### PR DESCRIPTION
PR that fixes the issue (in mojit):

ac.flush('hello ');
ac.flush('world!');
ac.done();
