### PR TITLE
Search perf

### DIFF
--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -225,7 +225,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         for (addonName in dependencies) {
             if (dependencies.hasOwnProperty(addonName)) {
-                if (mods.indexOf(addonName + '-addon') > -1 || addonName === 'core') {
+                //if (mods.indexOf(addonName + '-addon') > -1 || addonName === 'core') {
                     addon = new addons[addonName](command, adapter, ac);
                     if (addon.namespace) {
                         ac[addon.namespace] = addon;
@@ -233,7 +233,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                             addon.setStore(store);
                         }
                     }
-                }
+                //}
             }
         }
     }

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -548,6 +548,26 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 config,
                 perf;
 
+            console.log();
+            console.log();
+            console.log();
+            console.log();
+            console.log();
+            console.log(cacheKey);
+
+            /*
+            Y.Object.each(this._expandInstanceCache[env], function (v, k) {
+                console.log('key', Y.Object.keys(v || {}), k);
+            });
+            */
+
+            console.log();
+            console.log();
+            console.log();
+            console.log();
+            console.log();
+            console.log();
+
             if (cacheValue) {
                 cb(null, cacheValue);
                 return;
@@ -586,8 +606,9 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 spec.config = config;
             }
 
-            this._expandInstanceCache[env][cacheKey] = Object.freeze(spec);
-            cb(null, spec);
+            this._expandInstanceCache[env][cacheKey] = spec;
+            cb(null, Y.mojito.util.copy(spec));
+            //cb(null, spec);
         },
 
 

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -548,26 +548,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 config,
                 perf;
 
-            console.log();
-            console.log();
-            console.log();
-            console.log();
-            console.log();
-            console.log(cacheKey);
-
-            /*
-            Y.Object.each(this._expandInstanceCache[env], function (v, k) {
-                console.log('key', Y.Object.keys(v || {}), k);
-            });
-            */
-
-            console.log();
-            console.log();
-            console.log();
-            console.log();
-            console.log();
-            console.log();
-
             if (cacheValue) {
                 cb(null, cacheValue);
                 return;
@@ -608,7 +588,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             this._expandInstanceCache[env][cacheKey] = spec;
             cb(null, Y.mojito.util.copy(spec));
-            //cb(null, spec);
         },
 
 

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -541,7 +541,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          */
         expandInstanceForEnv: function(env, instance, ctx, cb) {
 
-            var cacheKey = JSON.stringify([instance, ctx]),
+            var cacheKey = JSON.stringify([instance.action, instance.base, action.id, action.type, ctx]),
                 cacheValue = this._expandInstanceCache[env][cacheKey],
                 spec,
                 typeDetails,


### PR DESCRIPTION
9/12 by 6:30pm we discovered we should consider a subset of the actual instance as part of the cache key. otherwise things from the request may get included (post parameters, headers, get parameters, etc...)
