### PR TITLE
Commented out executable code in bind method of binder archetype

### DIFF
--- a/lib/app/archetypes/mojit/default/binders/index.js.hb
+++ b/lib/app/archetypes/mojit/default/binders/index.js.hb
@@ -35,14 +35,21 @@ YUI.add('{{name}}BinderIndex', function(Y, NAME) {
         bind: function(node) {
             var me = this;
             this.node = node;
-            node.all('dt').on('mouseenter', function(evt) {
-                var dd = '#dd_' + evt.target.get('text');
-                me.node.one(dd).addClass('sel');
-            });
-            node.all('dt').on('mouseleave', function(evt) {
-                var dd = '#dd_' + evt.target.get('text');
-                me.node.one(dd).removeClass('sel');
-            });
+            /**
+             * Example code for the bind method:
+             *
+             * node.all('dt').on('mouseenter', function(evt) {
+             *   var dd = '#dd_' + evt.target.get('text');
+             *   me.node.one(dd).addClass('sel');
+             *
+             * });
+             * node.all('dt').on('mouseleave', function(evt) {
+             *   
+             *   var dd = '#dd_' + evt.target.get('text');
+             *   me.node.one(dd).removeClass('sel');
+             *
+             * });
+             */
         }
 
     };


### PR DESCRIPTION
Users were complaining that code is generated in the binder that is not used in the example code examples and tutorials, so I've commented out the code, which still allows users to see the example code.
