### PR TITLE
Updated the statement that adds the namespace for the mojit controller.

### DIFF
--- a/docs/dev_guide/quickstart/index.rst
+++ b/docs/dev_guide/quickstart/index.rst
@@ -38,8 +38,9 @@ To make the application return a string we want, replace the code in ``mojits/my
 
 .. code-block:: javascript
 
-  YUI.add('myMojit', function(Y) {
-    Y.mojito.controller = {
+  YUI.add('myMojit', function(Y, NAME) {
+  
+    Y.namespace('mojito.controllers')[NAME] =
 
         index: function(ac) {
             ac.done('Hello, world. I have created my first Mojito app at ' + (new Date()) + '.');


### PR DESCRIPTION
The syntax has changed from  "Y.mojito.controller = {}" to the following: "Y.namespace('mojito.controllers')[NAME] ={}"
