### PR TITLE
fix issue #13 ContextController cache never cleans up

### DIFF
--- a/lib/app/autoload/controller-context.common.js
+++ b/lib/app/autoload/controller-context.common.js
@@ -11,6 +11,12 @@
 
 YUI.add('mojito-controller-context', function(Y, NAME) {
 
+    /**
+     * @class ControllerContext
+     * @constructor
+     * @param {Object} opts contains instance, Y, store, appShareYUIInstance,
+     *   dispatch
+     */
     function ControllerContext(opts) {
         this.instance = opts.instance;
         this.dispatch = opts.dispatch;

--- a/lib/app/autoload/dispatch.common.js
+++ b/lib/app/autoload/dispatch.common.js
@@ -301,6 +301,19 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
             });
     }
 
+    function uncacheContext(instanceId) {
+        var msg = 'rm controller context cache for ' + instanceId;
+        if (CACHE.controllerContexts && CACHE.controllerContexts[instanceId]) {
+            delete CACHE.controllerContexts[instanceId];
+        } else {
+            msg += ' failed'
+        }
+        logger.log(msg, 'mojito', NAME);
+    }
+
+    function getCache() {
+        return CACHE;
+    }
 
     /*
      * the dispatcher must receive the global logger up front, because it is
@@ -345,9 +358,10 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
             return this;
         },
 
-
-        // Assign outer function here.
-        dispatch: dispatch
+        // Assign outer functions
+        dispatch: dispatch,
+        uncache: uncacheContext,
+        getCache: getCache
     };
 
 }, '0.1.0', {requires: [

--- a/lib/app/autoload/dispatch.common.js
+++ b/lib/app/autoload/dispatch.common.js
@@ -306,7 +306,7 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
         if (CACHE.controllerContexts && CACHE.controllerContexts[instanceId]) {
             delete CACHE.controllerContexts[instanceId];
         } else {
-            msg += ' failed'
+            msg += ' failed';
         }
         logger.log(msg, 'mojito', NAME);
     }

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -836,20 +836,20 @@ YUI.add('mojito-client', function(Y, NAME) {
          * @param {String} id The mojit's viewId to destroy
          * @param {Boolean} retainNode
          */
-        destroyMojitProxy: function(id, retainNode) {
-            var parent, instanceId;
+        destroyMojitProxy: function(viewId, retainNode) {
+            var mojits = this._mojits, parent, instanceId;
 
-            if (this._mojits[id] && this._mojits[id].proxy) {
+            if (mojits[viewId] && mojits[viewId].proxy) {
                 // lookup instanceId for this viewId
-                instanceId = this._mojits[id].proxy._instanceId;
+                instanceId = mojits[viewId].proxy._instanceId;
 
                 // TODO: activate call to unbindNode below:
-                // unbindNode(this._mojits[id].proxy._binder,
-                //      this._mojits[id].handles);
-                this._mojits[id].proxy._destroy(retainNode);
-                delete this._mojits[id];
+                // unbindNode(mojits[viewId].proxy._binder,
+                //      mojits[viewId].handles);
+                mojits[viewId].proxy._destroy(retainNode);
+                delete mojits[viewId];
 
-                if (instanceId && !hasInstanceId(this._mojits, instanceId)) {
+                if (instanceId && !hasInstanceId(mojits, instanceId)) {
                 	this.dispatcher.uncache(instanceId);
                 }
 
@@ -859,10 +859,10 @@ YUI.add('mojito-client', function(Y, NAME) {
                 // The only gap is when a mojit destroys itself.
                 // onChildDestroyed is called whenever a binder is destroyed so
                 // any parents can be notified.
-                parent = findParentProxy(this._mojits, id);
+                parent = findParentProxy(mojits, viewId);
                 if (parent && parent._binder.onChildDestroyed &&
                         Y.Lang.isFunction(parent._binder.onChildDestroyed)) {
-                    parent._binder.onChildDestroyed({ id: id });
+                    parent._binder.onChildDestroyed({ id: viewId });
                 }
             }
         },

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -207,6 +207,11 @@ YUI.add('mojito-client', function(Y, NAME) {
         return p;
     }
 
+    function hasInstanceId(mojits, instanceId) {
+        return Y.Object.some(mojits, function (mojit) {
+            return mojit.proxy._instanceId === instanceId;
+        });
+    }
 
     function recordBoundMojit(mojits, parentid, newid, type) {
         if (parentid && mojits[parentid]) {
@@ -826,16 +831,28 @@ YUI.add('mojito-client', function(Y, NAME) {
             }
         },
 
-
+        /**
+         * @method destroyMojitProxy
+         * @param {String} id The mojit's viewId to destroy
+         * @param {Boolean} retainNode
+         */
         destroyMojitProxy: function(id, retainNode) {
-            var parent;
+            var parent, instanceId;
 
-            if (this._mojits[id]) {
+            if (this._mojits[id] && this._mojits[id].proxy) {
+                // lookup instanceId for this viewId
+                instanceId = this._mojits[id].proxy._instanceId;
+
                 // TODO: activate call to unbindNode below:
                 // unbindNode(this._mojits[id].proxy._binder,
                 //      this._mojits[id].handles);
                 this._mojits[id].proxy._destroy(retainNode);
                 delete this._mojits[id];
+
+                if (instanceId && !hasInstanceId(this._mojits, instanceId)) {
+                	this.dispatcher.uncache(instanceId);
+                }
+
                 // We don't manage binder children automatically, but any time a
                 // new child is added or removed, we should at least give the
                 // application code a chance to stay up to date if they want to.

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -193,10 +193,8 @@ YUI.add('mojito-client', function(Y, NAME) {
     function findParentProxy(mojits, childId) {
         var p;
 
-        // TODO: convert to "some" instead of each for performance. We're doing
-        // a "detect" here.
-        Y.Object.each(mojits, function(mojit) {
-            Y.Object.each(mojit.children, function(child) {
+        Y.Object.some(mojits, function(mojit) {
+            Y.Object.some(mojit.children, function(child) {
                 if (child.viewId === childId) {
                     p = mojit.proxy;
                     return true;

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -850,7 +850,7 @@ YUI.add('mojito-client', function(Y, NAME) {
                 delete mojits[viewId];
 
                 if (instanceId && !hasInstanceId(mojits, instanceId)) {
-                	this.dispatcher.uncache(instanceId);
+                    this.dispatcher.uncache(instanceId);
                 }
 
                 // We don't manage binder children automatically, but any time a


### PR DESCRIPTION
- add method to dispatch.common to enable deleting cached
  controller contexts (cc caching occurs on the client only)
- check if cache cleanup needed during mojito-client destroyMojitProxy()
- other minor
