### PR TITLE
Bug Fix: Fixes how "mojito compile inlinecss" generates its output

### DIFF
--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -30,6 +30,7 @@ var libpath = require('path'),
 
     // private class
     YuiModuleCacheWriter,
+    YuiInlineCssCacheWriter,
 
     // public exports
     usage,
@@ -1240,7 +1241,7 @@ YuiInlineCssCacheWriter = function(name, file, options) {
 /**
  * Create a clean prototype instance.
  */
-YuiInlineCssCacheWriter.prototype = utils.heir(YuiModuleCacheWriter.prototype);
+YuiInlineCssCacheWriter.prototype = libutils.heir(YuiModuleCacheWriter.prototype);
 
 
 /**
@@ -1260,8 +1261,8 @@ YuiInlineCssCacheWriter.prototype.dump = function() {
     Object.keys(namespaces).forEach(function(ns) {
         s += '    YUI.namespace("_mojito._cache.' + ns + '");\n';
         Object.keys(namespaces[ns]._c).forEach(function(key) {
-           s += '    YUI._mojito._cache.' + ns + '[\''+key+'\'] = ' +
-               Y.JSON.stringify(namespaces[ns]._c[key]) + ';\n';
+            s += '    YUI._mojito._cache.' + ns + '[\'' + key + '\'] = ' +
+                Y.JSON.stringify(namespaces[ns]._c[key]) + ';\n';
         });
     });
     s += '});\n';

--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -333,7 +333,7 @@ compile.inlinecss = function(context, options, callback) {
     inlineNext = function(store, cb) {
         var inline = inlines.shift(),
             mojitName,
-            yuiModuleCacheWriter,
+            yuiInlineCssCacheWriter,
             inliner,
             shortDest,
             i,
@@ -382,7 +382,7 @@ compile.inlinecss = function(context, options, callback) {
         total = Object.keys(inline.srcs).length;
 
         // start of the script body
-        yuiModuleCacheWriter = new YuiModuleCacheWriter(inline.yuiModuleName,
+        yuiInlineCssCacheWriter = new YuiInlineCssCacheWriter(inline.yuiModuleName,
             inline.dest, options);
 
         inliner = function(srcKey) {
@@ -429,7 +429,7 @@ compile.inlinecss = function(context, options, callback) {
                 contentString = content.replace(/\n/g, '');
 
                 // inject into the body the CSS for this inline file
-                yuiModuleCacheWriter.createNamespace(
+                yuiInlineCssCacheWriter.createNamespace(
                     'compiled.css.inline'
                 ).cache(srcKey, contentString);
 
@@ -439,7 +439,7 @@ compile.inlinecss = function(context, options, callback) {
                 count += 1;
                 if (count === total) {
                     // end of the script body
-                    if (yuiModuleCacheWriter.write()) {
+                    if (yuiInlineCssCacheWriter.write()) {
                         processed += 1;
                     }
                     inlineNext(store, cb);
@@ -1225,6 +1225,47 @@ YuiModuleCacheWriter.prototype.write = function() {
         }
     }
     return false;
+};
+
+/**
+ * Extends YuiModuleCacheWriter and adds ability to write inlinecss files as well
+ * @param {string} name YUI module name.
+ * @param {string} file output file path.
+ * @param {object} options same options given to compile command.
+ */
+YuiInlineCssCacheWriter = function(name, file, options) {
+    YuiModuleCacheWriter.call(this, name, file, options);
+};
+
+/**
+ * Create a clean prototype instance.
+ */
+YuiInlineCssCacheWriter.prototype = utils.heir(YuiModuleCacheWriter.prototype);
+
+
+/**
+ * Patch the constructor slot.
+ */
+YuiInlineCssCacheWriter.prototype.constructor = YuiInlineCssCacheWriter;
+
+
+/**
+ * return the YUI inlinecss text.
+ * @return {string} The dump string of the namespace cache.
+ */
+YuiInlineCssCacheWriter.prototype.dump = function() {
+    var s = 'YUI.add("' + this.moduleName + '", function(Y, NAME) {\n',
+        namespaces = this.namespaces;
+
+    Object.keys(namespaces).forEach(function(ns) {
+        s += '    YUI.namespace("_mojito._cache.' + ns + '");\n';
+        Object.keys(namespaces[ns]._c).forEach(function(key) {
+           s += '    YUI._mojito._cache.' + ns + '[\''+key+'\'] = ' +
+               Y.JSON.stringify(namespaces[ns]._c[key]) + ';\n';
+        });
+    });
+    s += '});\n';
+    return s;
 };
 
 


### PR DESCRIPTION
Bug Fix: Fixes how "mojito compile inlinecss" generates its output, so that each instance doesn't clobber the namespace of _mojito._cache.compiled.css.inline
