### PR TITLE
Issue #264: Fixes for windows paths

### DIFF
--- a/examples/newsboxes/mojits/Read/definition.json
+++ b/examples/newsboxes/mojits/Read/definition.json
@@ -1,1 +1,50 @@
-../Shelf/definition.json
+[{
+    "settings": [ "master" ],
+
+    "feeds": {
+        "bbcnews": {
+            "name": "BBC World News",
+            "url": "http://feeds.bbci.co.uk/news/world/rss.xml"
+        },
+        "yahoonews": {
+            "name": "Yahoo! Internet News",
+            "url": "http://rss.news.yahoo.com/rss/internet"
+        },
+        "techcrunch": {
+            "name": "TechCrunch",
+            "url": "http://feeds.feedburner.com/TechCrunch"
+        },
+        "yahoopersonaltech": {
+            "name": "Yahoo! Sports MLB",
+            "url": "http://sports.yahoo.com/mlb/rss.xml"
+        },
+        "allthingsd": {
+            "name": "AllThingsD",
+            "url": "http://allthingsd.com/feed/"
+        },
+        "yahoostocks": {
+            "name": "Yahoo! Stock Markets News",
+            "url": "http://rss.news.yahoo.com/rss/stocks"
+        },
+        "bbcbusiness": {
+            "name": "BBC Business News",
+            "url": "http://feeds.bbci.co.uk/news/business/rss.xml"
+        },
+        "yahooomg": {
+            "name": "Yahoo! OMG",
+            "url": "http://rss.omg.yahoo.com/-/news/latest"
+        },
+        "yui": {
+            "name": "YUI Blog",
+            "url": "http://feeds.yuiblog.com/YahooUserInterfaceBlog"
+        },
+        "yql": {
+            "name": "YQL Blog",
+            "url": "http://yqlblog.net/blog/feed/"
+        },
+        "ysearch": {
+            "name": "Yahoo Search Blog",
+            "url": "http://www.ysearchblog.com/feed/"
+        }
+    }
+}]

--- a/lib/app/addons/rs/url.server.js
+++ b/lib/app/addons/rs/url.server.js
@@ -176,6 +176,11 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 rollupParts = [],
                 rollupFsPath;
 
+            // Fix windows paths
+            if ('win32' === process.platform) {
+                relativePath = relativePath.replace(/\\/g, '/');
+            }
+
             // Don't clobber a URL calculated by another RS addon.
             if (res.hasOwnProperty('url')) {
                 return;
@@ -202,7 +207,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                         rollupParts.push(this.config.appName);
                     }
                     rollupParts.push('rollup.client.js');
-                    rollupFsPath = libpath.join(this.appRoot, 'rollup.client.js');
+                    rollupFsPath = [this.appRoot, 'rollup.client.js'].join('/');
                 }
             } else {
                 if ('mojit' === res.type) {
@@ -213,7 +218,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 if (res.yui && res.yui.name) {
                     rollupParts.push(res.mojit);
                     rollupParts.push('rollup.client.js');
-                    rollupFsPath = libpath.join(mojitRes.source.fs.fullPath, 'rollup.client.js');
+                    rollupFsPath = [mojitRes.source.fs.fullPath, 'rollup.client.js'].join('/');
                 }
             }
 

--- a/lib/app/addons/rs/url.server.js
+++ b/lib/app/addons/rs/url.server.js
@@ -176,7 +176,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 rollupParts = [],
                 rollupFsPath;
 
-            // Fix windows paths
+            // Translate from filesystem path to URL
             if ('win32' === process.platform) {
                 relativePath = relativePath.replace(/\\/g, '/');
             }
@@ -207,7 +207,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                         rollupParts.push(this.config.appName);
                     }
                     rollupParts.push('rollup.client.js');
-                    rollupFsPath = [this.appRoot, 'rollup.client.js'].join('/');
+                    rollupFsPath = libpath.join(this.appRoot, 'rollup.client.js');
                 }
             } else {
                 if ('mojit' === res.type) {
@@ -218,7 +218,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 if (res.yui && res.yui.name) {
                     rollupParts.push(res.mojit);
                     rollupParts.push('rollup.client.js');
-                    rollupFsPath = [mojitRes.source.fs.fullPath, 'rollup.client.js'].join('/');
+                    rollupFsPath = libpath.join(mojitRes.source.fs.fullPath, 'rollup.client.js');
                 }
             }
 

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -174,16 +174,16 @@ function process_directory(archetype_path, dir, mojit_dir, template, force) {
 
     files = fs.readdirSync(path.join(archetype_path, dir));
     files.forEach(function(f) {
-        var s = fs.statSync(path.join(archetype_path, '/', dir, '/', f));
+        var s = fs.statSync(path.join(archetype_path, dir, f));
 
         if (f.charAt(0) === '.') {
             return;
         }
         if (s.isDirectory()) {
-            process_directory(path.join(archetype_path, '/', dir), f,
-                path.join(mojit_dir, '/', dir), template, force);
+            process_directory(path.join(archetype_path, dir), f,
+                path.join(mojit_dir, dir), template, force);
         } else {
-            process_file(path.join(archetype_path, '/', dir), f,
+            process_file(path.join(archetype_path, dir), f,
                 new_dir, template);
         }
     });

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -107,7 +107,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
     libs.semver = require('semver');
     libs.walker = require('./package-walker.server');
 
-
     // The Affinity object is to manage the use of the affinity string in
     // filenames.  Some files have affinities that have multiple parts
     // (e.g. "server-tests").
@@ -169,6 +168,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     this._libs[i] = libs[i];
                 }
             }
+            // Backport of node 0.8+ property
+            this._libs.path.sep = this._libs.path.sep || ('win32' === process.platform ? '\\' : '/');
 
             this._appRVs    = [];   // array of resource versions
             this._mojitRVs  = {};   // mojitType: array of resource versions
@@ -991,6 +992,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             if (!fs.isFile && fs.subDirArray.length < 2 && 'addons' === fs.subDirArray[0]) {
                 return true;
             }
+
             if (fs.isFile && fs.subDirArray.length >= 1 && 'addons' === fs.subDirArray[0]) {
                 if ('.js' !== fs.ext) {
                     return false;
@@ -1119,7 +1121,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(this._libs.path.sep), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 // special case
                 if ('addon' === type && ADDON_SUBTYPES_APPLEVEL[res.subtype]) {
@@ -1145,7 +1147,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(this._libs.path.sep), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return res;
             }
@@ -1189,7 +1191,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid view filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(this._libs.path.sep), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return res;
             }
@@ -1563,9 +1565,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 childName,
                 childPath;
 
-            if ('/' !== dir.charAt(0)) {
-                dir = this._libs.path.join(this._config.root, dir);
-            }
+            dir = this._libs.path.resolve(this._config.root, dir);
 
             if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
@@ -1601,9 +1601,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 r,
                 res;
 
-            if ('/' !== dir.charAt(0)) {
-                dir = this._libs.path.join(this._config.root, dir);
-            }
+
+            dir = this._libs.path.resolve(this._config.root, dir);
 
             if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
@@ -1766,7 +1765,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                         rootDir: dir,
                         rootType: dirType,
                         subDir: subdir,
-                        subDirArray: subdir.split('/'),
+                        subDirArray: subdir.split(me._libs.path.sep),
                         isFile: isFile,
                         ext: me._libs.path.extname(file)
                     },
@@ -1782,7 +1781,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if ('object' === typeof ret) {
                     if (ret.skipSubdirParts) {
                         source.fs.subDirArray = source.fs.subDirArray.slice(ret.skipSubdirParts);
-                        source.fs.subDir = source.fs.subDirArray.join('/') || '.';
+                        source.fs.subDir = source.fs.subDirArray.join(me._libs.path.sep) || '.';
                     }
                     res = me.parseResourceVersion(source, ret.type, ret.subtype, mojitType);
                     if ('object' === typeof res) {
@@ -1899,6 +1898,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if ('/' !== glob.charAt(0)) {
                     glob = this._libs.path.join(prefix, glob);
                 }
+                glob = glob.replace(/\\/g, '/'); // Glob only supports forward slashes
                 found = found.concat(this._libs.glob.sync(glob, {}));
             }
             return found;

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -107,6 +107,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
     libs.semver = require('semver');
     libs.walker = require('./package-walker.server');
 
+
     // The Affinity object is to manage the use of the affinity string in
     // filenames.  Some files have affinities that have multiple parts
     // (e.g. "server-tests").
@@ -992,7 +993,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             if (!fs.isFile && fs.subDirArray.length < 2 && 'addons' === fs.subDirArray[0]) {
                 return true;
             }
-
             if (fs.isFile && fs.subDirArray.length >= 1 && 'addons' === fs.subDirArray[0]) {
                 if ('.js' !== fs.ext) {
                     return false;


### PR DESCRIPTION
This PR gets mojito up and running on Windows (tested on Windows 7 with Node 0.8.6). I tested against the "newsboxes" example app and all seems to be working.

Known issues:
- Unit tests need to be fixed so that they pass on a Windows box, although they still pass on our dev and build boxes
- `mojito jslint`'s exclusion matcher uses regular expressions that contain "/". It may be better to use glob to get a list of exclusions instead.
- Other command line tools haven't been tested

I'm sure there's more, but this should at least get the ball rolling for anyone out there that is interested in Windows support.
