### PR TITLE
Add getter to avoid exposing _app for Manhattan use.

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -456,6 +456,15 @@ MojitoServer.prototype.close = function() {
 
 
 /**
+ * Returns the instance of http.Server (or a subtype) which is the true server.
+ * @return {http.Server} The node.js http.Server (or subtype) instance.
+ */
+MojitoServer.prototype.getHttpServer = function() {
+    return this._app;
+};
+
+
+/**
  * Invokes a callback function with the content of the requested url.
  * @param {string} url A url to fetch.
  * @param {{host: string, port: number, method: string}|function} opts A list of


### PR DESCRIPTION
Avoids exposing _app to consumers who must give Express app object to Manhattan for deployment.
