### PR TITLE
Remove call to flush for client side hb to prevent multiple done calls

### DIFF
--- a/lib/app/addons/view-engines/hb.client.js
+++ b/lib/app/addons/view-engines/hb.client.js
@@ -31,22 +31,27 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * @param {string} tmpl The name of the template to render.
          * @param {object} adapter The output adapter to use.
          * @param {object} meta Optional metadata.
+         * @param {boolean} more Whether there is more to be rendered
          */
-        render: function (data, mojitType, tmpl, adapter, meta) {
+        render: function (data, mojitType, tmpl, adapter, meta, more) {
             var cacheTemplates = meta && meta.view && meta.view.cacheTemplates,
                 handler = function (err, obj) {
+                    var output;
+
                     if (err) {
                         adapter.error(err);
                         return;
                     }
 
-                    if (obj) {
-                        adapter.done(obj.compiled(data), meta);
-                        Y.log('render complete for view "' +
-                            tmpl + '"',
-                            'mojito', 'qeperf');
+                    output = obj.compiled(data);
+                    Y.log('render complete for view "' +
+                        tmpl + '"',
+                        'mojito', 'qeperf');
+
+                    if (more) {
+                        adapter.flush(output, meta);
                     } else {
-                        adapter.done('', meta);
+                        adapter.done(output, meta);
                     }
                 };
 

--- a/lib/app/addons/view-engines/hb.client.js
+++ b/lib/app/addons/view-engines/hb.client.js
@@ -33,22 +33,24 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * @param {object} meta Optional metadata.
          */
         render: function (data, mojitType, tmpl, adapter, meta) {
-            var handler = function (err, obj) {
-                if (err) {
-                    adapter.error(err);
-                    return;
-                }
+            var cacheTemplates = meta && meta.view && meta.view.cacheTemplates,
+                handler = function (err, obj) {
+                    if (err) {
+                        adapter.error(err);
+                        return;
+                    }
 
-                if (obj) {
-                    adapter.flush(obj.compiled(data), meta);
-                    Y.log('render complete for view "' +
-                        tmpl + '"',
-                        'mojito', 'qeperf');
-                }
-                adapter.done('', meta);
-            };
+                    if (obj) {
+                        adapter.done(obj.compiled(data), meta);
+                        Y.log('render complete for view "' +
+                            tmpl + '"',
+                            'mojito', 'qeperf');
+                    } else {
+                        adapter.done('', meta);
+                    }
+                };
 
-            this._getTemplateObj(tmpl, !meta.view.cacheTemplates, handler);
+            this._getTemplateObj(tmpl, !cacheTemplates, handler);
         },
 
         /**
@@ -63,6 +65,7 @@ YUI.add('mojito-hb', function(Y, NAME) {
         _getTemplateObj: function (tmpl, bypassCache, callback) {
             if (cache[tmpl] && !bypassCache) {
                 callback(null, cache[tmpl]);
+                return;
             }
 
             this._loadTemplate(tmpl, function (err, str) {

--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -35,25 +35,27 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * @param {string} tmpl The name of the template to render.
          * @param {object} adapter The output adapter to use.
          * @param {object} meta Optional metadata.
-         * @param {boolean} more
+         * @param {boolean} more Whether there is more to be rendered
          */
         render: function (data, mojitType, tmpl, adapter, meta, more) {
             var cacheTemplates = meta && meta.view && meta.view.cacheTemplates,
                 handler = function (err, obj) {
+                    var output;
+
                     if (err) {
                         adapter.error(err);
                         return;
                     }
 
-                    if (obj) {
-                        adapter.flush(obj.compiled(data), meta);
-                        Y.log('render complete for view "' +
-                            tmpl + '"',
-                            'mojito', 'qeperf');
-                    }
+                    output = obj.compiled(data);
+                    Y.log('render complete for view "' +
+                        tmpl + '"',
+                        'mojito', 'qeperf');
 
-                    if (!more || false === more) {
-                        adapter.done('', meta);
+                    if (more) {
+                        adapter.flush(output, meta);
+                    } else {
+                        adapter.done(output, meta);
                     }
                 };
 

--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -38,25 +38,26 @@ YUI.add('mojito-hb', function(Y, NAME) {
          * @param {boolean} more
          */
         render: function (data, mojitType, tmpl, adapter, meta, more) {
-            var handler = function (err, obj) {
-                if (err) {
-                    adapter.error(err);
-                    return;
-                }
+            var cacheTemplates = meta && meta.view && meta.view.cacheTemplates,
+                handler = function (err, obj) {
+                    if (err) {
+                        adapter.error(err);
+                        return;
+                    }
 
-                if (obj) {
-                    adapter.flush(obj.compiled(data), meta);
-                    Y.log('render complete for view "' +
-                        tmpl + '"',
-                        'mojito', 'qeperf');
-                }
+                    if (obj) {
+                        adapter.flush(obj.compiled(data), meta);
+                        Y.log('render complete for view "' +
+                            tmpl + '"',
+                            'mojito', 'qeperf');
+                    }
 
-                if (!more || false === more) {
-                    adapter.done('', meta);
-                }
-            };
+                    if (!more || false === more) {
+                        adapter.done('', meta);
+                    }
+                };
 
-            this._getTemplateObj(tmpl, !meta.view.cacheTemplates, handler);
+            this._getTemplateObj(tmpl, !cacheTemplates, handler);
         },
 
         /**

--- a/tests/unit/lib/app/addons/view-engines/test-hb.client.js
+++ b/tests/unit/lib/app/addons/view-engines/test-hb.client.js
@@ -44,15 +44,11 @@ YUI({useBrowserConsole: true}).use(
                         view: {}
                     };
                 Y.Mock.expect(adapter, {
-                    method: 'flush',
+                    method: 'done',
                     args: [Y.Mock.Value.String, meta],
                     run: function (output, metaResult) {
                         Y.Assert.areEqual('<div>test</div>', output);
                     }
-                });
-                Y.Mock.expect(adapter, {
-                    method: 'done',
-                    args: ['', meta]
                 });
                 this.viewEngine.render(data, 'test', 'oldObjNotation.hb.html', adapter, meta);
             },
@@ -68,15 +64,11 @@ YUI({useBrowserConsole: true}).use(
                         view: {}
                     };
                 Y.Mock.expect(adapter, {
-                    method: 'flush',
+                    method: 'done',
                     args: [Y.Mock.Value.String, meta],
                     run: function (output, metaResult) {
                         Y.Assert.areEqual('<div>test</div>', output);
                     }
-                });
-                Y.Mock.expect(adapter, {
-                    method: 'done',
-                    args: ['', meta]
                 });
                 this.viewEngine.render(data, 'test', 'dotNotation.hb.html', adapter, meta);
             }


### PR DESCRIPTION
During some testing I discovered an issue with the client side HB view engine that made the output handler call `done` twice (this is arguably an issue with the client side output handler, but that's an issue for another day).

I also cleaned up the cacheTemplates configuration which could have thrown a "Cannot read property of undefined" error.
