### PR TITLE
Performance metrics in mojito

### DIFF
--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -19,12 +19,14 @@ YUI.add('mojito-composite-addon', function(Y, NAME) {
         this.id = id;
         this.callback = callback;
         this.__meta = [];
+        this.__perf = Y.mojito.perf.timeline(NAME, 'child:done', 'time to render a child mojit', id);
     }
 
 
     AdapterBuffer.prototype = {
 
         done: function(data, meta) {
+            this.__perf.done();
             this.buffer[this.id].meta = meta;
             this.buffer[this.id].data += data;
             this.buffer.__counter__ -= 1;
@@ -202,7 +204,8 @@ callback({
             var ac = this.ac,
                 buffer = {},
                 content = {},
-                meta = {};
+                meta = {},
+                perf;
 
             cfg.children = cfg.children || {};
 
@@ -211,6 +214,8 @@ callback({
                 throw new Error('Cannot process children in the format of an' +
                                 ' array. \'children\' must be an object.');
             }
+
+            perf = Y.mojito.perf.timeline(NAME, 'execute', Y.Object.keys(cfg.children), cfg.id);
 
             // check to ensure children doesn't have a null child
             // in which case it will be automatically discarded to
@@ -249,6 +254,8 @@ callback({
                         }
                         ac.assets.mixAssets(meta.assets, cfg.assets);
                     }
+
+                    perf.done();
 
                     cb(content, meta);
                 });

--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -214,8 +214,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
 
         // Time marker
         Y.mojito.perf.mark('mojito', 'core_action_end[' + instance.type +
-                ':' + action + ']', 'ac.done() completed for Mojit "' +
-                instance.type + '" with action "' + action + '"');
+                ':' + action + ']', 'ac.done() completed', instance.id);
     };
 
 

--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -49,7 +49,12 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             renderer = null,
             contentType,
             contentPath,
-            viewEngineOptions = (instance.appConfig && instance.appConfig.viewEngine) || {};
+            viewEngineOptions = (instance.appConfig && instance.appConfig.viewEngine) || {},
+            perf;
+
+        // Perf metric for time to done
+        perf = Y.mojito.perf.timeline(NAME, 'mojit:done[' + instance.type +
+                ':' + action + ']', 'time to execute ac.done process', instance.instanceId);
 
         if (Y.Lang.isString(meta)) {
             // If the meta string is a serializer set it
@@ -212,9 +217,12 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             adapter[callbackFunc](data, meta);
         }
 
+        // closing mojit:done
+        perf.done();
+
         // Time marker
         Y.mojito.perf.mark('mojito', 'core_action_end[' + instance.type +
-                ':' + action + ']', 'ac.done() completed', instance.id);
+                ':' + action + ']', 'ac.done() completed', instance.instanceId);
     };
 
 

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -251,7 +251,8 @@ YUI.add('mojito-action-context', function(Y, NAME) {
             adapter = opts.adapter,
             store = opts.store,
             actionFunction,
-            error;
+            error,
+            perf;
 
         // "init" is not an action
         if (command.action === 'init') {
@@ -268,6 +269,9 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         this.type = instance.type;
         this.context = command.context;
         this.models = models;
+
+        perf = Y.mojito.perf.timeline(NAME, 'ac:init',
+                'time to set up AC object', instance.instanceId);
 
         // identify this as internal... users probably won't want to use it, but
         // addons might need
@@ -312,14 +316,23 @@ YUI.add('mojito-action-context', function(Y, NAME) {
             }
         }
 
+        // closing the perf metric for ac:init
+        perf.done();
+
         // Time marker
         Y.mojito.perf.mark('mojito', 'core_action_start[' + instance.type +
-            ':' + command.action + ']', 'Calling Mojit', instance.id);
+            ':' + command.action + ']', 'Calling Mojit', instance.instanceId);
 
         Y.log('action context created, executing action "' + actionFunction +
             '"', 'mojito', 'qeperf');
 
+        perf = Y.mojito.perf.timeline(NAME, 'ac:action:invoke',
+                'time to call an action from AC', instance.instanceId);
+
         controller[actionFunction](this);
+
+        // closing the perf metric for ac:action:invoke
+        perf.done();
     }
 
     Y.namespace('mojito').ActionContext = ActionContext;

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -314,8 +314,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         // Time marker
         Y.mojito.perf.mark('mojito', 'core_action_start[' + instance.type +
-            ':' + command.action + ']', 'Calling the Mojit "' + instance.type +
-            '" with action "' + command.action + '"');
+            ':' + command.action + ']', 'Calling Mojit', instance.id);
 
         Y.log('action context created, executing action "' + actionFunction +
             '"', 'mojito', 'qeperf');

--- a/lib/app/autoload/controller-context.common.js
+++ b/lib/app/autoload/controller-context.common.js
@@ -110,7 +110,9 @@ YUI.add('mojito-controller-context', function(Y, NAME) {
                 config = command.instance.config,
                 // this is the action that will be executed
                 action = command.action,
-                ac;
+                ac,
+                perf = Y.mojito.perf.timeline(NAME, 'action:invoke',
+                    'time to create ac and invoke an action', instance.instanceId);
 
             // replace the non-expanded command instance with the proper
             // instance, that was already expanded when the controller context
@@ -158,8 +160,11 @@ YUI.add('mojito-controller-context', function(Y, NAME) {
                 // need this level of isolation.
             }
 
+            // closing the perf metric for timeline
+            perf.done();
+
             this.Y.mojito.perf.mark('mojito', 'core_dispatch_end[' +
-                (instance.id || '@' + instance.type) + ':' + action + ']');
+                (instance.id || '@' + instance.type) + ':' + action + ']', 'invoked action', instance.instanceId);
         }
     };
 

--- a/lib/app/autoload/dispatch.common.js
+++ b/lib/app/autoload/dispatch.common.js
@@ -148,7 +148,9 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
 
                 function runMojit() {
                     var moduleList,
-                        mojitYuiModules;
+                        mojitYuiModules,
+                        perf = Y.mojito.perf.timeline(NAME, 'mojit:use',
+                                instance.yui.sorted, instance.instanceId);
 
                     moduleList = instance.yui.sorted;
                     // gotta copy this or else it pollutes the client runtime
@@ -188,6 +190,8 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
                         if (cacheControllerContext) {
                             CACHE.controllerContexts[instance.instanceId] = cc;
                         }
+
+                        perf.done();
 
                         cc.invoke(command, adapter);
 

--- a/lib/app/autoload/dispatch.common.js
+++ b/lib/app/autoload/dispatch.common.js
@@ -78,7 +78,8 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
         var instance = command.instance,
             cc = cacheControllerContext ?
                     CACHE.controllerContexts[instance.instanceId] :
-                    null;
+                    null,
+            perf;
 
         if (cc) {
             logger.log('using cached controller context: ' +
@@ -89,6 +90,9 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
 
         logger.log('expanding partial mojit instance', 'mojito', 'qeperf');
 
+        perf = Y.mojito.perf.timeline(NAME, 'mojit:expand',
+            'time to expand an instance', instance.instanceId);
+
         // Convert the command partial instance to a full instance. Note
         // instance here means dictionary that's either fully populated or
         // not. When it's expanded it contains all the data from the resource
@@ -96,15 +100,18 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
         store.expandInstance(command.instance, command.context,
             function(err, instance) {
 
+                var instanceYuiCacheKey,
+                    instanceYuiCacheObj,
+                    ctxKey;
+
                 // if there is no action, make 'index' the default
                 if (!command.action) {
                     // use instance config for default action or 'index'
                     command.action = instance.action || 'index';
                 }
 
-                var instanceYuiCacheKey,
-                    instanceYuiCacheObj,
-                    ctxKey;
+                // closing the timeline for mojit:expand
+                perf.done();
 
                 if (err) {
                     if (adapter.error) {
@@ -200,9 +207,7 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
                     // Time marker
                     Y.mojito.perf.mark('mojito', 'core_dispatch_start[' +
                         (instance.id || '@' + instance.type) + ':' +
-                        command.action + ']', 'Dispatching an instance of \'' +
-                        (instance.id || '@' + instance.type) + '/' +
-                        command.action + '\'');
+                        command.action + ']', 'Dispatching an instance');
 
                     // Now we call YUI use() with our modules array
                     // This is the same as doing; YUI().use(arrayOfModules,

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -7,119 +7,153 @@
 
 /*jslint anon:true, sloppy:true, nomen:true*/
 /*global YUI*/
+YUI.add('mojito-perf', function (Y, NAME) {
+
+    if (!YUI._mojito) {
+        YUI._mojito = {};
+    }
 
 
-(function() {
+    var store = YUI._mojito._perf,
+        perfConfig = Y.config.perf || {},
+        requestId = 0,
+        getgo,
+        microtime;
 
-    //a single shared message buffer
-    var buffer = [];
+
+    try {
+        microtime = require('microtime');
+    } catch (e) {
+        Y.log('microtime not found. Recorded times will not have' +
+            ' microsecond accuracy', 'warn', NAME);
+    }
 
 
-    YUI.add('mojito-perf', function(Y, NAME) {
+    function print(group, label) {
+        var o = store[group][label],
+            // if we already have milliseconds, good
+            // if not, we can compute it based on request init
+            ms = o.ms || (o.time - getgo),
+            // if we have requestId, use it
+            req = o.id ? 'req:' + o.id + ' ' : '';
 
-        var perfEnabled = false,
-            requestId = 0,
-            microtime;
+        Y.log(req + group + ':' + label + ' ' +
+            ms +
+            'ms (' + (o.msg || 'no desc') + ')', 'mojito', NAME);
 
-        try {
-            microtime = require('microtime');
-        } catch (e) {
-            Y.log('microtime not found. Recorded times will not have' +
-                ' microsecond accuracy', 'warn', NAME);
+    }
+
+
+    //internal. abstracts where timestamps come from
+    function timestamp() {
+        return microtime ? microtime.now() : new Date().getTime();
+    }
+
+
+    function mark(group, label, msg, id) {
+        var s;
+
+        if (!group || !label) {
+            return;
         }
 
-
-        //internal. abstracts where timestamps come from
-        function timestamp() {
-            return microtime ? microtime.now() : new Date().getTime();
+        if (id) {
+            label += '[' + id + ']';
         }
 
+        if (!store[group]) {
+            store[group] = {};
+        }
 
-        //internal. controls the format of performance marks
-        function format(group, label, message, id, timestamp) {
-            if (typeof id === 'number') {
-                id = 'req:' + id + ' ';
-            } else {
-                id = '';
+        if (!msg) {
+            msg = '';
+        }
+
+        if (store[group][label]) {
+            Y.log('Perf metric collision for group=' + group + ' label=' + label +
+                '. Measure one thing at a time.', 'warn', NAME);
+        }
+
+        s = store[group][label] = {};
+        s.msg = msg;
+        s.time = timestamp();
+        return s;
+    }
+
+
+    function timeline(group, label, message, id) {
+        var t = timestamp();
+        return {
+            done: function () {
+                var s = mark(group, label, message, id);
+                // augmenting the default format
+                s.ms = timestamp() - t;
             }
-
-            if (timestamp) {
-                timestamp = timestamp + ' ';
-            } else {
-                timestamp = '';
-            }
-
-            return id + timestamp + group + ':' + label;
-        }
-
-
-        function mark(request, group, label, message) {
-            var s;
-
-            if (request.connection && request.connection.mojitoPerfMark) {
-                request.connection.mojitoPerfMark(group, label, message);
-            } else if (typeof request === 'string') {
-                message = label;
-                label = group;
-                group = request;
-                s = format(group, label, message, null, timestamp());
-                buffer.push(s);
-            } else {
-                Y.log('Invalid request object', 'warn', NAME);
-                Y.log('mark(): invalid argument', 'warn', NAME);
-            }
-        }
-
-
-        function dump() {
-            var len = buffer.length,
-                i;
-            for (i = 0; i < len; i += 1) {
-                Y.log(buffer[i], 'mojito', NAME);
-            }
-            buffer = [];
-        }
-
-
-        function instrumentConnectApp(app) {
-            app.on('connection', function(conn) {
-                var id = (requestId += 1);
-
-                conn.mojitoPerfMark = function(group, label, message) {
-                    var s = format(group, label, message, id, timestamp());
-                    buffer.push(s);
-                };
-
-                conn.on('close', function() {
-                    conn.mojitoPerfMark('mojito', NAME + ':connection_end');
-                    dump();
-                });
-
-                conn.mojitoPerfMark('mojito', NAME + ':connection');
-            });
-
-            app.use(function(req, res, next) {
-                req.connection.mojitoPerfMark('mojito', NAME + ':request');
-                next();
-            });
-        }
-
-
-        Y.namespace('mojito').perf = {
-
-            instrumentConnectApp: perfEnabled ?
-                    instrumentConnectApp :
-                    function() {},
-
-
-            mark: perfEnabled ?
-                    mark :
-                    function() {},
-
-
-            dump: perfEnabled ?
-                    dump :
-                    function() {}
         };
-    });
-}());
+    }
+
+
+    function dump() {
+
+        var group,
+            label;
+
+        for (group in store) {
+            if (store.hasOwnProperty(group)) {
+                for (label in store[group]) {
+                    if (store[group].hasOwnProperty(label)) {
+                        print(group, label);
+                    }
+                }
+                delete store[group];
+            }
+        }
+    }
+
+
+    function instrumentConnectApp(app) {
+
+        app.on('connection', function(conn) {
+            var id = (requestId += 1),
+                perf;
+
+            getgo = timestamp();
+            if (Y.Object.keys(store).length > 0) {
+                Y.log('Multiple requests at the same time. This can ' +
+                        'mess with the perf analysis. Curl is your best ' +
+                        'friend, use it.', 'warn', NAME);
+            }
+
+            perf = timeline('mojito', NAME + ':express:timeline', 'time to respond', id);
+
+            conn.on('close', function() {
+                perf.done();
+                dump();
+            });
+        });
+
+    }
+
+
+    Y.namespace('mojito').perf = {
+
+        instrumentConnectApp: perfConfig.app ?
+                instrumentConnectApp :
+                function() {},
+
+        timeline: perfConfig.timeline ? timeline : function() {
+            return {
+                done: function () {}
+            };
+        },
+
+        mark: perfConfig.mark ? mark : function() {},
+
+        dump: perfConfig ? dump : function() {}
+    };
+
+    if (!store) {
+        store = YUI._mojito._perf = {};
+    }
+
+});

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -17,6 +17,8 @@ YUI.add('mojito-perf', function (Y, NAME) {
     var store = YUI._mojito._perf,
         perfConfig = Y.config.perf || {},
         requestId = 0,
+        colorRed   = '\u001b[31m',
+        colorReset = '\u001b[0m',
         getgo,
         microtime;
 
@@ -35,9 +37,10 @@ YUI.add('mojito-perf', function (Y, NAME) {
             // if not, we can compute it based on request init
             ms = o.ms || (o.time - getgo);
 
-        Y.log(group + ':' + label + ' ' +
-            ms +
-            'ms (' + (o.msg || 'no desc') + ')', 'mojito', NAME);
+        Y.log(group + ':' + label + ' ' + colorRed +
+            (o.ms ? 'timeline=' : 'mark=') + ms +
+            colorReset + ' (' + (o.msg || 'no desc') + ')',
+            'mojito', NAME);
 
     }
 
@@ -109,45 +112,52 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    function instrumentConnectApp(app) {
+    function instrumentMojitoRequest(req, res) {
+        var id = (requestId += 1),
+            perf,
+            end = res.end;
 
-        app.on('connection', function(conn) {
-            var id = (requestId += 1),
-                perf;
+        getgo = timestamp();
+        if (Y.Object.keys(store).length > 0) {
+            Y.log('Multiple requests at the same time. This can ' +
+                    'mess with the perf analysis. Curl is your best ' +
+                    'friend, use it.', 'warn', NAME);
+        }
 
-            getgo = timestamp();
-            if (Y.Object.keys(store).length > 0) {
-                Y.log('Multiple requests at the same time. This can ' +
-                        'mess with the perf analysis. Curl is your best ' +
-                        'friend, use it.', 'warn', NAME);
-            }
+        perf = timeline('mojito', NAME + ':express:timeline', 'time to respond', id);
 
-            perf = timeline('mojito', NAME + ':express:timeline', 'time to respond', id);
-
-            conn.on('close', function() {
+        // hooking into the res.end called from output-handler.server.js
+        // to be able to flush perf metrics only for mojito requests.
+        // static requests and other type of requests will be ignored.
+        res.end = function () {
+            if (perf) {
+                end.apply(res, arguments);
+                Y.log('Flushing perf metrics', 'mojito', NAME);
                 perf.done();
                 dump();
-            });
-        });
-
+                // some cleanup
+                perf = null;
+                end = null;
+                req = null;
+                res = null;
+            }
+        };
     }
 
 
     Y.namespace('mojito').perf = {
 
-        instrumentConnectApp: perfConfig.app ?
-                instrumentConnectApp :
-                function() {},
+        instrumentMojitoRequest: perfConfig ? instrumentMojitoRequest : function () {},
 
-        timeline: perfConfig.timeline ? timeline : function() {
+        timeline: perfConfig.timeline ? timeline : function () {
             return {
                 done: function () {}
             };
         },
 
-        mark: perfConfig.mark ? mark : function() {},
+        mark: perfConfig.mark ? mark : function () {},
 
-        dump: perfConfig ? dump : function() {}
+        dump: perfConfig ? dump : function () {}
     };
 
     if (!store) {

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -33,11 +33,9 @@ YUI.add('mojito-perf', function (Y, NAME) {
         var o = store[group][label],
             // if we already have milliseconds, good
             // if not, we can compute it based on request init
-            ms = o.ms || (o.time - getgo),
-            // if we have requestId, use it
-            req = o.id ? 'req:' + o.id + ' ' : '';
+            ms = o.ms || (o.time - getgo);
 
-        Y.log(req + group + ':' + label + ' ' +
+        Y.log(group + ':' + label + ' ' +
             ms +
             'ms (' + (o.msg || 'no desc') + ')', 'mojito', NAME);
 

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -20,9 +20,9 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    var store = YUI._mojito._perf,
+    var buffer     = YUI._mojito._perf,
         perfConfig = Y.config.perf || {},
-        requestId = 0,
+        requestId  = 0,
         colorRed   = '\u001b[31m',
         colorReset = '\u001b[0m',
         getgo,
@@ -38,15 +38,19 @@ YUI.add('mojito-perf', function (Y, NAME) {
 
 
     function print(group, label) {
-        var o = store[group][label],
+        var o = buffer[group][label],
             // if we already have milliseconds, good
             // if not, we can compute it based on request init
             ms = o.ms || (o.time - getgo);
 
-        Y.log(group + ':' + label + ' ' + colorRed +
-            (o.ms ? 'timeline=' : 'mark=') + ms +
-            colorReset + ' (' + (o.msg || 'no desc') + ')',
-            'mojito', NAME);
+        if ((perfConfig.mark && !o.ms) || (perfConfig.timeline && o.ms)) {
+
+            Y.log(group + ':' + label + ' ' + colorRed +
+                (o.ms ? 'timeline=' : 'mark=') + ms +
+                colorReset + ' (' + (o.msg || 'no desc') + ')',
+                'mojito', NAME);
+
+        }
 
     }
 
@@ -81,20 +85,21 @@ YUI.add('mojito-perf', function (Y, NAME) {
             label += '[' + id + ']';
         }
 
-        if (!store[group]) {
-            store[group] = {};
+        if (!buffer[group]) {
+            buffer[group] = {};
         }
 
         if (!msg) {
             msg = '';
         }
 
-        if (store[group][label]) {
+        if (buffer[group][label]) {
             Y.log('Perf metric collision for group=' + group + ' label=' + label +
                 '. Measure one thing at a time.', 'warn', NAME);
+            label += Y.guid();
         }
 
-        s = store[group][label] = {};
+        s = buffer[group][label] = {};
         s.msg = msg;
         s.time = timestamp();
         return s;
@@ -130,7 +135,23 @@ YUI.add('mojito-perf', function (Y, NAME) {
     /**
      * Dumps all marks and timeline entries into the console.
      * This method is meant to be called automatically when
-     * a request ends.
+     * a request ends. You can target specific metrics by using
+     * the configuration:
+     *
+     * "perf": {
+     *    "include": {
+     *        "mojito-action-context": true
+     *    }
+     * }
+     *
+     * Or just exclude some of them by doing:
+     *
+     * "perf": {
+     *    "exclude": {
+     *        "mojito-action-context": true
+     *    }
+     * }
+     *
      *
      * @method dump
      **/
@@ -139,14 +160,16 @@ YUI.add('mojito-perf', function (Y, NAME) {
         var group,
             label;
 
-        for (group in store) {
-            if (store.hasOwnProperty(group)) {
-                for (label in store[group]) {
-                    if (store[group].hasOwnProperty(label)) {
+        for (group in buffer) {
+            if ((buffer.hasOwnProperty(group)) &&
+                (!perfConfig.exclude || !perfConfig.exclude[group]) &&
+                (!perfConfig.include || perfConfig.include[group])) {
+                for (label in buffer[group]) {
+                    if (buffer[group].hasOwnProperty(label)) {
                         print(group, label);
                     }
                 }
-                delete store[group];
+                delete buffer[group];
             }
         }
     }
@@ -169,7 +192,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
             end = res.end;
 
         getgo = timestamp();
-        if (Y.Object.keys(store).length > 0) {
+        if (Y.Object.keys(buffer).length > 0) {
             Y.log('Multiple requests at the same time. This can ' +
                     'mess with the perf analysis. Curl is your best ' +
                     'friend, use it.', 'warn', NAME);
@@ -211,8 +234,8 @@ YUI.add('mojito-perf', function (Y, NAME) {
         dump: perfConfig ? dump : function () {}
     };
 
-    if (!store) {
-        store = YUI._mojito._perf = {};
+    if (!buffer) {
+        buffer = YUI._mojito._perf = {};
     }
 
 });

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -9,6 +9,12 @@
 /*global YUI*/
 YUI.add('mojito-perf', function (Y, NAME) {
 
+    /**
+     * @module mojito-perf
+     * @class mojito.perf
+     * @static
+     */
+
     if (!YUI._mojito) {
         YUI._mojito = {};
     }
@@ -51,6 +57,19 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
+    /**
+     * Sets a mark in the request timeline. All marks will be flushed
+     * after the end. This is useful to measure when a particular process
+     * start or end with respect to the request timeline.
+     *
+     * @method mark
+     * @param {string} group Event group.
+     * @param {string} label Event identifier. Will be combined with group.
+     * @param {string} msg Description of the mark.
+     * @param {string} id Unique identifier of the mark, usually
+     *      the requestId or the yuid().
+     * @return {Object} The mark entry.
+     **/
     function mark(group, label, msg, id) {
         var s;
 
@@ -82,6 +101,20 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
+    /**
+     * Starts a timeline metric, providing a way to call it done
+     * at some point in the future. This is useful to measure the
+     * time to execute a process in mojito.
+     *
+     * @method timeline
+     * @param {string} group Event group.
+     * @param {string} label Event identifier. Will be combined with group.
+     * @param {string} msg Description of the mark.
+     * @param {string} id Unique identifier of the mark, usually
+     *      the requestId or the yuid().
+     * @return {object} represents the timeline object that has a method
+     *      called "done" that can be invoked when the process finish.
+     **/
     function timeline(group, label, message, id) {
         var t = timestamp();
         return {
@@ -94,6 +127,13 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
+    /**
+     * Dumps all marks and timeline entries into the console.
+     * This method is meant to be called automatically when
+     * a request ends.
+     *
+     * @method dump
+     **/
     function dump() {
 
         var group,
@@ -112,6 +152,17 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
+    /**
+     * Instruments requests that will be processed by mojito
+     * core, providing a valid timeline for that request, and
+     * allowing to instrument some other relative processes,
+     * and grouping them per request to facilitate analysis.
+     * This method is responsible for calling "dump".
+     *
+     * @method instrumentMojitoRequest
+     * @param {object} req the request object from express.
+     * @param {object} res the response object from express.
+     **/
     function instrumentMojitoRequest(req, res) {
         var id = (requestId += 1),
             perf,

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,13 @@ MojitoServer.prototype = {
 
         configureYUI(Y, store, CORE_MOJITO_MODULES);
 
+        // in case we want to collect some performance metrics,
+        // we can do that by setting:
+        // application.json (master) perf->metricName = true
+        YUI.applyConfig({
+            perf: appConfig.perf
+        });
+
         // Load logger early so that we can plug it in before the other loading
         // happens.
         Y.applyConfig({ useSync: true });

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,10 @@ MojitoServer.prototype = {
 
         // Load logger early so that we can plug it in before the other loading
         // happens.
-        Y.applyConfig({ useSync: true });
+        Y.applyConfig({
+            useSync: true,
+            perf: appConfig.perf // adding the perf to the mojito Y
+        });
         Y.use('mojito-logger');
         // TODO: extract function
         logger = new Y.mojito.Logger(serverLog.options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -211,8 +211,6 @@ MojitoServer.prototype = {
 
         loader = new Y.mojito.Loader(appConfig);
 
-        Y.mojito.perf.instrumentConnectApp(app);
-
         if (appConfig.middleware && appConfig.middleware.length) {
             hasMojito = false;
             for (m = 0; m < appConfig.middleware.length; m += 1) {
@@ -274,6 +272,11 @@ MojitoServer.prototype = {
             }
 
             logger.log('START', 'mojito', 'server');
+
+            // if perf metrics are on, we should hook into
+            // the mojito request to flush metrics when
+            // the connection is closed.
+            Y.mojito.perf.instrumentMojitoRequest(req, res);
 
             // Pass the "Resource Store" by wrapping it with the adapter
             dispatcher = Y.mojito.Dispatcher.init(


### PR DESCRIPTION
Getting perf.server.js as expected. Adding new configuration settings to enable and disable some of the metrics:

```
[{
    "settings": [ "master" ],
    "specs": {},
    "perf": {
        "timeline": true,
        "mark": true
    }
}]
```

With these new settings, we can get some useful metrics through the Node console. We can also instrument any mojit or any mojito-core related process by using `mark` or `timeline` methods. Here is an example:

```
YUI.add('something', function(Y, NAME) {

    // mark an important moment in the request life-cycle
    Y.mojito.perf.mark(NAME, 'metric-name',
            'metric description', 'uniqueId if needed');

    // open a timeline metric if you want to measure a process
    var perf = Y.mojito.perf.timeline(NAME, 'metric-name',
            'metric description', 'uniqueId if needed');

    // at some point in the future, you can call "done"
    // to mark the end of the timeline.
    perf.done();

}, '0.1.0', {requires: [
    'mojito-perf',
]});
```

As a result, we will get something like this in the console:

```
[MOJITO] (11) mojito-perf: something:metricName[id] mark=120 (metric description)
[MOJITO] (12) mojito-perf: something:metricName[id] timeline=300 (metric description)
[MOJITO] (14) mojito-perf: mojito:mojito-perf:express:timeline[1] timeline=420 (time to respond)
```
