### PR TITLE
fix some store unit tests in develop-perf

### DIFF
--- a/lib/app/commands/build.js
+++ b/lib/app/commands/build.js
@@ -80,6 +80,9 @@ exports.run = function(params, options, callback) {
             'mojito-util': {
                 fullpath: libpath.join(__dirname, '../../app/autoload/util.common.js')
             },
+            'mojito-perf': {
+                fullpath: libpath.join(__dirname, '../../app/autoload/perf.server.js')
+            },
             'mojito-resource-store': {
                 fullpath: libpath.join(__dirname, '../../store.server.js')
             }

--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -198,6 +198,9 @@ function makeStore(cfg) {
             'mojito-util': {
                 fullpath: libpath.join(__dirname, '../../app/autoload/util.common.js')
             },
+            'mojito-perf': {
+                fullpath: libpath.join(__dirname, '../../app/autoload/perf.server.js')
+            },
             'mojito-resource-store': {
                 fullpath: libpath.join(__dirname, '../../store.server.js')
             }

--- a/lib/app/commands/gv.js
+++ b/lib/app/commands/gv.js
@@ -443,6 +443,9 @@ run = function(params, options) {
             'mojito-util': {
                 fullpath: libpath.join(__dirname, '../../app/autoload/util.common.js')
             },
+            'mojito-perf': {
+                fullpath: libpath.join(__dirname, '../../app/autoload/perf.server.js')
+            },
             'mojito-resource-store': {
                 fullpath: libpath.join(__dirname, '../../store.server.js')
             }

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -703,6 +703,9 @@ runTests = function(opts) {
                     'mojito-util': {
                         fullpath: pathlib.join(targetMojitoPath, 'lib/app/autoload/util.common.js')
                     },
+                    'mojito-perf': {
+                        fullpath: libpath.join(__dirname, 'lib/app/autoload/perf.server.js')
+                    },
                     'mojito-resource-store': {
                         fullpath: pathlib.join(targetMojitoPath, 'lib/store.server.js')
                     }

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -704,7 +704,7 @@ runTests = function(opts) {
                         fullpath: pathlib.join(targetMojitoPath, 'lib/app/autoload/util.common.js')
                     },
                     'mojito-perf': {
-                        fullpath: libpath.join(__dirname, 'lib/app/autoload/perf.server.js')
+                        fullpath: pathlib.join(targetMojitoPath, 'lib/app/autoload/perf.server.js')
                     },
                     'mojito-resource-store': {
                         fullpath: pathlib.join(targetMojitoPath, 'lib/store.server.js')

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,6 +145,9 @@ MojitoServer.prototype = {
                 'mojito-util': {
                     fullpath: libpath.join(__dirname, 'app/autoload/util.common.js')
                 },
+                'mojito-perf': {
+                    fullpath: libpath.join(__dirname, 'app/autoload/perf.server.js')
+                },
                 'mojito-resource-store': {
                     fullpath: libpath.join(__dirname, 'store.server.js')
                 }

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -1972,5 +1972,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 }, '0.0.1', { requires: [
     'base',
     'oop',
-    'mojito-util'
+    'mojito-util',
+    'mojito-perf'
 ]});

--- a/lib/tests/autoload/app/autoload/action-context-tests.common.js
+++ b/lib/tests/autoload/app/autoload/action-context-tests.common.js
@@ -61,7 +61,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     instance: {
                         type: 'Type',
                         config: 'instance config',
-                        views: 'views'
+                        views: 'views',
+                        yui: { sorted: [] }
                     }
                 },
                 models: {},
@@ -113,7 +114,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     instance: {
                         type: 'Type',
                         config: 'instance config',
-                        views: 'views'
+                        views: 'views',
+                        yui: { sorted: [] }
                     }
                 },
                 models: {},
@@ -165,7 +167,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     instance: {
                         type: 'Type',
                         config: 'instance config',
-                        views: 'views'
+                        views: 'views',
+                        yui: { sorted: [] }
                     }
                 },
                 models: {},
@@ -216,7 +219,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     instance: {
                         type: 'Type',
                         config: 'instance config',
-                        views: 'views'
+                        views: 'views',
+                        yui: { sorted: [] }
                     }
                 },
                 controller: {index: function() {}},
@@ -309,7 +313,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     instance: {
                         type: 'Type',
                         config: 'instance config',
-                        views: 'views'
+                        views: 'views',
+                        yui: { sorted: [] }
                     }
                 },
                 models: {},
@@ -358,7 +363,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
 //                        id: 'id',
 //                        type: 'Type',
 //                        action: 'index',
-//                        config: 'instance config'
+//                        config: 'instance config',
+//                        yui: { sorted: [] }
 //                    }
 //                },
 //                controller: controller,
@@ -405,6 +411,7 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
 //                        type: 'Type',
 //                        action: 'index',
 //                        config: 'instance config'
+//                        yui: { sorted: [] }
 //                    }
 //                },
 //                controller: {index: function() {}},
@@ -446,6 +453,8 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
 //                        type: 'Type',
 //                        action: 'foo',
 //                        config: 'instance config'
+//                        yui: { sorted: [] }
+//                    }
 //                    }
 //                },
 //                controller: controller,

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -55,7 +55,8 @@ YUI.add('mojito-mojit-proxy', function(Y, NAME) {});
 YUI.add('mojito-output-handler', function(Y, NAME) {});
 YUI.add('mojito-perf', function(Y, NAME) {
     Y.namespace('mojito').perf = {
-        mark: function () {}
+        mark: function () {},
+        timeline: function () { return { done: function() {} }; }
     };
 });
 YUI.add('mojito-resource-store', function(Y, NAME) {});


### PR DESCRIPTION
Doesn't fix all tests for store-server.

The `validateContext()` test will continue to fail until that method is reimplemented.

One `expanceInstanceForEnv()` test is still failing because `defaults.json` isn't being merged in for some reason.  I'm still looking into that.
