### PR TITLE
perf: adding support for perf.log

### DIFF
--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -20,9 +20,9 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    var fs = require('fs'),
-        path = require('path'),
-        existsSync = fs.existsSync || path.existsSync,
+    var libfs = require('fs'),
+        libpath = require('path'),
+        existsSync = libfs.existsSync || libpath.existsSync,
         buffer     = YUI._mojito._perf,
         perfConfig = Y.config.perf || {},
         requestId  = 0,
@@ -46,7 +46,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
             i;
 
         try {
-            outstream = fs.createWriteStream(filename, {
+            outstream = libfs.createWriteStream(filename, {
                 flags: 'a' // append
             });
             for (i = 0; i < logs.length; i += 1) {
@@ -322,7 +322,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
     if (perfConfig.logFile && existsSync(perfConfig.logFile)) {
         Y.log("Removing the previous perf log file '" +
             perfConfig.logFile + "'", 'warn', NAME);
-        fs.unlinkSync(perfConfig.logFile);
+        libfs.unlinkSync(perfConfig.logFile);
     }
 
 });

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -68,18 +68,21 @@ YUI.add('mojito-perf', function (Y, NAME) {
             // if we already have milliseconds, good
             // if not, we can compute it based on request init
             time = o.time,
-            duration = (o.ms || (o.time - getgo)),
+            offset = o.time - getgo,
+            duration = o.ms || '',
             desc = o.msg || 'no description',
             label = o.label,
             id = o.id;
 
         if ((perfConfig.mark && !o.ms) || (perfConfig.timeline && o.ms)) {
 
-            Y.log(group + ':' + key + ' ' + type + '=' +
-                colorRed + duration + colorReset + ' (' + desc + ')',
+            Y.log(group + ':' + key + ' ' + type + colorReset +
+                ' offset=' + colorRed + offset + colorReset +
+                (o.ms ? ' duration=' + colorRed + duration + colorReset : '') +
+                ' (' + desc + ')',
                 'mojito', NAME);
 
-            return [type, time + ':' + duration, group, label, id, desc];
+            return [type, requestId, time, duration, group, label, id, desc];
 
         }
 
@@ -216,7 +219,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
      *
      * @method dump
      * @return {array} collection of perf logs. Each item will expose:
-     *     {type, time + ':' + duration, group, label, id, desc}
+     *     {type, requestId, time, duration, group, label, id, desc}
      **/
     function dump() {
 

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -6,7 +6,7 @@
 
 
 /*jslint anon:true, sloppy:true, nomen:true*/
-/*global YUI*/
+/*global YUI,require,process*/
 YUI.add('mojito-perf', function (Y, NAME) {
 
     /**
@@ -20,7 +20,12 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    var buffer     = YUI._mojito._perf,
+    var fs = require('fs'),
+        path = require('path'),
+        wrench = require('wrench'),
+        existsSync = fs.existsSync || path.existsSync,
+        folder     = path.join(process.cwd(), 'artifacts/perf'),
+        buffer     = YUI._mojito._perf,
         perfConfig = Y.config.perf || {},
         requestId  = 0,
         colorRed   = '\u001b[31m',
@@ -37,18 +42,44 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    function print(group, label) {
-        var o = buffer[group][label],
+    //internal. write perf info into a file
+    function writeLog(filename, logs) {
+        var outstream,
+            i;
+
+        try {
+            outstream = fs.createWriteStream(path.join(folder, filename));
+            for (i = 0; i < logs.length; i += 1) {
+                outstream.write(logs[i].join('|') + "\n");
+            }
+            outstream.end();
+            outstream = null;
+        } catch (err) {
+            Y.log('Error trying to dump perf metrics in file: ' +
+                filename + ' Error:' + err, 'error', NAME);
+        }
+    }
+
+
+    //internal. print perf info in the logs
+    function print(group, key) {
+        var o = buffer[group][key],
+            type = (o.ms ? 'TIMELINE' : 'MARK'),
             // if we already have milliseconds, good
             // if not, we can compute it based on request init
-            ms = o.ms || (o.time - getgo);
+            time = o.time,
+            duration = (o.ms || (o.time - getgo)),
+            desc = o.msg || 'no description',
+            label = o.label,
+            id = o.id;
 
         if ((perfConfig.mark && !o.ms) || (perfConfig.timeline && o.ms)) {
 
-            Y.log(group + ':' + label + ' ' + colorRed +
-                (o.ms ? 'timeline=' : 'mark=') + ms +
-                colorReset + ' (' + (o.msg || 'no desc') + ')',
+            Y.log(group + ':' + key + ' ' + type + '=' +
+                colorRed + duration + colorReset + ' (' + desc + ')',
                 'mojito', NAME);
+
+            return [type, time + ':' + duration, group, label, id, desc];
 
         }
 
@@ -62,6 +93,30 @@ YUI.add('mojito-perf', function (Y, NAME) {
 
 
     /**
+     * Produces an ID to identify the timeline or mark based on a
+     * command object.
+     *
+     * @method idFromCommand
+     * @param {object} command Object that represent the command to invoke.
+     * @return {string} ID that represents the command.
+     **/
+    function idFromCommand(command) {
+        var str;
+        if (command && command.instance) {
+            if (command.instance.id) {
+                str = command.instance.id;
+            } else if (command.instance.base) {
+                str = '+' + command.instance.base;
+            } else {
+                str = '@' + command.instance.type;
+            }
+            str += '.' + (command.action || command.instance.action || '???');
+        }
+        return str;
+    }
+
+
+    /**
      * Sets a mark in the request timeline. All marks will be flushed
      * after the end. This is useful to measure when a particular process
      * start or end with respect to the request timeline.
@@ -70,19 +125,22 @@ YUI.add('mojito-perf', function (Y, NAME) {
      * @param {string} group Event group.
      * @param {string} label Event identifier. Will be combined with group.
      * @param {string} msg Description of the mark.
-     * @param {string} id Unique identifier of the mark, usually
-     *      the requestId or the yuid().
+     * @param {string|object} id Unique identifier of the mark, usually
+     *      the requestId or a command object.
      * @return {Object} The mark entry.
      **/
     function mark(group, label, msg, id) {
-        var s;
+        var s,
+            key = label;
 
         if (!group || !label) {
             return;
         }
 
         if (id) {
-            label += '[' + id + ']';
+            // we might also accept a command object
+            id = Y.Lang.isObject(id) ? idFromCommand(id) : id;
+            key += '[' + id + ']';
         }
 
         if (!buffer[group]) {
@@ -93,14 +151,17 @@ YUI.add('mojito-perf', function (Y, NAME) {
             msg = '';
         }
 
-        if (buffer[group][label]) {
-            Y.log('Perf metric collision for group=' + group + ' label=' + label +
+        if (buffer[group][key]) {
+            Y.log('Perf metric collision for group=' + group +
+                ' label=' + label + ' id=' + id +
                 '. Measure one thing at a time.', 'warn', NAME);
-            label += Y.guid();
+            key += Y.guid();
         }
 
-        s = buffer[group][label] = {};
+        s = buffer[group][key] = {};
         s.msg = msg;
+        s.label = label;
+        s.id = id;
         s.time = timestamp();
         return s;
     }
@@ -132,20 +193,6 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
 
-    function idFromCommand(command) {
-        var str;
-        if (command.instance.id) {
-            str = command.instance.id;
-        } else if (command.instance.base) {
-            str = '+' + command.instance.base;
-        } else {
-            str = '@' + command.instance.type;
-        }
-        str += '.' + (command.action || command.instance.action || '???');
-        return str;
-    }
-
-
     /**
      * Dumps all marks and timeline entries into the console.
      * This method is meant to be called automatically when
@@ -168,24 +215,39 @@ YUI.add('mojito-perf', function (Y, NAME) {
      *
      *
      * @method dump
+     * @return {array} collection of perf logs. Each item will expose:
+     *     {type, time + ':' + duration, group, label, id, desc}
      **/
     function dump() {
 
         var group,
-            label;
+            key,
+            entry,
+            logs = [];
 
         for (group in buffer) {
             if ((buffer.hasOwnProperty(group)) &&
                     (!perfConfig.exclude || !perfConfig.exclude[group]) &&
                     (!perfConfig.include || perfConfig.include[group])) {
-                for (label in buffer[group]) {
-                    if (buffer[group].hasOwnProperty(label)) {
-                        print(group, label);
+                for (key in buffer[group]) {
+                    if (buffer[group].hasOwnProperty(key)) {
+                        entry = print(group, key);
+                        if (entry) {
+                            logs.push(entry);
+                        }
                     }
                 }
                 delete buffer[group];
             }
         }
+        // dumping to disk
+        if (perfConfig.log) {
+            Y.log('Dumping performance data into disk under folder=' +
+                folder, 'mojito', NAME);
+            writeLog('request-' + requestId + '.log', logs);
+        }
+
+        return logs;
     }
 
 
@@ -235,7 +297,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
 
     Y.namespace('mojito').perf = {
 
-        idFromCommand: perfConfig ? idFromCommand : function() {},
+        idFromCommand: perfConfig ? idFromCommand : function () {},
 
         instrumentMojitoRequest: perfConfig ? instrumentMojitoRequest : function () {},
 
@@ -252,6 +314,13 @@ YUI.add('mojito-perf', function (Y, NAME) {
 
     if (!buffer) {
         buffer = YUI._mojito._perf = {};
+    }
+
+    if (perfConfig.log) {
+        Y.log('Preparing app to dump performance data into disk under folder=' +
+            folder, 'mojito', NAME);
+        wrench.rmdirSyncRecursive(folder, true);
+        wrench.mkdirSyncRecursive(folder, '0744');
     }
 
 });

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -22,9 +22,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
 
     var fs = require('fs'),
         path = require('path'),
-        wrench = require('wrench'),
         existsSync = fs.existsSync || path.existsSync,
-        folder     = path.join(process.cwd(), 'artifacts/perf'),
         buffer     = YUI._mojito._perf,
         perfConfig = Y.config.perf || {},
         requestId  = 0,
@@ -48,7 +46,9 @@ YUI.add('mojito-perf', function (Y, NAME) {
             i;
 
         try {
-            outstream = fs.createWriteStream(path.join(folder, filename));
+            outstream = fs.createWriteStream(filename, {
+                flags: 'a' // append
+            });
             for (i = 0; i < logs.length; i += 1) {
                 outstream.write(logs[i].join('|') + "\n");
             }
@@ -241,10 +241,10 @@ YUI.add('mojito-perf', function (Y, NAME) {
             }
         }
         // dumping to disk
-        if (perfConfig.log) {
-            Y.log('Dumping performance data into disk under folder=' +
-                folder, 'mojito', NAME);
-            writeLog('request-' + requestId + '.log', logs);
+        if (perfConfig.logFile) {
+            Y.log('Dumping performance metrics into disk: ' +
+                perfConfig.logFile, 'mojito', NAME);
+            writeLog(perfConfig.logFile, logs);
         }
 
         return logs;
@@ -316,11 +316,10 @@ YUI.add('mojito-perf', function (Y, NAME) {
         buffer = YUI._mojito._perf = {};
     }
 
-    if (perfConfig.log) {
-        Y.log('Preparing app to dump performance data into disk under folder=' +
-            folder, 'mojito', NAME);
-        wrench.rmdirSyncRecursive(folder, true);
-        wrench.mkdirSyncRecursive(folder, '0744');
+    if (perfConfig.logFile && existsSync(perfConfig.logFile)) {
+        Y.log("Removing the previous perf log file '" +
+            perfConfig.logFile + "'", 'warn', NAME);
+        fs.unlinkSync(perfConfig.logFile);
     }
 
 });

--- a/lib/app/commands/start.js
+++ b/lib/app/commands/start.js
@@ -25,7 +25,8 @@ exports.usage = '\nmojito start [port]\n' +
     '\nOptions\n' +
     '\t--context  A comma-separated list of key:value pairs that define the' +
     ' base\n' +
-    '\t           context used to read configuration files\n';
+    '\t           context used to read configuration files\n' +
+    '\t--perf     Path and filename where to output performance metrics.\n';
 
 
 /**
@@ -34,6 +35,11 @@ exports.usage = '\nmojito start [port]\n' +
 exports.options = [
     {
         longName: 'context',
+        shortName: null,
+        hasValue: true
+    },
+    {
+        longName: 'perf',
         shortName: null,
         hasValue: true
     }
@@ -73,6 +79,10 @@ exports.run = function(params, opts, callback) {
     options.port = params[0] || appConfig.appPort || 8666;
     if (inputOptions.context) {
         options.context = utils.contextCsvToObject(inputOptions.context);
+    }
+
+    if (inputOptions.perf) {
+        options.perf = inputOptions.perf;
     }
 
     app = new utils.App(options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,8 @@ MojitoServer.prototype = {
             midFactory,
             hasMojito,
             midConfig,
-            dispatcher;
+            dispatcher,
+            perfConfig;
 
         if (!options) {
             options = {};
@@ -189,11 +190,17 @@ MojitoServer.prototype = {
         configureYUI(Y, store, CORE_MOJITO_MODULES);
 
         // in case we want to collect some performance metrics,
-        // we can do that by setting:
-        // application.json (master) perf->metricName = true
-        YUI.applyConfig({
-            perf: appConfig.perf
-        });
+        // we can do that by defining the "perf" object in:
+        // application.json (master)
+        // You can also use the option --perf path/filename.log when
+        // running mojito start to dump metrics to disk.
+        perfConfig = appConfig.perf;
+        if (perfConfig) {
+            perfConfig.logFile = options.perf;
+            YUI.applyConfig({
+                perf: perfConfig
+            });
+        }
 
         // Load logger early so that we can plug it in before the other loading
         // happens.
@@ -201,6 +208,7 @@ MojitoServer.prototype = {
             useSync: true,
             perf: appConfig.perf // adding the perf to the mojito Y
         });
+
         Y.use('mojito-logger');
         // TODO: extract function
         logger = new Y.mojito.Logger(serverLog.options);


### PR DESCRIPTION
introducing perf->log to write to disk.

```
"perf": {
    "timeline": true,
    "mark": true,
    "log": true,
    "exclude": {
        "groupName": true
    }
}
```

As a result, perf metrics will be log into disk under `./artifacts/perf/request-###.log`, where each line will have:

```
TIMELINE | timestamp:duration | group | label | id | desc
```

or

```
MARK | timestamp:duration | group | label | id | desc
```

Here is an example:

```
TIMELINE|1347418448352586:3947|mojito|ac.done|master.index|time to execute ac.done process
MARK|1347418448352593:795666|mojito|action:stop|master.index|after the action
```
