### PR TITLE
feature: models are optional for perf reasons

### DIFF
--- a/lib/app/addons/ac/models.common.js
+++ b/lib/app/addons/ac/models.common.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI*/
+
+/**
+ * @module ActionContextAddon
+ */
+YUI.add('mojito-models-addon', function (Y, NAME) {
+
+    'use strict';
+
+    /**
+     * <strong>Access point:</strong> <em>ac.models.*</em>
+     * Addon that provides access to the models collection
+     * @class Models.common
+     */
+    function Addon(command) {
+
+        var instance = command.instance,
+            config   = instance.config;
+
+        // making every model accessible through this addon
+        Y.Object.each(Y.mojito.models, function (model, modelName) {
+
+            // TODO: should we care about models that are not listed by
+            //       RS under instance.models? Are global models listed
+            //       there?
+            if (instance.models && instance.models[modelName]) {
+
+                // TODO: Why? There's no particular reason to inherit here.
+                // @caridy: we have to, otherwise this.something in the model
+                //          instance can be polluted.
+                var modelInstance = Y.mojito.util.heir(model);
+
+                if (Y.Lang.isFunction(modelInstance.init)) {
+                    // NOTE that we use the same config here that we use to
+                    // config the controller
+                    modelInstance.init(config);
+                }
+                this[modelName] = modelInstance;
+            }
+        }, this);
+    }
+
+
+    Addon.prototype = {
+
+        namespace: 'models'
+
+    };
+
+    Y.namespace('mojito.addons.ac').models = Addon;
+
+}, '0.1.0', {requires: [
+    'mojito'
+]});

--- a/lib/app/addons/ac/models.common.js
+++ b/lib/app/addons/ac/models.common.js
@@ -13,6 +13,12 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
 
     'use strict';
 
+    // TODO:
+    // - update tests
+    // - update fixtures
+    // - update documentation
+    // - update examples
+
     /**
      * <strong>Access point:</strong> <em>ac.models.*</em>
      * Addon that provides access to the models collection
@@ -39,9 +45,8 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
             // the ac object, this acts like an internal cache.
             if (Y.mojito.models[modelName] && !models[modelName]) {
 
-                // TODO: Why? There's no particular reason to inherit here.
-                // @caridy: we have to, otherwise this.something in the model
-                //          instance can be polluted.
+                // We have to heir() otherwise this.something in the model
+                // will pollute other instances of the model.
                 modelInstance = Y.mojito.util.heir(Y.mojito.models[modelName]);
 
                 if (Y.Lang.isFunction(modelInstance.init)) {

--- a/lib/app/addons/ac/models.common.js
+++ b/lib/app/addons/ac/models.common.js
@@ -20,32 +20,45 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
      */
     function Addon(command) {
 
-        var instance = command.instance,
-            config   = instance.config;
+        var models = {};
 
-        // making every model accessible through this addon
-        Y.Object.each(Y.mojito.models, function (model, modelName) {
+        /**
+         * Gets model instance
+         * @method get
+         * @param {string} modelName The name of the model.
+         * @return {object} model instance, or null.
+         */
+        // this is an experiment where "get" method uses the closure
+        // rather than be directly attached, to avoid storing
+        // a instance.config or models reference in the addon instance.
+        this.get = Y.bind(function (config, modelName) {
 
-            // TODO: should we care about models that are not listed by
-            //       RS under instance.models? Are global models listed
-            //       there?
-            if (instance.models && instance.models[modelName]) {
+            var modelInstance;
+
+            // instantanting the model once during the lifetime of
+            // the ac object, this acts like an internal cache.
+            if (Y.mojito.models[modelName] && !models[modelName]) {
 
                 // TODO: Why? There's no particular reason to inherit here.
                 // @caridy: we have to, otherwise this.something in the model
                 //          instance can be polluted.
-                var modelInstance = Y.mojito.util.heir(model);
+                modelInstance = Y.mojito.util.heir(Y.mojito.models[modelName]);
 
                 if (Y.Lang.isFunction(modelInstance.init)) {
                     // NOTE that we use the same config here that we use to
                     // config the controller
                     modelInstance.init(config);
                 }
-                this[modelName] = modelInstance;
-            }
-        }, this);
-    }
+                models[modelName] = modelInstance;
 
+            }
+
+            // returning from cache if exists
+            return models[modelName];
+
+        }, this, command.instance.config /* config (first arg) */);
+
+    }
 
     Addon.prototype = {
 

--- a/lib/app/archetypes/mojit/default/controller.server.js.hb
+++ b/lib/app/archetypes/mojit/default/controller.server.js.hb
@@ -29,7 +29,7 @@ YUI.add('{{name}}', function(Y, NAME) {
          *        to the Mojito API.
          */
         index: function(ac) {
-            ac.models.{{name}}ModelFoo.getData(function(err, data) {
+            ac.models.get('{{name}}ModelFoo').getData(function(err, data) {
                 if (err) {
                     ac.error(err);
                     return;
@@ -44,4 +44,4 @@ YUI.add('{{name}}', function(Y, NAME) {
 
     };
 
-}, '0.0.1', {requires: ['mojito', '{{name}}ModelFoo']});
+}, '0.0.1', {requires: ['mojito', 'mojito-models-addon', '{{name}}ModelFoo']});

--- a/lib/app/archetypes/mojit/full/controller.server.js.hb
+++ b/lib/app/archetypes/mojit/full/controller.server.js.hb
@@ -29,7 +29,7 @@ YUI.add('{{name}}', function(Y, NAME) {
          *        to the Mojito API.
          */
         index: function(ac) {
-            ac.models.{{name}}ModelFoo.getData(function(err, data) {
+            ac.models.get('{{name}}ModelFoo').getData(function(err, data) {
                 if (err) {
                     ac.error(err);
                     return;
@@ -44,4 +44,4 @@ YUI.add('{{name}}', function(Y, NAME) {
 
     };
 
-}, '0.0.1', {requires: ['mojito', '{{name}}ModelFoo']});
+}, '0.0.1', {requires: ['mojito', 'mojito-models-addon', '{{name}}ModelFoo']});


### PR DESCRIPTION
you should require model `mojito-models-addon` in your controller to access the default list of models through `ac.models.FooModelFoo` just like it was before.
