### PR TITLE
[docs] Corrected the syntax for creating namespaces for models/controllers.

### DIFF
--- a/docs/dev_guide/api_overview/mojito_action_context.rst
+++ b/docs/dev_guide/api_overview/mojito_action_context.rst
@@ -13,7 +13,7 @@ the ``done`` method sends the ``data`` object to the ``index`` template.
 
 .. code-block:: javascript
 
-   YUI.add('HelloMojit', function(Y) {
+   YUI.add('HelloMojit', function(Y, NAME) {
      /**
      * The HelloMojit module.
      *
@@ -25,7 +25,7 @@ the ``done`` method sends the ``data`` object to the ``index`` template.
      * @class Controller
      * @constructor
      */
-     Y.mojito.controller = {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/api_overview/mojito_action_context.rst
+++ b/docs/dev_guide/api_overview/mojito_action_context.rst
@@ -28,11 +28,7 @@ the ``done`` method sends the ``data`` object to the ``index`` template.
      * @class Controller
      * @constructor
      */
-<<<<<<< HEAD
      Y.namespace('mojito.controllers')[NAME] = { 
-=======
-      Y.namespace('mojito.controllers')[NAME] = {   
->>>>>>> 74b3d8ae25655cc8e8415cb12eb6b36a32335832
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/intro/mojito_configuring.rst
+++ b/docs/dev_guide/intro/mojito_configuring.rst
@@ -692,8 +692,8 @@ array as seen below:
 
 .. code-block:: javascript
 
-   YUI.add('BarMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('BarMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/intro/mojito_mvc.rst
+++ b/docs/dev_guide/intro/mojito_mvc.rst
@@ -37,7 +37,7 @@ Thus, the ``YUI.add`` statement in ``photos/models/flickr.server.js`` would be t
 
 .. code-block:: javascript
 
-   YUI.add("photosModelFlickr", function(Y) {
+   YUI.add("photosModelFlickr", function(Y, NAME) {
       ...
    }
 
@@ -48,7 +48,7 @@ A model should have the basic structure shown below.
 
 .. code-block:: javascript
 
-   YUI.add('{mojit_name}Model{Model_name}', function(Y) {
+   YUI.add('{mojit_name}Model{Model_name}', function(Y, NAME) {
      // Models must register themselves in the
      // Y.mojito.models namespace.
      Y.namespace('mojito.models').{model_name} = {
@@ -76,7 +76,7 @@ Model Objects and Methods
 The following objects and methods form the backbone of the model.
 
 - ``YUI.add`` - (required) adds the module 
-- ``Y.namespace('mojito.model')`` - (required) registers the model 
+- ``Y.namespace('mojito.models')`` - (required) registers the model 
 - ``init`` - (optional) gets configuration information 
 
 
@@ -86,7 +86,7 @@ instructs Mojito to load the YUI module ``yql`` for getting data.
 
 .. code-block:: javascript
 
-   YUI.add('galleryModelFlickr', function(Y) {
+   YUI.add('galleryModelFlickr', function(Y, NAME) {
    
      // Models must register themselves in the 
      // Y.mojito.models namespace.
@@ -121,8 +121,8 @@ see `Calling the Model`_ and `Calling YQL from a Mojit <../code_exs/calling_yql.
 
 .. code-block:: javascript
 
-   YUI.add('{mojit_name}', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('{mojit_name}', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          // Use ac.models.{mojit_name} if the default model 'model.server.js' is being used.
          var model = ac.models.{model_name};
@@ -136,7 +136,7 @@ Example
 
 .. code-block:: javascript
 
-   YUI.add('weatherModelForecast', function(Y) {
+   YUI.add('weatherModelForecast', function(Y, NAME) {
      // Models must register themselves in the
      // Y.mojito.models namespace.
      Y.namespace('mojito.models').forecast = {
@@ -183,10 +183,10 @@ A controller should have the following basic structure:
 
 .. code-block:: javascript
 
-   YUI.add('{mojit_name}', function(Y)
+   YUI.add('{mojit_name}', function(Y, NAME)
      // Module name is {mojit-name}
      // Constructor for the Controller class.
-     Y.mojito.controller = {
+     Y.namespace('mojito.controllers')[NAME] = {
        // The spec configuration is passed to init
        init: function(config) {
          this.config = config;
@@ -214,28 +214,27 @@ Controller Objects and Methods
 Several objects and methods form the backbone of the controller.
 
 - ``YUI.add`` - (required) registers the controller as a YUI module in the Mojito framework. 
-- ``Y.mojito.controller`` -  (required) creates a namespace that makes functions available as Mojito 
+- ``Y.namespace('mojito.controllers')[NAME]`` -  (required) creates a namespace that makes functions available as Mojito 
   actions.
 - ``init`` - (optional) if you provide an ``init`` function on your controller, Mojito will call it 
   as it creates a controller instance, passing in the mojit specification. You can store the 
   specification on the ``this`` reference for use within controller functions.
 - ``this`` - a reference pointing to an instance of the controller that the function is running 
-  within. This means that you can refer to other functions described within ``Y.mojito.controller`` 
+  within. This means that you can refer to other functions described within ``Y.namespace('mojito.controllers')[NAME]`` 
   using ``this.otherFunction``. This is helpful when you've added some utility functions onto your 
   controller that do not accept an ActionContext object.
 - ``requires`` - (optional) an array that lists additional YUI modules needed by the controller.
 
 The example controller below shows you how the components are used. The ``status`` mojit is 
-registered with ``YUI.add``, and the ``Y.mojito.controller`` namespace is created with the ``init`` 
-and other functions. The ``init`` function stores the date so it can be used by other functions, and 
+registered with ``YUI.add`` and the ``init`` function stores the date so it can be used by other functions, and 
 the ``this`` reference allows the ``index`` function to call ``create_status``. Lastly, the 
 ``requires`` array instructs Mojito to load the YUI module ``mojito-intl-addon`` for localizing the 
 date and title.
 
 .. code-block:: javascript
 
-   YUI.add('status', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('status', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(spec) {
          this.spec = spec;
          this.date = new Date();
@@ -298,15 +297,15 @@ properties as seen below.
      }
    ]
 
-In the controller, any function that is defined in the ``Y.mojito.controller`` namespace is 
+In the controller, any function that is defined in the ``Y.namespace('mojito.controllers')[NAME]`` is 
 available as a Mojito action. These functions can only accept the ``ActionContext`` object as an 
 argument. In the example controller below, the ``index`` and ``greeting`` functions are available as 
 Mojito actions.
 
 .. code-block:: javascript
 
-   YUI.add('Stateful', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('Stateful', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
        },
@@ -332,8 +331,8 @@ You can also use ``init`` to store other initialization data on ``this`` as seen
 
 .. code-block:: javascript
 
-   YUI.add('PlaceFinder', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('PlaceFinder', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
          this.geo_api = "http://where.yahooapis.com/geocode";
@@ -344,7 +343,7 @@ You can also use ``init`` to store other initialization data on ``this`` as seen
 
 Within your controller actions and the ``init`` action, the ``this`` reference points to an instance 
 of the controller the action is running within. This means that you can refer to other 
-functions or actions described within ``Y.mojito.controller`` using the syntax 
+functions or actions described within ``Y.namespace('mojito.controllers')[NAME]`` using the syntax 
 ``this.{otherFunction}``. This is helpful when you've added some utility functions onto your 
 controller that do not accept an ActionContext object as the argument, but you wish to use for 
 several actions.
@@ -354,8 +353,8 @@ In the example controller below, the ``health`` function uses ``this`` to call t
 
 .. code-block:: javascript
 
-   YUI.add('HealthStats', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('HealthStats', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
        },
@@ -399,8 +398,8 @@ the ``simple`` mojit.
 
 .. code-block:: javascript
 
-   YUI.add('simple', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('simple', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
        },
@@ -431,7 +430,7 @@ the ``index`` template.
 
 .. code-block:: javascript
 
-   YUI.add('UserMojit', function(Y) {
+   YUI.add('UserMojit', function(Y, NAME) {
      /**
      * The HelloMojit module.
      * @module HelloMojit
@@ -441,7 +440,7 @@ the ``index`` template.
      * @class Controller
      * @constructor
      */
-     Y.mojito.controller = {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
        },
@@ -475,7 +474,7 @@ instead of the default ``user`` template.
 
 .. code-block:: javascript
 
-   YUI.add('UserMojit', function(Y) {
+   YUI.add('UserMojit', function(Y, NAME) {
      /**
      * The HelloMojit module.
      * @module HelloMojit
@@ -485,7 +484,7 @@ instead of the default ``user`` template.
      * @class Controller
      * @constructor
      */
-     Y.mojito.controller = {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
        },
@@ -548,8 +547,8 @@ sent back in a callback.
 
 .. code-block:: javascript
 
-   YUI.add('Stateful', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('Stateful', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = {  
        init: function(config) {
          this.config = config;
          this.time = new Date().getTime();

--- a/docs/dev_guide/intro/mojito_mvc.rst
+++ b/docs/dev_guide/intro/mojito_mvc.rst
@@ -50,8 +50,8 @@ A model should have the basic structure shown below.
 
    YUI.add('{mojit_name}Model{Model_name}', function(Y, NAME) {
      // Models must register themselves in the
-     // Y.mojito.models namespace.
-     Y.namespace('mojito.models').{model_name} = {
+     // Namespace for models
+     Y.namespace('mojito.models')[NAME] = {
        // Optional init() method is given the
        // mojit configuration information.
        init: function(config) {
@@ -76,12 +76,12 @@ Model Objects and Methods
 The following objects and methods form the backbone of the model.
 
 - ``YUI.add`` - (required) adds the module 
-- ``Y.namespace('mojito.models')`` - (required) registers the model 
+- ``Y.namespace('mojito.models')[NAME]`` - (required) registers the model 
 - ``init`` - (optional) gets configuration information 
 
 
 The example model below shows you how the objects and methods are used. The ``galleryModelFlickr`` model is registered with ``YUI.add``, and the namespace for the 
-model is created with ``Y.namespace('mojito.models').flickr``. The ``init`` function stores the date so it can be used by other functions, and the ``requires`` array 
+model is created with ``Y.namespace('mojito.models')[NAME]``. The ``init`` function stores the date so it can be used by other functions, and the ``requires`` array 
 instructs Mojito to load the YUI module ``yql`` for getting data.
 
 .. code-block:: javascript
@@ -89,8 +89,8 @@ instructs Mojito to load the YUI module ``yql`` for getting data.
    YUI.add('galleryModelFlickr', function(Y, NAME) {
    
      // Models must register themselves in the 
-     // Y.mojito.models namespace.
-     Y.namespace('mojito.models').flickr = {
+     // Namespace for model
+     Y.namespace('mojito.models')[NAME] = {
        // Optional init() method is given the mojit 
        // configuration information.       
        init: function(config) {
@@ -138,8 +138,8 @@ Example
 
    YUI.add('weatherModelForecast', function(Y, NAME) {
      // Models must register themselves in the
-     // Y.mojito.models namespace.
-     Y.namespace('mojito.models').forecast = {
+     // Namespace for model
+     Y.namespace('mojito.models')[NAME] = {
        // Optional init() method is given the mojit
        // configuration information.
        init: function(config) {

--- a/docs/dev_guide/topics/mojito_assets.rst
+++ b/docs/dev_guide/topics/mojito_assets.rst
@@ -1,5 +1,3 @@
-
-
 ======
 Assets
 ======
@@ -159,8 +157,8 @@ the ``<meta>`` tag and the ``addCss`` method adds the device-specific CSS.
 
 .. code-block:: javascript
 
-   YUI.add('device', function(Y){
-     Y.mojito.controller = {
+   YUI.add('device', function(Y, NAME){
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -215,8 +213,8 @@ and then add the module name in the ``requires`` array as seen in the example mo
 
 .. code-block:: javascript
 
-   YUI.add('textProcessor', function(Y){
-     Y.mojito.controller = {
+   YUI.add('textProcessor', function(Y, NAME){
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/topics/mojito_composite_mojits.rst
+++ b/docs/dev_guide/topics/mojito_composite_mojits.rst
@@ -1,5 +1,3 @@
-
-
 ================
 Composite Mojits
 ================
@@ -55,8 +53,8 @@ In the example controller of ``ParentMojit`` below, the ``init`` function saves 
 
 .. code-block:: javascript
 
-   YUI.add('ParentMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParentMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
          // Displays the 'children' object that is
@@ -79,7 +77,7 @@ template.
 .. code-block:: javascript
 
    YUI.add('ParentMojit', function(Y, NAME) {
-     Y.mojito.controllers[NAME] = {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -94,7 +92,7 @@ If ``ParentMojit`` above is the parent of ``ChildMojit``, the controller of ``Ch
 .. code-block:: javascript
 
    YUI.add('ChildMojit', function(Y, NAME) {
-     Y.mojito.controllers[NAME] = {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -46,8 +46,8 @@ In the example controller below, the value for the ``name`` query string paramet
 
 .. code-block:: javascript
 
-   YUI.add('ParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -71,8 +71,8 @@ the template.
 
 .. code-block:: javascript
 
-   YUI.add('ParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -107,8 +107,8 @@ In the example controller below, the POST body parameter ``name`` is retrieved a
 
 .. code-block:: javascript
 
-   YUI.add('ParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -132,8 +132,8 @@ template.
 
 .. code-block:: javascript
 
-   YUI.add('ParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -204,8 +204,8 @@ In the example controller below, the routing parameter ``coupon`` is used to det
 
 .. code-block:: javascript
 
-   YUI.add('CouponMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('CouponMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -234,8 +234,8 @@ In the example controller below, all of the routing routing parameters to create
 
 .. code-block:: javascript
 
-   YUI.add('LinkMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('LinkMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -274,8 +274,8 @@ In the example controller below, the ``name`` parameter is obtained using ``getF
 
 .. code-block:: javascript
 
-   YUI.add('MergedParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('MergedParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -296,8 +296,8 @@ To get all of the GET, POST, and routing parameters, call ``getFromMerged`` or `
 
 .. code-block:: javascript
 
-   YUI.add('MergedParamsMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('MergedParamsMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -332,8 +332,8 @@ for ``'user'`` is obtained and then used to pass user information to the templat
 
 .. code-block:: javascript
 
-   YUI.add('CookieMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('CookieMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
      },
@@ -356,8 +356,8 @@ with the name ``'user'`` if one does not exist.
 
 .. code-block:: javascript
 
-   YUI.add('CookieMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('CookieMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
      },

--- a/docs/dev_guide/topics/mojito_extensions.rst
+++ b/docs/dev_guide/topics/mojito_extensions.rst
@@ -148,13 +148,8 @@ addon's constructor. In our addon, we defined the namespace ``cheese`` (``"names
 
 .. code-block:: javascript
 
-<<<<<<< HEAD
    YUI.add('Foo', function(Y, NAME) {
      Y.namespace('mojito.controllers')[NAME] = { 
-=======
-   YUI.add('Foo', function(Y) {
-     Y.namespace('mojito.controllers')[NAME] = {
->>>>>>> 74b3d8ae25655cc8e8415cb12eb6b36a32335832
        index: function(ac) {
          // Use the type 'cheese' and then the
          // the addon function 'cheesify'

--- a/docs/dev_guide/topics/mojito_extensions.rst
+++ b/docs/dev_guide/topics/mojito_extensions.rst
@@ -1,6 +1,4 @@
-﻿
-
-================
+﻿================
 Extending Mojito
 ================
 
@@ -150,8 +148,8 @@ addon's constructor. In our addon, we defined the namespace ``cheese`` (``"names
 
 .. code-block:: javascript
 
-   YUI.add('Foo', function(Y) {
-     Y.mojito.controllers = {
+   YUI.add('Foo', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          // Use the type 'cheese' and then the
          // the addon function 'cheesify'
@@ -320,8 +318,8 @@ With the saved instance, the ``log`` method from the ``hello-uid`` module can be
 
 .. code-block:: javascript
 
-   YUI.add('HelloMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('HelloMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
          this.uid = new Y.mojito.UID();

--- a/docs/dev_guide/topics/mojito_framework_mojits.rst
+++ b/docs/dev_guide/topics/mojito_framework_mojits.rst
@@ -1,5 +1,3 @@
-
-
 ================
 Framework Mojits
 ================
@@ -318,8 +316,8 @@ The ``Container`` mojit uses ``ac.composite.done`` to execute its child mojits.
 
 .. code-block:: javascript
 
-   YUI.add('Container', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('Container', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
      /**
      * Method corresponding to the 'index' action.
      *
@@ -354,8 +352,8 @@ The ``LazyLoadMojit`` in the ``application.json`` is configured to lazily load t
 
 .. code-block:: javascript
 
-   YUI.add('LazyChild', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('LazyChild', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        hello: function(ac) {
          ac.done({time: new Date()});
        },

--- a/docs/dev_guide/topics/mojito_resource_store.rst
+++ b/docs/dev_guide/topics/mojito_resource_store.rst
@@ -948,8 +948,7 @@ Controller
 
    YUI.add('Viewer', function(Y, NAME) {
    
-     Y.mojito.controllers[NAME] = {
-
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },

--- a/docs/dev_guide/topics/mojito_run_dyn_defined_mojits.rst
+++ b/docs/dev_guide/topics/mojito_run_dyn_defined_mojits.rst
@@ -110,8 +110,8 @@ In the example controller below, the child instances ``header``, ``body``, and `
 
 .. code-block:: javascript
 
-   YUI.add('FrameMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('FrameMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(config) {
          this.config = config;
        },
@@ -158,8 +158,8 @@ ParentMojit
 
 .. code-block:: javascript
 
-   YUI.add('ParentMojit', function(Y) {
-      Y.mojito.controller = {
+   YUI.add('ParentMojit', function(Y, NAME) {
+      Y.namespace('mojito.controllers')[NAME] = { 
         index: function(ac) {
           var cfg = {
             "children": {
@@ -187,8 +187,8 @@ DynamicChildMojit
 
 .. code-block:: javascript
 
-   YUI.add('DynamicChildMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('DynamicChildMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          var caller = ac.config.get("caller");       
          if("ParentMojit"==caller){
@@ -322,10 +322,8 @@ instance and passes custom versions of ``done``, ``flush``, and ``error``.
 
 .. code-block:: javascript
 
-   YUI.add('MotherlodeMojit', function(Y) {
-
-     Y.mojito.controller = {
-
+   YUI.add('MotherlodeMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          var adapter = {
            done: function(data, meta){
@@ -398,10 +396,9 @@ CreatorMojit
 
 .. code-block:: javascript 
 
-   YUI.add('CreatorMojit', function(Y) {
+   YUI.add('CreatorMojit', function(Y, NAME) {
    
-      Y.mojito.controller = {
-
+      Y.namespace('mojito.controllers')[NAME] = { 
         index: function(ac) {
           var buffer = '';
           var command = {
@@ -444,9 +441,9 @@ SpawnedMojit
 
 .. code-block:: javascript 
 
-   YUI.add('SpawnedMojit', function(Y) {
+   YUI.add('SpawnedMojit', function(Y, NAME) {
    
-      Y.mojito.controller = {
+      Y.namespace('mojito.controllers')[NAME] = { 
 
         "index": function(ac) {
           ac.done({ "route": ac.params.route('name'), "url": ac.params.url('path'), "body": ac.params.body("message") });
@@ -542,8 +539,8 @@ ParentMojit
 
 .. code-block:: javascript
 
-   YUI.add('ParentMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParentMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          ac.assets.addCss("/static/parent/assets/index.css", "top");
          ac.done();
@@ -567,8 +564,8 @@ ChildMojit
 
 .. code-block:: javascript
 
-   YUI.add('ChildMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ChildMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          ac.assets.addCss("/static/child/assets/index.css", "top");
          var content = Math.floor(Math.random()*10001);
@@ -733,8 +730,8 @@ GrandparentMojit
 
 .. code-block:: javascript
 
-   YUI.add('GrandparentMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('GrandparentMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          var command = {
            "instance": {
@@ -761,8 +758,8 @@ ParentMojit
 
 .. code-block:: javascript
 
-   YUI.add('ParentMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('ParentMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          var params = ac.params.body();
          var cfg = {
@@ -791,8 +788,8 @@ GrandchildMojit
 
 .. code-block:: javascript
 
-   YUI.add('GrandchildMojit', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('GrandchildMojit', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        index: function(ac) {
          var data = { "creator": ac.config.get("creator"), "whoami": ac.config.get("whoami") };
          ac.done(data);

--- a/docs/dev_guide/topics/mojito_testing.rst
+++ b/docs/dev_guide/topics/mojito_testing.rst
@@ -195,8 +195,8 @@ The ``controller.server.js`` below requires the ``Foo`` module.
 
 .. code-block:: javascript
 
-   YUI.add('Foo', function(Y) {
-     Y.mojito.controller = {
+   YUI.add('Foo', function(Y, NAME) {
+     Y.namespace('mojito.controllers')[NAME] = { 
        init: function(mojitSpec) {
          this.spec = mojitSpec;
        },

--- a/docs/dev_guide/topics/mojito_testing.rst
+++ b/docs/dev_guide/topics/mojito_testing.rst
@@ -465,7 +465,7 @@ The ``model.server.js`` below includes the ``FooModel`` module.
 .. code-block:: javascript
 
    YUI.add('FooModel', function(Y, NAME) {
-     Y.mojito.models.Foo = {
+     Y.namespace('mojito.models')[NAME] = {      
        getData: function(callback) {
          callback({some:'data'});
        }


### PR DESCRIPTION
No longer used:

Y.mojito.controllers = {
Y.mojito.controllers[NAME] = {
Y.mojito.models.myMojit = {

New syntax:

Y.namespace('mojito.controllers')[NAME] = {  
 Y.namespace('mojito.models')[NAME] = {  
