### PR TITLE
fixed multiple typos in the code example as well as typo in explanation ...

### DIFF
--- a/docs/dev_guide/code_exs/route_config.rst
+++ b/docs/dev_guide/code_exs/route_config.rst
@@ -33,7 +33,7 @@ is created, which can then be associated in a route defined in ``routes.json``.
    ]
 
 The example ``routes.json`` below associates the ``mapped_mojit`` instance defined in ``application.json`` with a path and explicitly calls the ``index`` action. If the controller for ``RoutingMojit`` had the function ``myFunction``, 
-you could would use the following to call it: ``mapped_mojit.myFunction``.   Based on the ``custom-route`` route below, when an HTTP GET call is made on the URL ``http:{domain}:8666/custom-route``, 
+you would use the following to call it: ``mapped_mojit.myFunction``.   Based on the ``custom-route`` route below, when an HTTP GET call is made on the URL ``http:{domain}:8666/custom-route``, 
 the ``index`` action is called from the ``custom-route`` instance.
 
 .. code-block:: javascript
@@ -64,11 +64,11 @@ method ``post_params`` from the ``post-route`` mojit instance.
          "verbs": ["get"],
          "path": "/custom-route",
          "call": "mapped_mojit.index"
-       }
+       },
        "another-route": {
-         "verbs": ["post"]
+         "verbs": ["post"],
          "path": "/*",
-         "call": mojit-post-route.post_params"
+         "call": "mojit-post-route.post_params"
        }
      }
    ]


### PR DESCRIPTION
The code in the third code example of http://developer.yahoo.com/cocktails/mojito/docs/code_exs/route_config.html has three bugs/typos which prevent it from being parsed as valid JSON.  I added missing commas and quotes so that you could copy and paste the code.  Also fixed the sentence: "you could would use the following to call it"
