### PR TITLE
Move app init so any getHttpServer call returns initialized app instance...

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -460,6 +460,14 @@ MojitoServer.prototype.close = function() {
  * @return {http.Server} The node.js http.Server (or subtype) instance.
  */
 MojitoServer.prototype.getHttpServer = function() {
+
+    // Only configure the server once by checking for a startup time.
+    if (!this._startupTime) {
+        this._startupTime = new Date().getTime();
+        this._configureAppInstance(this._app, this._options);
+    }
+
+    // Return the http.Server instance, properly configured above.
     return this._app;
 };
 
@@ -612,21 +620,15 @@ MojitoServer.prototype.setLogWriter = function(writer) {
 MojitoServer.prototype.start = function(cb) {
 
     var logger,
-        app = this._app,
+        app = this.getHttpServer(),     // Get initialized app instance.
         callback = cb || Mojito.NOOP;
 
     if (this._options.verbose) {
         libutils.warn('Starting Mojito Application');
     }
 
-    // Only configure the server once by checking for a startup time.
-    if (!this._startupTime) {
-        this._startupTime = new Date().getTime();
-        this._configureAppInstance(this._app, this._options);
-    }
-
     try {
-        this._app.listen(this._options.port, null, function(err) {
+        app.listen(this._options.port, null, function(err) {
             // NOTE that we're passing the private app instance here!!!
             // TODO: Verify we want to do this, as opposed to passing 'this'.
             callback(err, app);
@@ -635,7 +637,8 @@ MojitoServer.prototype.start = function(cb) {
         callback(err);
     }
 
-    // Return the application instance for certain server containers to use.
+    // NOTE that we're passing the private app instance here!!!
+    // TODO: Verify we want to do this, as opposed to passing 'this'.
     return app;
 };
 


### PR DESCRIPTION
The idea here is that some containers just want the app instance, but we were only initializing it if you called start(). This update moves the initialization into the getter to ensure the server instance you get is always initialized, but only initialized once. 
