### PR TITLE
Removed references to app.config in output-adapter addon

### DIFF
--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -51,8 +51,8 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             renderer = null,
             contentType,
             contentPath,
-            viewEngineOptions = (this.app && this.app.config &&
-                                 this.app.config.viewEngine) || {},
+            appConfig = this.config.getAppConfig(),
+            viewEngineOptions,
             perf = Y.mojito.perf.timeline('mojito', 'ac.done',
                 'time to execute ac.done process', this.command);
 
@@ -77,13 +77,13 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         meta.http.code = meta.http.code || 200;
         meta.http.headers = meta.http.headers || {};
         meta.view = meta.view || {};
+        viewEngineOptions = appConfig.viewEngine || {};
 
         // Cache all tempates by default
         meta.view.cacheTemplates = true;
 
-        if (this.app && this.app.config && this.app.config.cacheViewTemplates) {
-            meta.view.cacheTemplates = this.app.config.cacheViewTemplates ||
-                false;
+        if (appConfig.cacheViewTemplates) {
+            meta.view.cacheTemplates = appConfig.cacheViewTemplates || false;
         }
 
         // Check to see we need to serialize the data
@@ -197,8 +197,8 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
 
             contentPath = mojitView['content-path'];
             // this is mainly used by html5app
-            if (this.app.config.pathToRoot) {
-                contentPath = this.app.config.pathToRoot + contentPath;
+            if (appConfig.pathToRoot) {
+                contentPath = appConfig.pathToRoot + contentPath;
             }
 
             // optimize for server only
@@ -362,7 +362,6 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         ac.flush = flush;
         ac.done = done;
         ac.error = error;
-
     }
 
     Addon.prototype = {
@@ -372,6 +371,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
     Y.namespace('mojito.addons.ac').core = Addon;
 
 }, '0.1.0', {requires: [
+    'mojito-config-addon',
     'json-stringify',
     'event-custom-base',
     'mojito-view-renderer',

--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -51,7 +51,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             renderer = null,
             contentType,
             contentPath,
-            appConfig = this.config.getAppConfig(),
+            appConfig = this.app.config,
             viewEngineOptions,
             perf = Y.mojito.perf.timeline('mojito', 'ac.done',
                 'time to execute ac.done process', this.command);
@@ -371,7 +371,6 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
     Y.namespace('mojito.addons.ac').core = Addon;
 
 }, '0.1.0', {requires: [
-    'mojito-config-addon',
     'json-stringify',
     'event-custom-base',
     'mojito-view-renderer',

--- a/lib/tests/autoload/app/addons/ac/output-adapter-tests.common.js
+++ b/lib/tests/autoload/app/addons/ac/output-adapter-tests.common.js
@@ -15,7 +15,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
 
         'flush calls done with "more"': function() {
             var doneCalled;
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             new Y.mojito.addons.ac.core({}, null, ac);
 
             ac.done = function(data, meta, more) {
@@ -31,7 +37,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with string data, done renders a string without templating': function() {
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var doneCalled;
             ac._adapter = {
                 done: function(data, meta) {
@@ -53,7 +65,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with string data and Content-Type header set, done respects the type': function() {
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var doneCalled;
             ac._adapter = {
                 done: function(data, meta) {
@@ -81,7 +99,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with "json" meta string, done renders a string with json content type': function() {
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var doneCalled;
             var json = {hi:'there'};
             ac._adapter = {
@@ -103,7 +127,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with "xml" meta string, done renders a string with xml content type': function() {
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var doneCalled;
             var json = {hi:'there'};
             ac._adapter = {
@@ -125,7 +155,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when there is no view meta, adapter is called directly': function() {
-            var ac = {};
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var doneCalled;
             var data = 'data';
             var meta = {};
@@ -163,7 +199,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     }
                 };
             };
-            var ac = { app: { config: {} } };
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var data = {};
             var meta = { view: {name: 'viewName'} };
             ac._adapter = {
@@ -195,17 +237,29 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
 
 
         'Using cached renderers for context.runtime server': function() {
-            var ac = { app: { config: { viewEngine: { mockEngine: { foo: 'bar' } } } } };
+            var ac = {
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                }
+            };
             var mockdata = {};
             var mockmeta = { view: {name: 'viewName', id: 'viewId'} };
             var constorWasCalled = false;
             var renderWasCalled = false;
 
+            ac.config = {
+                getAppConfig: function() {
+                    return { viewEngine: { mockEngine: { foo: 'bar' } } };
+                }
+            };
             // mock view engine
             Y.mojito.addons.viewEngines.mockEngine = function(viewId, options) {
                 A.areEqual('', viewId, 'viewId should be empty');
-                OA.areEqual(ac.app.config.viewEngine,
-                            options, 
+                A.isNotUndefined(options.mockEngine, 'options.viewEngine is missing');
+                OA.areEqual(ac.config.getAppConfig().viewEngine.mockEngine,
+                            options.mockEngine, 
                             'options is missing');
                 constorWasCalled = true;
 
@@ -260,7 +314,11 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                 }
             };
             var ac = {
-                app: { config: {} },
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                },
                 command: {
                     instance: {
                         config: {
@@ -310,10 +368,11 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
             var rendered = false;
             var VR = Y.mojito.ViewRenderer;
             var ac = {
-                app: { config: { } },
+                config: {
+                    getAppConfig: function() { return {}; }
+                },
                 command: {
                     instance: {
-                        config: { },
                         views: {
                             myView : { }
                         }
@@ -346,10 +405,13 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
             var rendered = false;
             var VR = Y.mojito.ViewRenderer;
             var ac = {
-                app: { config: { } },
+                config: {
+                    getAppConfig: function() {
+                        return {};
+                    }
+                },
                 command: {
                     instance: {
-                        config: { },
                         views: {
                             myView : { }
                         }

--- a/lib/tests/autoload/app/addons/ac/output-adapter-tests.common.js
+++ b/lib/tests/autoload/app/addons/ac/output-adapter-tests.common.js
@@ -15,13 +15,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
 
         'flush calls done with "more"': function() {
             var doneCalled;
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             new Y.mojito.addons.ac.core({}, null, ac);
 
             ac.done = function(data, meta, more) {
@@ -37,13 +31,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with string data, done renders a string without templating': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             var doneCalled;
             ac._adapter = {
                 done: function(data, meta) {
@@ -55,6 +43,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                 }
             };
             var instance = {views: {}};
+            ac.app = { config: {} };
             ac.command = {instance: instance};
             new Y.mojito.addons.ac.core(null, null, ac);
 
@@ -65,13 +54,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with string data and Content-Type header set, done respects the type': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             var doneCalled;
             ac._adapter = {
                 done: function(data, meta) {
@@ -82,6 +65,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     A.areSame('my favorite type', ct[0]);
                 }
             };
+            ac.app = { config: {} };
             ac.command = {instance: {views: {}}};
             new Y.mojito.addons.ac.core(null, null, ac);
 
@@ -99,13 +83,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with "json" meta string, done renders a string with json content type': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             var doneCalled;
             var json = {hi:'there'};
             ac._adapter = {
@@ -117,6 +95,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     A.areSame('application/json; charset=utf-8', ct[0]);
                 }
             };
+            ac.app = { config: {} };
             ac.command = {instance: {views: {}}};
             new Y.mojito.addons.ac.core(null, null, ac);
 
@@ -127,13 +106,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when called with "xml" meta string, done renders a string with xml content type': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             var doneCalled;
             var json = {hi:'there'};
             ac._adapter = {
@@ -145,6 +118,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     A.areSame('application/xml; charset=utf-8', ct[0]);
                 }
             };
+            ac.app = { config: {} };
             ac.command = {instance: {views: {}}};
             new Y.mojito.addons.ac.core(null, null, ac);
 
@@ -155,13 +129,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
         },
 
         'when there is no view meta, adapter is called directly': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = {};
             var doneCalled;
             var data = 'data';
             var meta = {};
@@ -172,6 +140,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     A.areSame(meta, m, 'bad meta to done');
                 }
             };
+            ac.app = { config: {} };
             ac.command = {instance: {views: {}}};
             new Y.mojito.addons.ac.core(null, null, ac);
 
@@ -199,13 +168,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                     }
                 };
             };
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = { app: { config: {} } };
             var data = {};
             var meta = { view: {name: 'viewName'} };
             ac._adapter = {
@@ -237,29 +200,17 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
 
 
         'Using cached renderers for context.runtime server': function() {
-            var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                }
-            };
+            var ac = { app: { config: { viewEngine: { mockEngine: { foo: 'bar' } } } } };
             var mockdata = {};
             var mockmeta = { view: {name: 'viewName', id: 'viewId'} };
             var constorWasCalled = false;
             var renderWasCalled = false;
 
-            ac.config = {
-                getAppConfig: function() {
-                    return { viewEngine: { mockEngine: { foo: 'bar' } } };
-                }
-            };
             // mock view engine
             Y.mojito.addons.viewEngines.mockEngine = function(viewId, options) {
                 A.areEqual('', viewId, 'viewId should be empty');
-                A.isNotUndefined(options.mockEngine, 'options.viewEngine is missing');
-                OA.areEqual(ac.config.getAppConfig().viewEngine.mockEngine,
-                            options.mockEngine, 
+                OA.areEqual(ac.app.config.viewEngine,
+                            options, 
                             'options is missing');
                 constorWasCalled = true;
 
@@ -314,11 +265,7 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
                 }
             };
             var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                },
+                app: { config: {} },
                 command: {
                     instance: {
                         config: {
@@ -368,11 +315,10 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
             var rendered = false;
             var VR = Y.mojito.ViewRenderer;
             var ac = {
-                config: {
-                    getAppConfig: function() { return {}; }
-                },
+                app: { config: { } },
                 command: {
                     instance: {
+                        config: { },
                         views: {
                             myView : { }
                         }
@@ -405,13 +351,10 @@ YUI.add('mojito-output-adapter-addon-tests', function(Y, NAME) {
             var rendered = false;
             var VR = Y.mojito.ViewRenderer;
             var ac = {
-                config: {
-                    getAppConfig: function() {
-                        return {};
-                    }
-                },
+                app: { config: { } },
                 command: {
                     instance: {
+                        config: { },
                         views: {
                             myView : { }
                         }

--- a/lib/tests/autoload/app/addons/view-engines/mu-tests.server.js
+++ b/lib/tests/autoload/app/addons/view-engines/mu-tests.server.js
@@ -53,10 +53,13 @@ YUI.add('mojito-mu-tests', function(Y, NAME) {
                 ac;
 
             mockOptions = { mu: { bufferOutput: true } };
-            ac = { app: {
-                config: { 
-                    viewEngine: mockOptions
-                } } };
+            ac = {
+                config: {
+                    getAppConfig: function() {
+                        return { viewEngine: mockOptions }
+                    }
+                }
+            };
             ac._adapter = {
                 done: function(data, meta) {},
                 flush: function(data, meta) {}

--- a/lib/tests/autoload/app/addons/view-engines/mu-tests.server.js
+++ b/lib/tests/autoload/app/addons/view-engines/mu-tests.server.js
@@ -54,9 +54,9 @@ YUI.add('mojito-mu-tests', function(Y, NAME) {
 
             mockOptions = { mu: { bufferOutput: true } };
             ac = {
-                config: {
-                    getAppConfig: function() {
-                        return { viewEngine: mockOptions }
+                app: {
+                    config: {
+                        viewEngine: mockOptions
                     }
                 }
             };

--- a/lib/tests/autoload/app/autoload/action-context-tests.common.js
+++ b/lib/tests/autoload/app/autoload/action-context-tests.common.js
@@ -77,6 +77,11 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     }
                 }
             });
+            ac.config = {
+                getAppConfig: function() {
+                    return 'app config';
+                }
+            };
 
             ac._adapter = {
                 flush: function (data, meta) {
@@ -130,6 +135,11 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     }
                 }
             });
+            ac.config = {
+                getAppConfig: function() {
+                    return 'app config';
+                }
+            };
 
             ac._adapter = {
                 done: function (data, meta) {

--- a/lib/tests/autoload/app/autoload/action-context-tests.common.js
+++ b/lib/tests/autoload/app/autoload/action-context-tests.common.js
@@ -77,11 +77,6 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     }
                 }
             });
-            ac.config = {
-                getAppConfig: function() {
-                    return 'app config';
-                }
-            };
 
             ac._adapter = {
                 flush: function (data, meta) {
@@ -135,11 +130,6 @@ YUI.add('mojito-action-context-tests', function(Y, NAME) {
                     }
                 }
             });
-            ac.config = {
-                getAppConfig: function() {
-                    return 'app config';
-                }
-            };
 
             ac._adapter = {
                 done: function (data, meta) {


### PR DESCRIPTION
FIX removed references to app.config and replaced with ac.config.getAppConfig(); updated unit tests

This PR superceds https://github.com/yahoo/mojito/pull/559.
