### PR TITLE
attaching required ac addons

### DIFF
--- a/lib/app/addons/ac/analytics.common.js
+++ b/lib/app/addons/ac/analytics.common.js
@@ -72,7 +72,7 @@ YUI.add('mojito-analytics-addon', function(Y, NAME) {
          */
         store: function(val) {
             // if you don't like using our internal meta merge function,
-            // you can supply an AC addon that dependsOn this one, and call
+            // you can supply an AC addon that requires this one, and call
             // ac.analytics.setMergeFunction(fn) within the initializer.
             this[ANALYTICS] = this.mergeFunction(this[ANALYTICS], val);
             this.ac.meta.store(ANALYTICS, this[ANALYTICS]);
@@ -96,8 +96,6 @@ YUI.add('mojito-analytics-addon', function(Y, NAME) {
             }, scope);
         }
     };
-
-    AnalyticsAddon.dependsOn = ['meta'];
 
     Y.namespace('mojito.addons.ac').analytics = AnalyticsAddon;
 

--- a/lib/app/addons/ac/carrier.server.js
+++ b/lib/app/addons/ac/carrier.server.js
@@ -61,10 +61,10 @@ YUI.add('mojito-carrier-addon', function(Y, NAME) {
         }
     };
 
-    CarrierAddon.dependsOn = ['config', 'http'];
-
     Y.namespace('mojito.addons.ac').carrier = CarrierAddon;
 
 }, '0.1.0', {requires: [
-    'mojito'
+    'mojito',
+    'mojito-config-addon',
+    'mojito-http-addon'
 ]});

--- a/lib/app/addons/ac/cookie.server.js
+++ b/lib/app/addons/ac/cookie.server.js
@@ -75,8 +75,6 @@ YUI.add('mojito-cookie-addon', function(Y, NAME) {
         }
     };
 
-    Addon.dependsOn = ['http'];
-
     Y.namespace('mojito.addons.ac').cookie = Addon;
 
 }, '0.1.0', {requires: [

--- a/lib/app/addons/ac/device.server.js
+++ b/lib/app/addons/ac/device.server.js
@@ -56,10 +56,10 @@ YUI.add('mojito-device-addon', function(Y, NAME) {
         }
     };
 
-    DeviceAddon.dependsOn = ['config', 'http'];
-
     Y.namespace('mojito.addons.ac').device = DeviceAddon;
 
 }, '0.1.0', {requires: [
-    'mojito'
+    'mojito',
+    'mojito-config-addon',
+    'mojito-http-addon'
 ]});

--- a/lib/app/addons/ac/intl.common.js
+++ b/lib/app/addons/ac/intl.common.js
@@ -59,8 +59,6 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
         }
     };
 
-    IntlAddon.dependsOn = ['config'];
-
     Y.namespace('mojito.addons.ac').intl = IntlAddon;
 
 }, '0.1.0', {requires: [

--- a/lib/app/addons/ac/meta.common.js
+++ b/lib/app/addons/ac/meta.common.js
@@ -79,8 +79,6 @@ YUI.add('mojito-meta-addon', function(Y, NAME) {
         }
     };
 
-    MetaAddon.dependsOn = ['core'];
-
     Y.namespace('mojito.addons.ac').meta = MetaAddon;
 
 }, '0.1.0', {requires: [

--- a/lib/app/addons/rs/dispatch-helper.server.js
+++ b/lib/app/addons/rs/dispatch-helper.server.js
@@ -56,6 +56,7 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 posl = evt.args.posl,
                 poslKey = JSON.stringify(posl),
                 mojitType = evt.args.mojitType;
+            dest.acAddons = {};
             if (this.acAddons[env] && this.acAddons[env][poslKey] && this.acAddons[env][poslKey][mojitType]) {
                 dest.acAddons = this.acAddons[env][poslKey][mojitType];
             }
@@ -140,6 +141,7 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
     Y.namespace('mojito.addons.rs')['dispatch-helper'] = RSAddonDispatchHelper;
 
 }, '0.0.1', { requires: [
+    'addon-rs-yui',
     'plugin',
     'oop'
 ]});

--- a/lib/app/addons/rs/dispatch-helper.server.js
+++ b/lib/app/addons/rs/dispatch-helper.server.js
@@ -121,7 +121,9 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
             // setting up the proper namespace for the cache.
             this.acAddons[env] = this.acAddons[env] || {};
             this.acAddons[env][poslKey] = this.acAddons[env][poslKey] || {};
-            this.acAddons[env][poslKey][mojitType] = this.acAddons[env][poslKey][mojitType] || {};
+            // TODO: should we worry if this.acAddons[env][poslKey][mojitType] is set
+            //       at this point? It should never happen.
+            this.acAddons[env][poslKey][mojitType] = [];
 
             required[controllerYuiName] = true;
             // the language doesn't matter for this
@@ -130,7 +132,7 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 if (sorted.paths.hasOwnProperty(yuiName)) {
                     addonName = acAddonNames[yuiName];
                     if (addonName) {
-                        this.acAddons[env][poslKey][mojitType][addonName] = yuiName;
+                        this.acAddons[env][poslKey][mojitType].push(addonName);
                     }
                 }
             }

--- a/lib/app/addons/rs/dispatch-helper.server.js
+++ b/lib/app/addons/rs/dispatch-helper.server.js
@@ -16,22 +16,22 @@
  * RS addon that computes AC addon dependencies at startup to be attached
  * at runtime.
  *
- * @class RSAddonDispatcherHelper
+ * @class RSAddonDispatchHelper
  * @extension ResourceStore.server
  */
-YUI.add('addon-rs-dispatcher-helper', function (Y, NAME) {
+YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
 
     'use strict';
 
-    function RSAddonDispatcherHelper() {
-        RSAddonDispatcherHelper.superclass.constructor.apply(this, arguments);
+    function RSAddonDispatchHelper() {
+        RSAddonDispatchHelper.superclass.constructor.apply(this, arguments);
     }
 
 
-    RSAddonDispatcherHelper.NS = 'dispatcher-helper';
+    RSAddonDispatchHelper.NS = 'dispatch-helper';
 
 
-    Y.extend(RSAddonDispatcherHelper, Y.Plugin.Base, {
+    Y.extend(RSAddonDispatchHelper, Y.Plugin.Base, {
 
 
         initializer: function (config) {
@@ -137,7 +137,7 @@ YUI.add('addon-rs-dispatcher-helper', function (Y, NAME) {
 
     });
 
-    Y.namespace('mojito.addons.rs')['dispatcher-helper'] = RSAddonDispatcherHelper;
+    Y.namespace('mojito.addons.rs')['dispatch-helper'] = RSAddonDispatchHelper;
 
 }, '0.0.1', { requires: [
     'plugin',

--- a/lib/app/addons/rs/dispatcher-helper.server.js
+++ b/lib/app/addons/rs/dispatcher-helper.server.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*jslint anon:true, nomen:true*/
+/*global YUI*/
+
+
+/**
+ * @module ResourceStoreAddon
+ */
+
+/**
+ * RS addon that computes AC addon dependencies at startup to be attached
+ * at runtime.
+ *
+ * @class RSAddonDispatchHelper
+ * @extension ResourceStore.server
+ */
+YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
+
+    'use strict';
+
+    function RSAddonDispatchHelper() {
+        RSAddonDispatchHelper.superclass.constructor.apply(this, arguments);
+    }
+
+
+    RSAddonDispatchHelper.NS = 'dispatch-helper';
+
+
+    Y.extend(RSAddonDispatchHelper, Y.Plugin.Base, {
+
+
+        initializer: function (config) {
+            this.addons = {}; // env: poslKey: mojit: details
+            this.onHostEvent('mojitResourcesResolved', this.onMojitResourcesResolved, this);
+        },
+
+
+        /**
+         * This is called when the ResourceStore fires this event.
+         * It augments the mojit type details with the precomputed YUI module
+         * dependencies.
+         * @method onGetMojitTypeDetails
+         * @param {object} evt The fired event.
+         * @return {nothing}
+         */
+        onGetMojitTypeDetails: function (evt) {
+            var dest = evt.mojit,
+                env = evt.args.env,
+                ctx = evt.args.ctx,
+                posl = evt.args.posl,
+                poslKey = JSON.stringify(posl),
+                mojitType = evt.args.mojitType;
+
+            if (this.addons[env] && this.addons[env][poslKey]) {
+                dest.addons = this.addons[env][poslKey][mojitType];
+            }
+
+        },
+
+
+        /**
+         * This is called when the ResourceStore fires this event.
+         * It precomputes the YUI module dependencies, to be used later during
+         * onGetMojitTypeDetails.
+         * @method onMojitResourcesResolved
+         * @param {object} evt The fired event
+         * @return {nothing}
+         */
+        onMojitResourcesResolved: function (evt) {
+            var my = this,
+                env = evt.env,
+                posl = evt.posl,
+                poslKey = JSON.stringify(posl),
+                mojitType = evt.mojit,
+                ress = evt.ress,
+                controller,
+                res,
+                i;
+
+            if ('server' !== evt.env) {
+                return;
+            }
+
+            if (!evt.ress) {
+                return;
+            }
+
+            if ('shared' === mojitType) {
+                return;
+            }
+
+            for (i = 0; i < ress.length; i += 1) {
+                res = ress[i];
+                // console.log(res);
+                if (!res.yui || !res.yui.name) {
+                    continue;
+                }
+
+                // TODO: why can't we do the client affinity as well?
+                if ('client' === res.affinity.affinity) {
+                    continue;
+                }
+
+                if ('controller' === res.type) {
+                    controller = res.yui.name;
+                }
+            }
+
+            if (!controller) {
+                Y.log('Missing controller for mojit ' + evt.mojit, 'error', NAME);
+                return;
+            }
+
+            // setting up the proper namespace for the cache.
+            this.addons[env] = this.addons[env] || {};
+            this.addons[env][poslKey] = this.addons[env][poslKey] || {};
+
+            // requiring controller, as a result all the required addons
+            // will be attached in the right order.
+            YUI({
+                useSync: true
+            }).use(controller, 'mojito-output-adapter-addon', 'oop', function (YY) {
+
+                // caching the computed list of addon names for the current controller
+                my.addons[env][poslKey][mojitType] = Y.Object.keys(YY.namespace('mojito.addons.ac'));
+
+            });
+
+        }
+
+    });
+
+    Y.namespace('mojito.addons.rs')['dispatch-helper'] = RSAddonDispatchHelper;
+
+}, '0.0.1', { requires: [
+    'plugin',
+    'oop'
+]});

--- a/lib/app/addons/rs/dispatcher-helper.server.js
+++ b/lib/app/addons/rs/dispatcher-helper.server.js
@@ -16,27 +16,28 @@
  * RS addon that computes AC addon dependencies at startup to be attached
  * at runtime.
  *
- * @class RSAddonDispatchHelper
+ * @class RSAddonDispatcherHelper
  * @extension ResourceStore.server
  */
-YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
+YUI.add('addon-rs-dispatcher-helper', function (Y, NAME) {
 
     'use strict';
 
-    function RSAddonDispatchHelper() {
-        RSAddonDispatchHelper.superclass.constructor.apply(this, arguments);
+    function RSAddonDispatcherHelper() {
+        RSAddonDispatcherHelper.superclass.constructor.apply(this, arguments);
     }
 
 
-    RSAddonDispatchHelper.NS = 'dispatch-helper';
+    RSAddonDispatcherHelper.NS = 'dispatcher-helper';
 
 
-    Y.extend(RSAddonDispatchHelper, Y.Plugin.Base, {
+    Y.extend(RSAddonDispatcherHelper, Y.Plugin.Base, {
 
 
         initializer: function (config) {
-            this.addons = {}; // env: poslKey: mojit: details
+            this.acAddons = {}; // env: poslKey: mojit: details
             this.onHostEvent('mojitResourcesResolved', this.onMojitResourcesResolved, this);
+            this.onHostEvent('getMojitTypeDetails', this.onGetMojitTypeDetails, this);
         },
 
 
@@ -55,11 +56,9 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 posl = evt.args.posl,
                 poslKey = JSON.stringify(posl),
                 mojitType = evt.args.mojitType;
-
-            if (this.addons[env] && this.addons[env][poslKey]) {
-                dest.addons = this.addons[env][poslKey][mojitType];
+            if (this.acAddons[env] && this.acAddons[env][poslKey] && this.acAddons[env][poslKey][mojitType]) {
+                dest.acAddons = this.acAddons[env][poslKey][mojitType];
             }
-
         },
 
 
@@ -72,19 +71,21 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
          * @return {nothing}
          */
         onMojitResourcesResolved: function (evt) {
-            var my = this,
+            var store = this.get('host'),
                 env = evt.env,
                 posl = evt.posl,
                 poslKey = JSON.stringify(posl),
                 mojitType = evt.mojit,
-                ress = evt.ress,
-                controller,
+                r,
                 res,
-                i;
-
-            if ('server' !== evt.env) {
-                return;
-            }
+                ress = evt.ress,
+                controllerYuiName,
+                modules = {},
+                required = {},
+                sorted,
+                yuiName,
+                addonName,
+                acAddonNames = {};   // YUI module: addon name
 
             if (!evt.ress) {
                 return;
@@ -94,48 +95,49 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 return;
             }
 
-            for (i = 0; i < ress.length; i += 1) {
-                res = ress[i];
-                // console.log(res);
+            for (r = 0; r < ress.length; r += 1) {
+                res = ress[r];
                 if (!res.yui || !res.yui.name) {
                     continue;
                 }
-
-                // TODO: why can't we do the client affinity as well?
-                if ('client' === res.affinity.affinity) {
-                    continue;
-                }
-
                 if ('controller' === res.type) {
-                    controller = res.yui.name;
+                    controllerYuiName = res.yui.name;
+                    modules[res.yui.name] = this.get('host').yui._makeYUIModuleConfig(env, res);
+                }
+                if ('addon' === res.type && 'ac' === res.subtype) {
+                    modules[res.yui.name] = this.get('host').yui._makeYUIModuleConfig(env, res);
+                    acAddonNames[res.yui.name] = res.name;
                 }
             }
 
-            if (!controller) {
-                Y.log('Missing controller for mojit ' + evt.mojit, 'error', NAME);
+            if (!controllerYuiName) {
+                // It's not an error if a mojit is missing a controller, since
+                // some mojits only run on the server side (or only on the
+                // client side).
                 return;
             }
 
             // setting up the proper namespace for the cache.
-            this.addons[env] = this.addons[env] || {};
-            this.addons[env][poslKey] = this.addons[env][poslKey] || {};
+            this.acAddons[env] = this.acAddons[env] || {};
+            this.acAddons[env][poslKey] = this.acAddons[env][poslKey] || {};
+            this.acAddons[env][poslKey][mojitType] = this.acAddons[env][poslKey][mojitType] || {};
 
-            // requiring controller, as a result all the required addons
-            // will be attached in the right order.
-            YUI({
-                useSync: true
-            }).use(controller, 'mojito-output-adapter-addon', 'oop', function (YY) {
-
-                // caching the computed list of addon names for the current controller
-                my.addons[env][poslKey][mojitType] = Y.Object.keys(YY.namespace('mojito.addons.ac'));
-
-            });
-
+            required[controllerYuiName] = true;
+            // the language doesn't matter for this
+            sorted = store.yui._precomputeYUIDependencies('en', env, mojitType, modules, required);
+            for (yuiName in sorted.paths) {
+                if (sorted.paths.hasOwnProperty(yuiName)) {
+                    addonName = acAddonNames[yuiName];
+                    if (addonName) {
+                        this.acAddons[env][poslKey][mojitType][addonName] = yuiName;
+                    }
+                }
+            }
         }
 
     });
 
-    Y.namespace('mojito.addons.rs')['dispatch-helper'] = RSAddonDispatchHelper;
+    Y.namespace('mojito.addons.rs')['dispatcher-helper'] = RSAddonDispatcherHelper;
 
 }, '0.0.1', { requires: [
     'plugin',

--- a/lib/app/addons/rs/yui.server.js
+++ b/lib/app/addons/rs/yui.server.js
@@ -360,10 +360,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                     langs[res.name] = res;
                 }
                 if (res.yui && res.yui.name) {
-                    modules[res.yui.name] = {
-                        requires: res.yui.meta.requires,
-                        fullpath: (('client' === env) ? res.url : res.source.fs.fullPath)
-                    };
+                    modules[res.yui.name] = this._makeYUIModuleConfig(env, res);
                     if ('binder' === res.type) {
                         binders[res.name] = res;
                     }

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -208,10 +208,6 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         my = this;
 
-        // set some defaults
-        command.instance.yui = command.instance.yui || {};
-        command.instance.yui.sorted = command.instance.yui.sorted || [];
-
         this.action = command.action;
         this.type = command.instance.type;
         this.context = command.context;
@@ -221,6 +217,10 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         this.command = command;
         this.instance = command.instance;
         this._adapter = opts.adapter;
+
+        // TODO: this computation should not be executed here
+        // instead mojito-config-addon provides a way to
+        // access it. For now, it is needed on output-adapter
         this.app = {
             config: opts.store.getAppConfig(this.context),
             routes: opts.store.getRoutes(this.context)
@@ -258,99 +258,11 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         perf.done(); // closing the 'action:call' timeline
 
-        // return; // << RIC
-
-        // Y.log('constructing action context', 'mojito', 'qeperf');
-
-        // var self = this,
-        //     command = opts.command,
-        //     instance = command.instance,
-        //     controller = opts.controller,
-        //     models = opts.models,
-        //     dispatch = opts.dispatch,
-        //     adapter = opts.adapter,
-        //     store = opts.store,
-        //     actionFunction,
-        //     error,
-        //     perfID,
-        //     perf;
-
-        // // "init" is not an action
-        // if (command.action === 'init') {
-        //     throw new Error('Cannot execute action \'init\' on any mojit.' +
-        //         ' This name is reserved by the Mojito framework.');
-        // }
-
-        // // we want to make these easily accessible to any functions that addons
-        // // attach directly to the ac object.
-        // // TODO: These properties should be hidden behind accessor functions.
-        // this.command = command;
-        // this.instance = instance;
-        // this.action = command.action;
-        // this.type = instance.type;
-        // this.context = command.context;
-        // this.models = models;
-
-        // // identify this as internal... users probably won't want to use it, but
-        // // addons might need
-        // this._dispatch = dispatch;
-        // this._adapter = adapter;
-
-        // // deprecated this function for current users
-        // this.dispatch = function() {
-        //     Y.log('ac.dispatch() will soon be deprecated to discourage' +
-        //         ' usage from within controllers. If you want to dispatch' +
-        //         ' a command from within an ActionContext addon, please use' +
-        //         ' ac._dispatch().', 'warn', NAME);
-        //     self._dispatch.apply(self, arguments);
-        // };
-
-        // this.app = {
-        //     config: store.getAppConfig(this.context),
-        //     routes: store.getRoutes(this.context)
-        // };
-
-        // // this is where the addons list is injected onto the action
-        // // context...yay!
-        // attachActionContextAddons(Y.mojito.addons.ac, command, adapter, this, store);
-
-        // Y.log('ActionContext created for "' + (instance.id || '@' +
-        //     instance.type) + '/' + command.action + '"', 'mojito', NAME);
-
-        // // Grab the action here as me may change it
-        // actionFunction = command.action;
-
-        // // Check if the controller has the requested action
-        // if (!Y.Lang.isFunction(controller[actionFunction])) {
-        //     // If the action is not found try the '__call' function
-        //     if (Y.Lang.isFunction(controller.__call)) {
-        //         actionFunction = '__call';
-        //     } else {
-        //         // If there is still no joy then die
-        //         error = new Error("No method '" + command.action +
-        //             "' on controller type '" + instance.type + "'");
-        //         error.code = 404;
-        //         throw error;
-        //     }
-        // }
-
-        // Y.log('action context created, executing action "' + actionFunction +
-        //     '"', 'mojito', 'qeperf');
-
-        // controller[actionFunction](this);
     }
 
     Y.namespace('mojito').ActionContext = ActionContext;
 
 }, '0.1.0', {requires: [
-    // following are ACPs are always available
     'mojito-output-adapter-addon',
     'mojito-perf'
-    // << RIC
-    // 'mojito-config-addon',
-    // 'mojito-url-addon',
-    // 'mojito-assets-addon',
-    // 'mojito-cookie-addon',
-    // 'mojito-params-addon',
-    // 'mojito-composite-addon',
 ]});

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -5,7 +5,7 @@
  */
 
 
-/*jslint anon:true, sloppy:true, nomen:true*/
+/*jslint anon:true, nomen:true*/
 /*global YUI*/
 
 
@@ -17,6 +17,8 @@
  * @module ActionContext
  */
 YUI.add('mojito-action-context', function(Y, NAME) {
+
+    'use strict';
 
     // -------------------------------------------------------------------------
     // Comments below are so generated comments for flush, done, etc. are found
@@ -159,6 +161,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
     function attachActionContextAddons(addons, command, adapter, ac, store) {
 
         var i,
+            addon,
             addonName,
             acAddons = command.instance.acAddons || [];
 

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -18,9 +18,6 @@
  */
 YUI.add('mojito-action-context', function(Y, NAME) {
 
-    var CACHE;
-
-
     // -------------------------------------------------------------------------
     // Comments below are so generated comments for flush, done, etc. are found
     // on ActionContext even though they're not really done here.
@@ -149,45 +146,6 @@ YUI.add('mojito-action-context', function(Y, NAME) {
      *     above.
      */
 
-    // TODO: probably should move to mojito.common.js (namespace definitions).
-    if (!YUI._mojito) {
-        YUI._mojito = {};
-    }
-
-    if (!YUI._mojito._cache) {
-        YUI._mojito._cache = {};
-    }
-
-    if (!YUI._mojito._cache.addons) {
-        YUI._mojito._cache.addons = {};
-    }
-
-    CACHE = YUI._mojito._cache.addons;
-
-
-    function calculateAddonDependencies(addon, addons, dependencies) {
-        var dep,
-            dependsOn = addon.dependsOn,
-            i;
-
-        if (!Y.Lang.isArray(dependsOn)) {
-            return;
-        }
-
-        for (i = 0; i < dependsOn.length; i += 1) {
-            dep = dependsOn[i];
-            if (!dependencies[dep]) {
-                if (!addons[dep]) {
-                    throw new Error(addon.prototype.namespace +
-                        " addon has invalid dependency: '" + dep + "'");
-                }
-                calculateAddonDependencies(addons[dep], addons, dependencies);
-            }
-            dependencies[dep] = true;
-        }
-    }
-
-
     /**
      * Mixes all the Action Context addons into the Action Context
      * @private
@@ -200,40 +158,33 @@ YUI.add('mojito-action-context', function(Y, NAME) {
      */
     function attachActionContextAddons(addons, command, adapter, ac, store) {
 
-        var addonName,
-            addon,
-            dependencies = {},
-            // TODO: list of required addons will be provided by RS
-            mods = command.instance.yui.sorted;
+        var i,
+            addonName,
+            acAddons = command.instance.acAddons || [];
 
-        mods = mods.join(' ');
+        // adding 'core' addon at the begining (from output-adapter)
+        // as the default addon support ac.done/error/flush)
+        // TODO: we might merge AC and output-adapter since it
+        //       looks like a hack.
+        acAddons.unshift('core');
 
-        if (CACHE[ac.type]) {
-            dependencies = CACHE[ac.type];
-        } else {
-            for (addonName in addons) {
-                if (addons.hasOwnProperty(addonName)) {
-                    if (!dependencies[addonName]) {
-                        calculateAddonDependencies(addons[addonName], addons,
-                            dependencies);
-                    }
-                    dependencies[addonName] = true;
-                }
-            }
-            CACHE[ac.type] = dependencies;
-        }
-
-        for (addonName in dependencies) {
-            if (dependencies.hasOwnProperty(addonName)) {
-                if (mods.indexOf(addonName) > -1 || addonName === 'core') {
-                    addon = new addons[addonName](command, adapter, ac);
-                    if (addon.namespace) {
-                        ac[addon.namespace] = addon;
-                        if (Y.Lang.isFunction(addon.setStore)) {
-                            addon.setStore(store);
-                        }
+        for (i = 0; i < acAddons.length; i += 1) {
+            addonName = acAddons[i];
+            if (addons[addonName]) {
+                addon = new addons[addonName](command, adapter, ac);
+                if (addon.namespace) {
+                    ac[addon.namespace] = addon;
+                    // TODO: this is a big hack to pass the store reference
+                    // into the addon without changing the signature of ctor,
+                    // instead we should pass an object with all the stuff that
+                    // an addon will need as part of the ctor.
+                    if (Y.Lang.isFunction(addon.setStore)) {
+                        addon.setStore(store);
                     }
                 }
+            } else {
+                Y.log('[' + addonName + '] addon was not found for mojit ' + command.instance.type,
+                    'warn', NAME);
             }
         }
     }

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -37,6 +37,7 @@ YUI.add('mojito-url-addon', function(Y, NAME) {});
 
 /* RS ADDONS */
 YUI.add('addon-rs-config', function(Y, NAME) {});
+YUI.add('addon-rs-dispatch-helper', function(Y, NAME) {});
 YUI.add('addon-rs-selector', function(Y, NAME) {});
 YUI.add('addon-rs-url', function(Y, NAME) {});
 YUI.add('addon-rs-yui', function(Y, NAME) {});

--- a/tests/fixtures/gsg5/mojits/PagedFlickr/controller.common.js
+++ b/tests/fixtures/gsg5/mojits/PagedFlickr/controller.common.js
@@ -87,4 +87,11 @@ YUI.add('PagedFlickr', function(Y) {
         return ac.url.make(mojitType, 'index', Y.QueryString.stringify(params));
     }
 
-}, '0.0.1', {requires: ['mojito-intl-addon', 'mojito-util', 'querystring-stringify', 'ModelFlickr'], lang: ['de', 'en-US']});
+}, '0.0.1', {requires: [
+    'mojito-intl-addon',
+    'mojito-params-addon',
+    'mojito-url-addon',
+    'mojito-util',
+    'querystring-stringify',
+    'ModelFlickr'
+], lang: ['de', 'en-US']});

--- a/tests/func/applications/frameworkapp/common/mojits/TestsLayout/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/TestsLayout/controller.common.js
@@ -74,4 +74,4 @@ YUI.add('TestsLayout', function(Y, NAME) {
 		}
     };
 
-}, '0.0.1', {requires: ['mojito', 'mojito-config-addon']});
+}, '0.0.1', {requires: ['mojito', 'mojito-composite-addon', 'mojito-config-addon']});

--- a/tests/func/applications/frameworkapp/common/mojits/TestsLayout/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/TestsLayout/controller.common.js
@@ -74,4 +74,4 @@ YUI.add('TestsLayout', function(Y, NAME) {
 		}
     };
 
-}, '0.0.1', {requires: ['mojito']});
+}, '0.0.1', {requires: ['mojito', 'mojito-config-addon']});

--- a/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
+++ b/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
@@ -16,6 +16,14 @@
                 },
                 "group": "fw,server"
             },
+            "dispatch-helper.server": {
+                "params": {
+                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.server.js,../../../../../../lib/app/addons/rs/config.server.js,../../../../../../lib/app/addons/rs/selector.server.js,../../../../../../lib/app/addons/rs/yui.server.js,../../../../../../lib/store.server.js",
+                    "test": "./test-dispatch-helper.server.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,server"
+            },
             "selector.server": {
                 "params": {
                     "lib": "$$config.lib$$/app/addons/rs/selector.server.js,../../../../../../lib/app/addons/rs/config.server.js",

--- a/tests/unit/lib/app/addons/rs/test-dispatch-helper.server.js
+++ b/tests/unit/lib/app/addons/rs/test-dispatch-helper.server.js
@@ -12,7 +12,7 @@ YUI().use(
     'json',
     'test',
     function(Y) {
-    
+
     var suite = new YUITest.TestSuite('mojito-addon-rs-dispatch-helper-tests'),
         libpath = require('path'),
         mojitoRoot = libpath.join(__dirname, '../../../../../../lib'),
@@ -20,9 +20,9 @@ YUI().use(
 
 
     suite.add(new YUITest.TestCase({
-        
+
         name: 'dispatch-helper rs addon tests',
-        
+
 
         'augment getMojitTypeDetails with AC addons': function() {
             var fixtures = libpath.join(__dirname, '../../../../../fixtures/gsg5');
@@ -31,18 +31,13 @@ YUI().use(
 
             var details = store.getMojitTypeDetails('server', {}, 'PagedFlickr');
             // order matters
-            var keys = Y.Object.keys(details.acAddons);
-            A.areSame(4, keys.length, 'number of AC addons');
-            A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(keys), 'correct order');
-            A.areSame('mojito-config-addon', details.acAddons.config);
-            A.areSame('mojito-intl-addon', details.acAddons.intl);
-            A.areSame('mojito-params-addon', details.acAddons.params);
-            A.areSame('mojito-url-addon', details.acAddons.url);
+            A.areSame(4, details.acAddons.length, 'number of AC addons');
+            A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(details.acAddons), 'correct order');
         }
 
 
     }));
-    
+
     Y.Test.Runner.add(suite);
-    
+
 });

--- a/tests/unit/lib/app/addons/rs/test-dispatch-helper.server.js
+++ b/tests/unit/lib/app/addons/rs/test-dispatch-helper.server.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+YUI().use(
+    'base',
+    'oop',
+    'mojito-resource-store',
+    'addon-rs-yui',
+    'addon-rs-dispatch-helper',
+    'json',
+    'test',
+    function(Y) {
+    
+    var suite = new YUITest.TestSuite('mojito-addon-rs-dispatch-helper-tests'),
+        libpath = require('path'),
+        mojitoRoot = libpath.join(__dirname, '../../../../../../lib'),
+        A = Y.Assert;
+
+
+    suite.add(new YUITest.TestCase({
+        
+        name: 'dispatch-helper rs addon tests',
+        
+
+        'augment getMojitTypeDetails with AC addons': function() {
+            var fixtures = libpath.join(__dirname, '../../../../../fixtures/gsg5');
+            var store = new Y.mojito.ResourceStore({ root: fixtures, mojitoRoot: mojitoRoot });
+            store.preload();
+
+            var details = store.getMojitTypeDetails('server', {}, 'PagedFlickr');
+            // order matters
+            var keys = Y.Object.keys(details.acAddons);
+            A.areSame(4, keys.length, 'number of AC addons');
+            A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(keys), 'correct order');
+            A.areSame('mojito-config-addon', details.acAddons.config);
+            A.areSame('mojito-intl-addon', details.acAddons.intl);
+            A.areSame('mojito-params-addon', details.acAddons.params);
+            A.areSame('mojito-url-addon', details.acAddons.url);
+        }
+
+
+    }));
+    
+    Y.Test.Runner.add(suite);
+    
+});

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -34,19 +34,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             Y.namespace('mojito').controller = {
                 index: function() {}
             };
-            // fake out the http plugin so the others will load
-            Y.namespace('mojito.addons.ac').http = function() {
-                this.namespace = 'http';
-                this.getRequest = function() {};
-            };
-            // fake out the url plugin so it won't try to load routes
-            Y.namespace('mojito.addons.ac').url = function() {
-                this.namespace = 'url';
-            };
-            // fake out the intl plugin so the others will load
-            Y.namespace('mojito.addons.ac').intl = function() {
-                this.namespace = 'intl';
-            };
             ac = new Y.mojito.ActionContext({
                 dispatcher: 'the dispatcher',
                 command: {
@@ -86,19 +73,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             var ac;
             Y.namespace('mojito').controller = {
                 index: function() {}
-            };
-            // fake out the http plugin so the others will load
-            Y.namespace('mojito.addons.ac').http = function() {
-                this.namespace = 'http';
-                this.getRequest = function() {};
-            };
-            // fake out the url plugin so it won't try to load routes
-            Y.namespace('mojito.addons.ac').url = function() {
-                this.namespace = 'url';
-            };
-            // fake out the intl plugin so the others will load
-            Y.namespace('mojito.addons.ac').intl = function() {
-                this.namespace = 'intl';
             };
             ac = new Y.mojito.ActionContext({
                 dispatcher: 'the dispatcher',
@@ -140,19 +114,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             Y.namespace('mojito').controller = {
                 index: function() {}
             };
-            // fake out the http plugin so the others will load
-            Y.namespace('mojito.addons.ac').http = function() {
-                this.namespace = 'http';
-                this.getRequest = function() {};
-            };
-            // fake out the url plugin so it won't try to load routes
-            Y.namespace('mojito.addons.ac').url = function() {
-                this.namespace = 'url';
-            };
-            // fake out the intl plugin so the others will load
-            Y.namespace('mojito.addons.ac').intl = function() {
-                this.namespace = 'intl';
-            };
             ac = new Y.mojito.ActionContext({
                 dispatcher: 'the dispatcher',
                 command: {
@@ -193,19 +154,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             Y.namespace('mojito').controller = {
                 index: function() {}
             };
-            // fake out the http plugin so the others will load
-            Y.namespace('mojito.addons.ac').http = function() {
-                this.namespace = 'http';
-                this.getRequest = function() {};
-            };
-            // fake out the url plugin so it won't try to load routes
-            Y.namespace('mojito.addons.ac').url = function() {
-                this.namespace = 'url';
-            };
-            // fake out the intl plugin so the others will load
-            Y.namespace('mojito.addons.ac').intl = function() {
-                this.namespace = 'intl';
-            };
             ac = new Y.mojito.ActionContext({
                 command: {
                     action: 'index',
@@ -237,14 +185,8 @@ YUI().use('mojito-action-context', 'test', function (Y) {
         },
 
         'test all required (was: default) plugins are preloaded and plugged': function() {
-            Y.namespace('mojito.addons.ac').config = function() {
-                this.namespace = 'config';
-            };
-            Y.namespace('mojito.addons.ac').params = function() {
-                this.namespace = 'params';
-            };
-            Y.namespace('mojito.addons.ac').composite = function() {
-                this.namespace = 'composite';
+            Y.namespace('mojito.addons.ac').custom = function() {
+                return { namespace: 'custom' };
             };
             var ac = new Y.mojito.ActionContext({
                 dispatcher: 'the dispatcher',
@@ -253,13 +195,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     instance: {
                         id: 'id',
                         type: 'Type666',
-                        yui: { sorted: [
-                            'mojito-config-addon',
-                            'mojito-url-addon',
-                            'mojito-params-addon',
-                            'mojito-composite-addon'
-                        ] }
-                    },
+                        yui: { sorted: [] },
+                        acAddons: ['custom']
+                    }
                 },
                 controller: {index: function() {}},
                 store: {
@@ -270,29 +208,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 }
             });
 
-            A.isObject(ac.config, 'Missing config addon');
-            A.isObject(ac.url, 'Missing url addon');
-            A.isObject(ac.params, 'Missing config params');
-            A.isObject(ac.composite, 'Missing config composite');
+            A.isObject(ac.core, 'output-adapter addon should be plug by default');
+            A.isObject(ac.custom, 'custom required addon is missing');
         },
 
         'test AC properties': function() {
             var ac;
             Y.namespace('mojito').controller = {
                 index: function() {}
-            };
-            // fake out the http plugin so the others will load
-            Y.namespace('mojito.addons.ac').http = function() {
-                this.namespace = 'http';
-                this.getRequest = function() {};
-            };
-            // fake out the url plugin so it won't try to load routes
-            Y.namespace('mojito.addons.ac').url = function() {
-                this.namespace = 'url';
-            };
-            // fake out the intl plugin so the others will load
-            Y.namespace('mojito.addons.ac').intl = function() {
-                this.namespace = 'intl';
             };
             ac = new Y.mojito.ActionContext({
                 dispatcher: 'the dispatcher',
@@ -355,9 +278,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 mixes.push(4);
                 return { namespace: 'fourth' };
             };
-            Y.namespace('mojito.addons.ac').first.dependsOn = ['second'];
-            Y.namespace('mojito.addons.ac').second.dependsOn = ['third'];
-            Y.namespace('mojito.addons.ac').third.dependsOn = ['fourth'];
 
             new Y.mojito.ActionContext({
                 dispatch: 'the dispatch',
@@ -366,14 +286,13 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     instance: {
                         id: 'id',
                         type: 'Type2', // Need to clear the addons cache
-                        yui: {
-                            sorted: [
-                                'first',
-                                'second',
-                                'third',
-                                'fourth'
-                            ]
-                        }
+                        yui: { sorted: [] },
+                        acAddons: [
+                            'first',
+                            'second',
+                            'third',
+                            'fourth'
+                        ]
                     }
                 },
                 controller: {index: function() {}},
@@ -385,7 +304,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 }
             });
 
-            OA.areEqual([4,3,2,1], mixes, 'wrong addon load order');
+            OA.areEqual([1,2,3,4], mixes, 'wrong addon attach order, should be based on acAddons');
         }
 
     }));


### PR DESCRIPTION
- precomputed `instance.acAddons` as part of the RS init.
- attach acAddons in the same order they were precomputed.
- deprecating the infamous `dependsOn` (including the clean up) in favor of YUI requirements
