### PR TITLE
Fixed Issue #429: Added params to body for PUT requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ node_modules
 arrowreport
 artifacts
 flatfile
-test_descriptor-report.json
-test_descriptor-report.xml
+*_descriptor-report.json
+*_descriptor-report.xml

--- a/.npmignore
+++ b/.npmignore
@@ -10,5 +10,5 @@ artifacts
 examples
 flatfile
 Makefile
-test_descriptor-report.json
-test_descriptor-report.xml
+*_descriptor-report.json
+*_descriptor-report.xml

--- a/lib/app/autoload/rest.common.js
+++ b/lib/app/autoload/rest.common.js
@@ -53,9 +53,29 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
     Y.namespace('mojito.lib').REST = {
 
         /**
+         * Calls IO. Provides mockability
+         * @param url
+         * @param config the IO configuration
+         * @param callback
          * @private
          */
-        _doRequest: function(method, url, params, config, callback) {
+        _doRequest: function (url, config) {
+            Y.io(url, config);
+        },
+
+        /**
+         * Creates the configuration to be passed to the IO request
+         *
+         * @param {String} method HTTP method
+         * @param {String} url HTTP location
+         * @param {Object} params Params that are passed in the request
+         * @param {Object} config Additional configuration
+         * @param {Object} config.headers Headers to be sent with the request
+         * @param {Number} config.timeout Timeout for the IO request
+         * @param {Function} callback The handler for the response
+         * @private
+         */
+        _makeRequest: function(method, url, params, config, callback) {
             // TODO: [Issue 72] Figure out why 'params' values are attaching
             // themselves to headers!
             var ioConfig = {
@@ -72,7 +92,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
                     } else {
                         url += '&' + params;
                     }
-                } else if ('POST' === method) {
+                } else if ('POST' === method || 'PUT' === method) {
                     ioConfig.data = params;
                 }
             }
@@ -89,8 +109,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
                     callback(resp);
                 };
             }
-
-            Y.io(url, ioConfig);
+            this._doRequest(url, ioConfig);
         },
 
 
@@ -104,7 +123,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
          */
         GET: function() {
             var args = ['GET'].concat(Array.prototype.slice.call(arguments));
-            this._doRequest.apply(this, args);
+            this._makeRequest.apply(this, args);
         },
 
 
@@ -118,7 +137,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
          */
         POST: function() {
             var args = ['POST'].concat(Array.prototype.slice.call(arguments));
-            this._doRequest.apply(this, args);
+            this._makeRequest.apply(this, args);
         },
 
 
@@ -132,7 +151,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
          */
         PUT: function() {
             var args = ['PUT'].concat(Array.prototype.slice.call(arguments));
-            this._doRequest.apply(this, args);
+            this._makeRequest.apply(this, args);
         },
 
 
@@ -146,7 +165,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
          */
         DELETE: function() {
             var args = ['DELETE'].concat(Array.prototype.slice.call(arguments));
-            this._doRequest.apply(this, args);
+            this._makeRequest.apply(this, args);
         },
 
 
@@ -160,7 +179,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
          */
         HEAD: function() {
             var args = ['HEAD'].concat(Array.prototype.slice.call(arguments));
-            this._doRequest.apply(this, args);
+            this._makeRequest.apply(this, args);
         }
     };
 

--- a/lib/app/autoload/rest.common.js
+++ b/lib/app/autoload/rest.common.js
@@ -54,6 +54,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
 
         /**
          * Calls IO. Provides mockability
+         * @method _doRequest
          * @param url
          * @param config the IO configuration
          * @param callback
@@ -65,7 +66,7 @@ YUI.add('mojito-rest-lib', function(Y, NAME) {
 
         /**
          * Creates the configuration to be passed to the IO request
-         *
+         * @method _makeRequest
          * @param {String} method HTTP method
          * @param {String} url HTTP location
          * @param {Object} params Params that are passed in the request

--- a/lib/tests/autoload/app/autoload/rest-tests.common.js
+++ b/lib/tests/autoload/app/autoload/rest-tests.common.js
@@ -13,22 +13,28 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
 
         name: 'deferring methods',
 
-        'GET call defers to main call function': function() {
+        'test GET call defers to main call function': function() {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('GET', method, 'wrong method');
-                A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('GET', config.method, 'wrong method');
+                A.areSame('url?params', url, 'wrong url');
+                A.areSame('header1', config.headers.header1, 'wrong header');
+                A.areSame(10000, config.timeout, 'wrong timeout');
+                A.isFunction(config.on.success, 'callback is not a function');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.GET('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.GET('url', 'params', {
+                headers: {
+                    'header1': 'header1'
+                },
+                timeout: 10000
+
+            }, 'callback');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -37,22 +43,20 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
             Y.mojito.lib.REST._doRequest = doRequest;
         },
 
-        'POST call defers to main call function': function() {
+        'test POST call defers to main call function': function() {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('POST', method, 'wrong method');
+                A.areSame('POST', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('params', config.data, 'data not added to body');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.POST('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.POST('url', 'params');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -61,22 +65,20 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
             Y.mojito.lib.REST._doRequest = doRequest;
         },
 
-        'PUT call defers to main call function': function() {
+        'test PUT call defers to main call function': function() {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('PUT', method, 'wrong method');
+                A.areSame('PUT', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('params', config.data, 'data not added to body');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.PUT('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.PUT('url', 'params');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -85,17 +87,14 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
             Y.mojito.lib.REST._doRequest = doRequest;
         },
 
-        'DELETE call defers to main call function': function() {
+        'test DELETE call defers to main call function': function() {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('DELETE', method, 'wrong method');
+                A.areSame('DELETE', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
                 doRequestCalled = true;
             };
 
@@ -109,17 +108,14 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
             Y.mojito.lib.REST._doRequest = doRequest;
         },
 
-        'HEAD call defers to main call function': function() {
+        'test HEAD call defers to main call function': function() {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('HEAD', method, 'wrong method');
+                A.areSame('HEAD', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
                 doRequestCalled = true;
             };
 
@@ -137,123 +133,30 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
 
     suite.add(new YUITest.TestCase({
 
-        name: 'y.io',
-
-        'doRequest defers to Y.io with proper method': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url, opts) {
-                A.isObject(opts, 'io was not sent an options object');
-                A.areSame('method', opts.method, 'bad http method to y.io');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('method');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'doRequest defers to Y.io with proper url': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url) {
-                A.areSame('url', url, 'bad url to y.io');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('', 'url');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'doRequest defers to Y.io with proper params data': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url, opts) {
-                A.areSame('/x/?params', url, 'params added to URL');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('GET', '/x/', 'params');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'doRequest defers to Y.io with proper config data': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            var headers = {headers:'yo'};
-            Y.io = function(url, opts) {
-                A.areSame(47, opts.timeout, 'bad timeout to y.io');
-                OA.areEqual(headers, opts.headers);
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('', '', '', {
-                timeout: 47,
-                headers: headers,
-                proxy: 'proxy'
-            });
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        }
-
-    }));
-
-    suite.add(new YUITest.TestCase({
-
         name: 'callback',
 
-        'callback is called without err on Y.io success': function() {
+        'test callback is called without err on Y.io success': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
-            Y.io = function(url, opts) {
-                opts.on.success();
+
+            Y.mojito.lib.REST._doRequest = function (url, config) {
+                config.on.success();
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err) {
                 A.isNull(err, 'err object within callback should be null on success');
                 cbCalled = true;
             });
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         },
 
-        'callback is called with proper response object on Y.io success': function() {
+        'test callback is called with proper response object on Y.io success': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
-            Y.io = function(url, opts) {
+            Y.mojito.lib.REST._doRequest = function(url, opts) {
                 opts.on.success(1234, {
                     status: 200,
                     statusText: 'Success',
@@ -272,7 +175,7 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err, resp) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err, resp) {
                 A.isFunction(resp.getStatusCode, 'response missing getStatusCode function');
                 A.isFunction(resp.getStatusMessage, 'response missing getStatusMessage function');
                 A.isFunction(resp.getHeader, 'response missing getHeader function');
@@ -288,22 +191,18 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         },
 
-        'callback is called with err on Y.io failure with proper error status and message': function() {
+        'test callback is called with err on Y.io failure with proper error status and message': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
             var error = {status:503, statusText:'Wicked Error'};
-            Y.io = function(url, opts) {
+            Y.mojito.lib.REST._doRequest = function(url, opts) {
                 opts.on.failure(1234 /* tx id */, error);
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err, data) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err, data) {
                 A.isObject(err, 'err object was not populated');
                 OA.areEqual(error, err, 'wrong error object');
                 cbCalled = true;
@@ -311,9 +210,6 @@ YUI.add('mojito-rest-lib-tests', function(Y, NAME) {
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         }
 
     }));

--- a/tests/func/applications/frameworkapp/serveronly/mojits/RESTLib/controller.common.js
+++ b/tests/func/applications/frameworkapp/serveronly/mojits/RESTLib/controller.common.js
@@ -314,12 +314,11 @@ YUI.add('RESTLib', function(Y) {
 	        },
 
 	        printPUTParams: function(actionContext){
-	            var project = actionContext.params.getFromUrl("project");
-	            var sprint = actionContext.params.getFromUrl("sprint");
+	            var project = actionContext.params.getFromBody("project");
+	            var sprint = actionContext.params.getFromBody("sprint");
 	            var method = actionContext.http.getRequest().method;
 
-	            //var output = "<p id=\"output\">(METHOD: " + method + ") This is sprint " + sprint + " for the project " + project + "</p>";
-	            var output = "<p id=\"output\">(METHOD: " + method + ")</p>";
+	            var output = "<p id=\"output\">(METHOD: " + method + ") This is sprint " + sprint + " for the project " + project + "</p>";
 	            actionContext.http.setHeader('content-type', 'text/html');
 	            actionContext.done(output);
 	        },

--- a/tests/func/serveronly/testrestlib-PUTWithParamsClient.js
+++ b/tests/func/serveronly/testrestlib-PUTWithParamsClient.js
@@ -15,7 +15,7 @@ YUI({
 	        var that = this;
 	        Y.one('#p_putParam').simulate('click');
             that.wait(function(){
-	            Y.Assert.areEqual('(METHOD: PUT)', Y.one('#output').get('innerHTML'));
+                Y.Assert.areEqual('(METHOD: PUT) This is sprint 4 for the project Mojito', Y.one('#output').get('innerHTML'));
             }, 2000);
        }
        

--- a/tests/func/serveronly/testrestlib-PUTWithParamsServer.js
+++ b/tests/func/serveronly/testrestlib-PUTWithParamsServer.js
@@ -12,7 +12,7 @@ YUI({
      suite.add(new Y.Test.Case({
 	    "test PUTWithParamsServer": function(){
             Y.Assert.areEqual('200', Y.one('#status').get('innerHTML'));
-            Y.Assert.areEqual('(METHOD: PUT)', Y.one('#output').get('innerHTML'));
+            Y.Assert.areEqual('(METHOD: PUT) This is sprint 4 for the project Mojito', Y.one('#output').get('innerHTML'));
         }
      }));
 

--- a/tests/run.js
+++ b/tests/run.js
@@ -158,12 +158,11 @@ function deploy (cmd, callback) {
 
 function startArrowSelenium (callback) {
     console.log("---Starting Arrow Selenium---");
-    var p = runCommand(cwd+"/func/applications/frameworkapp/common", "arrow_selenium", ["--open=firefox"]);
-    setTimeout(function () {
+    var p = runCommand(cwd+"/func/applications/frameworkapp/common", "arrow_selenium", ["--open=firefox"], function () {
         pids.push(p.pid);
         pidNames[p.pid] = 'arrow_selenium';
         callback(null);
-    }, 10000);
+    });
 }
 
 function runFuncTests (callback) {

--- a/tests/unit/lib/app/autoload/test-rest.common.js
+++ b/tests/unit/lib/app/autoload/test-rest.common.js
@@ -17,18 +17,24 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('GET', method, 'wrong method');
-                A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('GET', config.method, 'wrong method');
+                A.areSame('url?params', url, 'wrong url');
+                A.areSame('header1', config.headers.header1, 'wrong header');
+                A.areSame(10000, config.timeout, 'wrong timeout');
+                A.isFunction(config.on.success, 'callback is not a function');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.GET('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.GET('url', 'params', {
+                headers: {
+                    'header1': 'header1'
+                },
+                timeout: 10000
+
+            }, 'callback');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -41,18 +47,16 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('POST', method, 'wrong method');
+                A.areSame('POST', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('params', config.data, 'data not added to body');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.POST('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.POST('url', 'params');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -65,18 +69,16 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('PUT', method, 'wrong method');
+                A.areSame('PUT', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
+                A.areSame('params', config.data, 'data not added to body');
                 doRequestCalled = true;
             };
 
             // act
-            Y.mojito.lib.REST.PUT('url', 'params', 'config', 'callback');
+            Y.mojito.lib.REST.PUT('url', 'params');
 
             // assert
             A.isTrue(doRequestCalled, 'doRequest never called');
@@ -89,13 +91,10 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('DELETE', method, 'wrong method');
+                A.areSame('DELETE', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
                 doRequestCalled = true;
             };
 
@@ -113,13 +112,10 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             // arrange and mock
             var doRequest = Y.mojito.lib.REST._doRequest;
             var doRequestCalled = false;
-            Y.mojito.lib.REST._doRequest = function(method, url, params, config, callback) {
+            Y.mojito.lib.REST._doRequest = function(url, config) {
                 // assert
-                A.areSame('HEAD', method, 'wrong method');
+                A.areSame('HEAD', config.method, 'wrong method');
                 A.areSame('url', url, 'wrong url');
-                A.areSame('params', params, 'wrong params');
-                A.areSame('config', config, 'wrong config');
-                A.areSame('callback', callback, 'wrong callback');
                 doRequestCalled = true;
             };
 
@@ -137,123 +133,30 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
 
     suite.add(new Y.Test.Case({
 
-        name: 'y.io',
-
-        'test doRequest defers to Y.io with proper method': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url, opts) {
-                A.isObject(opts, 'io was not sent an options object');
-                A.areSame('method', opts.method, 'bad http method to y.io');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('method');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'test doRequest defers to Y.io with proper url': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url) {
-                A.areSame('url', url, 'bad url to y.io');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('', 'url');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'test doRequest defers to Y.io with proper params data': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            Y.io = function(url, opts) {
-                A.areSame('/x/?params', url, 'params added to URL');
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('GET', '/x/', 'params');
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        },
-
-        'test doRequest defers to Y.io with proper config data': function() {
-            // arrange
-            var io = Y.io;
-            var ioCalled = false;
-            var headers = {headers:'yo'};
-            Y.io = function(url, opts) {
-                A.areSame(47, opts.timeout, 'bad timeout to y.io');
-                OA.areEqual(headers, opts.headers);
-                ioCalled = true;
-            };
-
-            // act
-            Y.mojito.lib.REST._doRequest('', '', '', {
-                timeout: 47,
-                headers: headers,
-                proxy: 'proxy'
-            });
-
-            // assert
-            A.isTrue(ioCalled, 'io never called');
-
-            // replace mocks
-            Y.io = io;
-        }
-
-    }));
-
-    suite.add(new Y.Test.Case({
-
         name: 'callback',
 
         'test callback is called without err on Y.io success': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
-            Y.io = function(url, opts) {
-                opts.on.success();
+
+            Y.mojito.lib.REST._doRequest = function (url, config) {
+                config.on.success();
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err) {
                 A.isNull(err, 'err object within callback should be null on success');
                 cbCalled = true;
             });
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         },
 
         'test callback is called with proper response object on Y.io success': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
-            Y.io = function(url, opts) {
+            Y.mojito.lib.REST._doRequest = function(url, opts) {
                 opts.on.success(1234, {
                     status: 200,
                     statusText: 'Success',
@@ -272,7 +175,7 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err, resp) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err, resp) {
                 A.isFunction(resp.getStatusCode, 'response missing getStatusCode function');
                 A.isFunction(resp.getStatusMessage, 'response missing getStatusMessage function');
                 A.isFunction(resp.getHeader, 'response missing getHeader function');
@@ -288,22 +191,18 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         },
 
         'test callback is called with err on Y.io failure with proper error status and message': function() {
             // arrange
-            var io = Y.io;
             var cbCalled = false;
             var error = {status:503, statusText:'Wicked Error'};
-            Y.io = function(url, opts) {
+            Y.mojito.lib.REST._doRequest = function(url, opts) {
                 opts.on.failure(1234 /* tx id */, error);
             };
 
             // act
-            Y.mojito.lib.REST._doRequest('', '', '', '', function(err, data) {
+            Y.mojito.lib.REST._makeRequest('', '', '', '', function(err, data) {
                 A.isObject(err, 'err object was not populated');
                 OA.areEqual(error, err, 'wrong error object');
                 cbCalled = true;
@@ -311,9 +210,6 @@ YUI().use('mojito-rest-lib', 'test', function(Y) {
 
             // assert
             A.isTrue(cbCalled, 'success callback never called');
-
-            // replace mocks
-            Y.io = io;
         }
 
     }));


### PR DESCRIPTION
We should probably look at what's going on with other request methods too, but if we're going to upgrade YUI in the next couple of weeks, these fixes would be rolled back anyway. For now, just fixing up the PUT.

Fully abstracted out the Y.io call to make for better mockability. Fixed up the functional and unit tests as well.
