### PR TITLE
no longer use resource store adapter

### DIFF
--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -154,7 +154,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
                 useOnDemand = true;
             }
 
-            urls = store.store.getAllURLs();
+            urls = store.getAllURLs();
 
             // Set the YUI URL to use on the client (This has to be done
             // before any other scripts are added)
@@ -178,7 +178,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
                 yuiModules = ['yui'];
                 yuiJsUrlContains.yui = true;
                 if (useOnDemand) {
-                    fwConfig = store.store.getFrameworkConfig();
+                    fwConfig = store.getFrameworkConfig();
                     yuiModules.push('get');
                     yuiJsUrlContains.get = true;
                     yuiModules.push('loader-base');
@@ -241,7 +241,7 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
             // fw & app scripts.
             if (useOnDemand) {
                 // add all framework-level and app-level code
-                this.addScripts('bottom', store.store.yui.getConfigShared(
+                this.addScripts('bottom', store.yui.getConfigShared(
                     'client',
                     contextClient
                 ).modules, false);

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -283,7 +283,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                 actionFunction = '__call';
             } else {
                 // If there is still no joy then die
-                error = new Error("No method '" + opts.command.action + "' on controller type '" + opts.instance.type + "'");
+                error = new Error("No method '" + command.action + "' on controller type '" + command.instance.type + "'");
                 error.code = 404;
                 throw error;
             }

--- a/lib/app/autoload/dispatch.common.js
+++ b/lib/app/autoload/dispatch.common.js
@@ -75,9 +75,9 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
         var perf = Y.mojito.perf.timeline('mojito', 'dispatch:expandInstance',
                 'gather details about mojit', command);
 
-        store.store.validateContext(command.context);
+        store.validateContext(command.context);
 
-        store.store.expandInstance(command.instance, command.context, function(err, instance) {
+        store.expandInstance(command.instance, command.context, function(err, instance) {
 
             var yuiObj,
                 groups = {},

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -394,14 +394,11 @@ YUI.add('mojito-client', function(Y, NAME) {
                 this.tunnel = new Y.mojito.TunnelClient(config.appConfig);
             }
 
-            // Make the "Resource Store" by wrapping it with the adapter
-            this.resourceStore = new Y.mojito.ResourceStore(config);
 
             // the resource store adapter and the dispatcher must be passed the
             // mojito logger object, because they were created within a Y scope
             // that still has reference to the original Y.log function
-            this.resourceStore = Y.mojito.ResourceStoreAdapter.init('client',
-                this.resourceStore, YUI._mojito.logger);
+            this.resourceStore = new Y.mojito.ResourceStore(config);
             this.dispatcher = Y.mojito.Dispatcher.init(this.resourceStore,
                 null, YUI._mojito.logger, YUI._mojito.loader);
 
@@ -730,7 +727,7 @@ YUI.add('mojito-client', function(Y, NAME) {
 
         doRender: function(mp, data, view, cb) {
             if (!mp._views || !mp._assetsRoot) {
-                this.resourceStore.getType('client', mp.type, mp.context,
+                this.resourceStore.expandInstanceForEnv('client', {type: mp.type}, mp.context,
                     function(err, typeInfo) {
                         if (err) {
                             cb(new Error(

--- a/lib/app/autoload/store.client.js
+++ b/lib/app/autoload/store.client.js
@@ -60,7 +60,7 @@ YUI.add('mojito-client-store', function(Y, NAME) {
     };
 
 
-    retrieveFile = function(url, callback) {
+    retrieveFile = function(url, cb) {
         // iOS has a bug that returns "failure" on "success".
         var onComplete = function(id, obj) {
             CACHE[url] = {};
@@ -75,7 +75,7 @@ YUI.add('mojito-client-store', function(Y, NAME) {
 
         // use the cache first
         if (CACHE[url]) {
-            callback(null, CACHE[url]);
+            cb(null, CACHE[url]);
             return;
         }
 
@@ -89,7 +89,7 @@ YUI.add('mojito-client-store', function(Y, NAME) {
                 }
             });
         }
-        queue(url, callback);
+        queue(url, cb);
     };
 
 
@@ -132,11 +132,133 @@ YUI.add('mojito-client-store', function(Y, NAME) {
 
     ClientStore.prototype = {
 
-        /*
-         * TODO: REVIEW RE [Issue 76].
+        /**
+         * This just calls `expandInstanceForEnv()` with `env` set to `client`.
+         *
+         * @async
+         * @method expandInstance
+         * @param {map} instance partial instance to expand
+         * @param {object} ctx the context
+         * @param {function(err,instance)} cb callback used to return the results (or error)
          */
-        getSpec: function(env, id, context, callback) {
+        expandInstance: function(instance, ctx, cb) {
+            return this.expandInstanceForEnv('client', instance, ctx, cb);
+        },
 
+
+        /**
+         * Expands the instance into all details necessary to dispatch the mojit.
+         *
+         * @async
+         * @method expandInstanceForEnv
+         * @param {string} env the runtime environment (either `client` or `server`)
+         * @param {map} instance partial instance to expand
+         * @param {object} ctx the context
+         * @param {function(err,instance)} cb callback used to return the results (or error)
+         */
+        expandInstanceForEnv: function(env, instance, ctx, cb) {
+            var base = {},
+                source = {},
+                my = this;
+
+            if (!instance.instanceId) {
+                instance.instanceId = Y.guid();
+                //DEBUGGING:  instance.instanceId += '-instance-common-' +
+                //    [instance.base||'', instance.type||''].join('-');
+            }
+            // DEPRECATED, but kept in case a user is using.
+            instance.guid = instance.instanceId;
+
+            // What are being asked to expand?
+            if (instance.base) {
+                source.name = instance.base;
+                source.func = this._getSpec;
+            } else if (instance.type) {
+                source.name = instance.type;
+                source.func = this._getType;
+            } else {
+                // We don't have any inputs so fail
+                throw new Error('There was no info in the "instance" object');
+            }
+
+            // Here we get either the a spec or a type
+            source.func.call(this, env, source.name, ctx, function(err, data) {
+                if (err) {
+                    cb(err, {});
+                    return;
+                }
+
+                base = Y.mojito.util.mergeRecursive(data, instance);
+
+                // Ensure the "instance" has been properly resolved. If
+                // there are no specs in the application.json file, there is
+                // an error below because the instance is invalid. We should
+                // check here for a valid instance object and throw an error
+                // if it is not. This happens because someone could create a
+                // routes.json file with routes that don't route to mojit
+                // instances, and the URI router creates invalid commands,
+                // which are passed into the dispatch.
+                if (!my._validateInstance(base)) {
+                    cb(new Error('Instance was not valid. ' + Y.JSON.stringify(base)), {});
+                    return;
+                }
+
+                cb(null, base);
+            });
+
+        },
+
+
+        /**
+         * Returns a contextualized application configuration.
+         * @method getAppConfig
+         * @param {object} ctx the context
+         * @return {object} the application configuration contextualized by the "ctx" argument.
+         */
+        getAppConfig: function(ctx) {
+            return this.appConfig;
+        },
+
+
+        /**
+         * Returns the routes configured in the application.
+         * @method getRoutes
+         * @param {object} ctx the context
+         * @return {object} routes
+         */
+        getRoutes: function(ctx) {
+            return this.routes;
+        },
+
+
+        /**
+         * Validates the context, and throws an exception if it isn't.
+         * @method validateContext
+         * @param {object} ctx the context
+         * @return {nothing} if this method returns at all then the context is valid
+         */
+        validateContext: function(ctx) {
+            // This is OK since per-context caching (which is the main reason to
+            // make sure that the context matches the YCB dimensions) on the
+            // client is less sensitive to pollution by application code.
+            return true;
+        },
+
+
+        /**
+         * Returns, via callback, the fully expanded mojit instance specification.
+         *
+         * @private
+         * @async
+         * @method _getSpec
+         * @param {string} env the runtime environment (either `client` or `server`)
+         * @param {string} id the ID of the spec to return
+         * @param {object} ctx the runtime context for the spec
+         * @param {function} cb callback used to return the results (or error)
+         * @param {Error} cb.err error encountered, or a falsy value if no error
+         * @param {object} cb.spec the expanded mojit instance
+         */
+        _getSpec: function(env, id, context, cb) {
             var parts = id.split(':'),
                 typeName = parts[0],
                 specName = parts[1] || 'default',
@@ -150,50 +272,44 @@ YUI.add('mojito-client-store', function(Y, NAME) {
             url = this.staticPrefix + '/' + typeName + '/specs/' + specName +
                 '.json';
 
-            url = this.buildUrl(url, context);
+            url = this._buildUrl(url, context);
 
             // use the compiled version if there was one built
             if (isCompiled(ns, specName)) {
                 CACHE[url] = YUI._mojito._cache.compiled[ns].specs[specName];
-                callback(null, CACHE[url]);
+                cb(null, CACHE[url]);
                 return;
             }
 
-            retrieveFile(url, callback);
+            retrieveFile(url, cb);
         },
 
 
-        /*
-         * TODO: REVIEW RE [Issue 77]
+        /**
+         * Returns, via callback, the details of the mojit type.
+         *
+         * @private
+         * @async
+         * @method _getType
+         * @param {string} env the runtime environment (either `client` or `server`)
+         * @param {string} type the mojit type
+         * @param {object} ctx the runtime context for the type
+         * @param {function} cb callback used to return the results (or error)
+         * @param {Error} cb.err error encountered, or a falsy value if no error
+         * @param {object} cb.spec the mojit type details
          */
-        getType: function(env, type, context, callback) {
-
+        _getType: function(env, type, context, cb) {
             // This should really have the tunnelPrefix.  However, that
             // complicates offline apps (from `mojito build html5app`).
             // The mojito-handler-tunnel will be able to handle this URL
             // just fine.
             var url = this.staticPrefix + '/' + type + '/definition.json';
 
-            url = this.buildUrl(url, context);
+            url = this._buildUrl(url, context);
 
-            retrieveFile(url, callback);
+            retrieveFile(url, cb);
         },
 
-
-        /*
-         * TODO: REVIEW RE [Issue 78]
-         */
-        getAppConfig: function(context) {
-            return this.appConfig;
-        },
-
-
-        /*
-         * TODO: REVIEW RE [Issue 78]
-         */
-        getRoutes: function() {
-            return this.routes;
-        },
 
         /**
          * Checks the given URL and adds a context query string.
@@ -201,7 +317,7 @@ YUI.add('mojito-client-store', function(Y, NAME) {
          * @param context {Object} the runtime context
          * @return {String}
          */
-        buildUrl: function (url, context) {
+        _buildUrl: function (url, context) {
 
             if ('/' !== url.charAt(0)) {
                 url = '/' + url;
@@ -217,6 +333,14 @@ YUI.add('mojito-client-store', function(Y, NAME) {
             }
 
             return url;
+        },
+
+
+        _validateInstance: function(base) {
+            if (!base.type || !base.yui) {
+                return false;
+            }
+            return true;
         }
     };
 

--- a/lib/app/middleware/mojito-handler-tunnel.js
+++ b/lib/app/middleware/mojito-handler-tunnel.js
@@ -24,8 +24,8 @@ function trimSlash(str) {
 function TunnelServer() {}
 
 /*
-* ResourceStoreAdapter will call expandInstance and the TunnelServer is what
-* handles that. The header 'x-mojito-header' (read here and set in
+* store.client.js expandInstance() makes an RPC call to the TunnelServer.
+* The header 'x-mojito-header' (read here and set in
 * store.client.js) tells the server not to try to route the URL, it gets handled
 * by this critter. The targeted URL _might actually exist_ but we need to make
 * sure that it _does not_ if the mojito header is set to 'tunnel'.
@@ -86,16 +86,16 @@ TunnelServer.prototype = {
         };
     },
 
-    _handleSpec: function(req, res, next, type, basename) {
 
+    _handleSpec: function(req, res, next, type, basename) {
         var name,
             instance = {},
-            that = this;
+            my = this;
 
         name = basename.split('.').slice(0, -1).join('.') || null;
 
         if (!type || !name) {
-            that._sendError(res, 'Not found: ' + req.url, 500);
+            my._sendError(res, 'Not found: ' + req.url, 500);
             return;
         }
 
@@ -105,44 +105,45 @@ TunnelServer.prototype = {
             instance.base += ':' + name;
         }
 
-        this._store.getSpec('client', instance.base, req.context,
+        this._store.expandInstanceForEnv('client', instance, req.context,
             function(err, data) {
                 if (err) {
-                    that._sendError(res, 'Error opening: ' + req.url + '\n' +
+                    my._sendError(res, 'Error opening: ' + req.url + '\n' +
                         err,
                         500
                         );
                     return;
                 }
-                that._sendData(res, data);
+                my._sendData(res, data);
             });
     },
 
-    _handleType: function(req, res, next, type) {
 
+    _handleType: function(req, res, next, type) {
         var instance = {},
-            that = this;
+            my = this;
 
         if (!type) {
-            that._sendError(res, 'Not found: ' + req.url, 500);
+            my._sendError(res, 'Not found: ' + req.url, 500);
             return;
         }
 
         instance.type = type;
 
-        this._store.getType('client', instance.type, req.context,
+        this._store.expandInstanceForEnv('client', instance, req.context,
             function(err, data) {
                 if (err) {
-                    that._sendError(res, 'Error opening: ' + req.url + '\n' +
+                    my._sendError(res, 'Error opening: ' + req.url + '\n' +
                         err,
                         'debug',
                         'Tunnel:specs'
                         );
                     return;
                 }
-                that._sendData(res, data);
+                my._sendData(res, data);
             });
     },
+
 
     _handleRpc: function(req, res, next) {
         var data = req.body,
@@ -164,6 +165,7 @@ TunnelServer.prototype = {
                 // replace with the expanded instance
                 command.instance = inst;
                 req.command = {
+                    action: command.action,
                     instance: {
                         // Magic here to delegate to tunnelProxy.
                         base: 'tunnelProxy'

--- a/lib/app/mojits/TunnelProxy/controller.server.js
+++ b/lib/app/mojits/TunnelProxy/controller.server.js
@@ -99,5 +99,6 @@ YUI.add('TunnelProxy', function(Y, NAME) {
 
 }, '0.1.0', {requires: [
     'mojito-http-addon',
+    'mojito-params-addon',
     'mojito-util'
 ]});

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,9 +257,8 @@ MojitoServer.prototype = {
             context: options.context
         };
 
-        // Pass the "Resource Store" by wrapping it with the adapter
         ric_dispatcher = Y.mojito.Dispatcher.init(
-            Y.mojito.ResourceStoreAdapter.init('server', store, logger),
+            store,
             CORE_YUI_MODULES,
             logger,
             loader

--- a/lib/store.server.js
+++ b/lib/store.server.js
@@ -478,54 +478,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
 
         /**
-         * Returns, via callback, the fully expanded mojit instance specification.
-         *
-         * @async
-         * @method getSpec
-         * @param {string} env the runtime environment (either `client` or `server`)
-         * @param {string} id the ID of the spec to return
-         * @param {object} ctx the runtime context for the spec
-         * @param {function(err,spec)} callback callback used to return the results (or error)
-         */
-        getSpec: function(env, id, ctx, callback) {
-            this.expandInstanceForEnv(env, {base: id}, ctx, function(err, obj) {
-                if (err) {
-                    callback(err);
-                    return;
-                }
-                if (env === 'client' && obj) {
-                    delete obj.assets;
-                }
-                callback(null, obj);
-            });
-        },
-
-
-        /**
-         * Returns, via callback, the details of the mojit type.
-         *
-         * @async
-         * @method getType
-         * @param {string} env the runtime environment (either `client` or `server`)
-         * @param {string} type the mojit type
-         * @param {object} ctx the runtime context for the type
-         * @param {function(err,spec)} callback callback used to return the results (or error)
-         */
-        getType: function(env, type, ctx, callback) {
-            this.expandInstanceForEnv(env, {type: type}, ctx, function(err, obj) {
-                if (err) {
-                    callback(err);
-                    return;
-                }
-                if (env === 'client' && obj) {
-                    delete obj.assets;
-                }
-                callback(null, obj);
-            });
-        },
-
-
-        /**
          * This just calls `expandInstanceForEnv()` with `env` set to `server`.
          *
          * @async
@@ -542,6 +494,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
         /**
          * Expands the instance into all details necessary to dispatch the mojit.
+         *
+         * @async
          * @method expandInstanceForEnv
          * @param {string} env the runtime environment (either `client` or `server`)
          * @param {object} instance

--- a/tests/unit/lib/app/addons/ac/test-deploy.server.js
+++ b/tests/unit/lib/app/addons/ac/test-deploy.server.js
@@ -52,14 +52,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 
@@ -151,14 +149,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 
@@ -228,14 +224,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 
@@ -320,14 +314,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 
@@ -403,14 +395,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 
@@ -486,14 +476,12 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 serializeClientStore: function() {
                     return 'clientstore';
                 },
-                store: {
-                    getAllURLs: function() { return {}; },
-                    getFrameworkConfig: function() {
-                        return { ondemandBaseYuiModules:[] };
-                    },
-                    yui: {
-                        getConfigShared: function() { return {}; }
-                    }
+                getAllURLs: function() { return {}; },
+                getFrameworkConfig: function() {
+                    return { ondemandBaseYuiModules:[] };
+                },
+                yui: {
+                    getConfigShared: function() { return {}; }
                 }
             });
 

--- a/tests/unit/lib/app/middleware/test-handler-tunnel.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel.js
@@ -37,6 +37,10 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     expandInstance: function(instance, context, callback) {
                         expandedContext = context;
                         callback(null, instance);
+                    },
+                    expandInstanceForEnv: function(env, instance, context, callback) {
+                        expandedContext = context;
+                        callback(null, instance);
                     }
                 },
                 globalLogger = null;
@@ -87,6 +91,10 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                         });
                     },
                     expandInstance: function(instance, context, callback) {
+                        expandedContext = context;
+                        callback(null, instance);
+                    },
+                    expandInstanceForEnv: function(env, instance, context, callback) {
                         expandedContext = context;
                         callback(null, instance);
                     }
@@ -180,8 +188,7 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     },
                     end: function(data) {
                         var expected = {
-                            "env": "client",
-                            "id": "MojitA:orange"
+                            "base": "MojitA:orange"
                         };
                         endCalls++;
                         A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
@@ -212,8 +219,7 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     },
                     end: function(data) {
                         var expected = {
-                            "env": "client",
-                            "id": "MojitA:orange"
+                            "base": "MojitA:orange"
                         };
                         endCalls++;
                         A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
@@ -244,7 +250,6 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     },
                     end: function(data) {
                         var expected = {
-                            "env": "client",
                             "type": "MojitA"
                         };
                         endCalls++;
@@ -276,7 +281,6 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     },
                     end: function(data) {
                         var expected = {
-                            "env": "client",
                             "type": "MojitA"
                         };
                         endCalls++;

--- a/tests/unit/lib/test-store.server.js
+++ b/tests/unit/lib/test-store.server.js
@@ -299,24 +299,6 @@ YUI().use(
                 cmp(post, pre);
             },
 
-            'call getSpec()': function() {
-                store.getSpec('server', 'test1', {}, function(err, instance) {
-                    A.areSame('test_mojit_1', instance.type);
-                    A.areSame('test1', instance.id);
-                    // ... and all the type-specific parts...
-                    A.areSame('/static/test_mojit_1/assets', instance.assetsRoot);
-                });
-            },
-
-            'call getType()': function() {
-                store.getType('server', 'test_mojit_1', {}, function(err, instance) {
-                    A.areSame('test_mojit_1', instance.type);
-                    A.isUndefined(instance.id);
-                    // ... and all the type-specific parts...
-                    A.areSame('/static/test_mojit_1/assets', instance.assetsRoot);
-                });
-            },
-
             'instance with base pointing to non-existant spec': function() {
                 var spec = { base: 'nonexistant' };
                 store.expandInstance(spec, {}, function(err, instance) {


### PR DESCRIPTION
- use duck typing to define the API for {client,server} stores
- moved the useful bits of the adapter into store.client (where it matters most)
- related cleanups
