### PR TITLE
adding command.ActionContext support on ControllerContext

### DIFF
--- a/lib/app/autoload/controller-context.common.js
+++ b/lib/app/autoload/controller-context.common.js
@@ -110,7 +110,8 @@ YUI.add('mojito-controller-context', function(Y, NAME) {
                 config = command.instance.config,
                 // this is the action that will be executed
                 action = command.action,
-                ac;
+                ac,
+                o;
 
             // replace the non-expanded command instance with the proper
             // instance, that was already expanded when the controller context
@@ -132,14 +133,18 @@ YUI.add('mojito-controller-context', function(Y, NAME) {
 
             try {
                 // Note: ac var is here to appease jslint.
-                ac = new this.Y.mojito.ActionContext({
+                o = {
                     command: command,
                     controller: this.controller,
                     models: this.models,
                     dispatch: this.dispatch,
                     adapter: adapter,
                     store: this.store
-                });
+                };
+
+                ac = Y.Lang.isFunction(command.ActionContext) ?
+                    new command.ActionContext(o) :
+                    new this.Y.mojito.ActionContext(o);
 
                 // TODO: uncomment once above issue is repaired.
                 // ac.invoke(command, adapter);  // do it this way ;)


### PR DESCRIPTION
We have identified a scenario where, in certain cases, is necessary to execute arbitrary code after dispatching a mojit but before its controller gets executed. Once the ActionContext is the last mile before the controller, we would like to augment it. The way mojito is today, it is impossible to change the Y.mojito.ActionContext from inside any mojit (and expect those changes on the dispatch). The solution here would be to augment the command object which is passed around with an ActionContext property. It contains a replacement constructor to the standard ActionContext.
