### PR TITLE
fixed the addons/ac/composite unit tests

### DIFF
--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -205,7 +205,6 @@ callback({
                 buffer = {},
                 content = {},
                 meta = {},
-                perfID,
                 perf;
 
             cfg.children = cfg.children || {};
@@ -216,8 +215,7 @@ callback({
                                 ' array. \'children\' must be an object.');
             }
 
-            perfID = Y.mojito.perf.idFromCommand(ac.command);
-            perf = Y.mojito.perf.timeline(NAME, 'execute', Y.Object.keys(cfg.children).join(','), perfID);
+            perf = Y.mojito.perf.timeline(NAME, 'execute', Y.Object.keys(cfg.children).join(','), ac.command);
 
             // check to ensure children doesn't have a null child
             // in which case it will be automatically discarded to
@@ -340,5 +338,6 @@ callback({
 }, '0.1.0', {requires: [
     'mojito',
     'mojito-util',
+    'mojito-perf',
     'mojito-params-addon'
 ]});


### PR DESCRIPTION
let the perf subsystem create the perfID from the command
