### PR TITLE
Merge assets from iconfig.assets to meta

### DIFF
--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -44,6 +44,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
         // NOTE: 'this' is the ActionContext instance
         var callbackFunc = more ? 'flush' : 'done',
             instance = this.command.instance,
+            config = instance.config || {},
             context = this.command.context || {},
             adapter = this._adapter,
             action = this.command.action,
@@ -119,6 +120,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             mojitView.engine = meta.view.engine;
         }
 
+        meta.assets = Y.mojito.util.metaMerge(meta.assets, config.assets || {} );
         // Here we ask each "thing" attached to the AC if it wants to add view
         // "meta"
         Y.Object.each(this, function(item) {

--- a/lib/app/addons/ac/output-adapter.common.js
+++ b/lib/app/addons/ac/output-adapter.common.js
@@ -120,7 +120,7 @@ YUI.add('mojito-output-adapter-addon', function(Y, NAME) {
             mojitView.engine = meta.view.engine;
         }
 
-        meta.assets = Y.mojito.util.metaMerge(meta.assets, config.assets || {} );
+        meta.assets = Y.mojito.util.metaMerge(meta.assets, config.assets || {});
         // Here we ask each "thing" attached to the AC if it wants to add view
         // "meta"
         Y.Object.each(this, function(item) {


### PR DESCRIPTION
In mojito 0.4.x due to the automatic inclusion of the mojito-assets-addon, when executing the loop on line 124 it calls the metaMergeInto of the assets addon which makes the config to merge.

Since we dont have that addon as default in the new mojito version, we will need to do it manually.

If you add the assets addon as a dependencie, due to the implementation of metaMerge will not duplicate assets. So is just a small overhead on computation in that case. 

This is a must merge to Shaker.
