### PR TITLE
controller only gets what is -explicitely- listed in it's "requires"

### DIFF
--- a/lib/app/addons/rs/yui.server.js
+++ b/lib/app/addons/rs/yui.server.js
@@ -341,7 +341,6 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 modules = {},
                 binders = {},
                 controller,
-                controllerRequired = {},
                 required,
                 sorted,
                 binderName,
@@ -365,9 +364,6 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                         requires: res.yui.meta.requires,
                         fullpath: (('client' === env) ? res.url : res.source.fs.fullPath)
                     };
-                    if (res.mojit === mojit && res.type !== 'yui-lang' && res.type !== 'binder') {
-                        controllerRequired[res.yui.name] = true;
-                    }
                     if ('binder' === res.type) {
                         binders[res.name] = res;
                     }
@@ -398,8 +394,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 lang = langs[langName];
 
                 if (controller) {
-                    required = Y.mojito.util.copy(controllerRequired);
-                    required['mojito-dispatcher'] = true;
+                    required = { 'mojito-dispatcher': true };
                     required[controller.yui.name] = true;
                     if (lang && lang.yui) {
                         required[lang.yui.name] = true;


### PR DESCRIPTION
This was uncovered by @dferreiroval while working on mojito-shaker 2.0.
