### PR TITLE
Fixed a browser incompatibilty with xml output

### DIFF
--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -298,7 +298,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         // A dirty XML function I found on the interwebs
         function simpleXml(js, wraptag) {
             if (js instanceof Object) {
-                return simpleXml(Object.keys(js).map(function(key) {
+                return simpleXml(Y.Object.keys(js).map(function(key) {
                     return simpleXml(js[key], key);
                 }).join('\n'), wraptag);
             }


### PR DESCRIPTION
The unit test for this was broken in Firefox 3.6.9.
