### PR TITLE
FIX static-handler middleware for well known files

### DIFF
--- a/lib/app/middleware/mojito-handler-static.js
+++ b/lib/app/middleware/mojito-handler-static.js
@@ -227,13 +227,13 @@ function staticProvider(store, logger) {
 
         // TODO:  these adjustments should really be done by addons/rs/url
         if (!resource && (path === '/favicon.ico')) {
-            resource = store.getResource('client', {}, 'asset-ico-favicon');
+            resource = store.getResources('client', {}, 'asset-ico-favicon');
         }
         if (!resource && (path === '/robots.txt')) {
-            resource = store.getResource('client', {}, 'asset-txt-robots');
+            resource = store.getResources('client', {}, 'asset-txt-robots');
         }
         if (!resource && (path === '/crossdomain.xml')) {
-            resource = store.getResource('client', {}, 'asset-xml-crossdomain');
+            resource = store.getResources('client', {}, 'asset-xml-crossdomain');
         }
 
         if (!resource) {

--- a/lib/app/middleware/mojito-handler-static.js
+++ b/lib/app/middleware/mojito-handler-static.js
@@ -227,17 +227,23 @@ function staticProvider(store, logger) {
 
         // TODO:  these adjustments should really be done by addons/rs/url
         if (!resource && (path === '/favicon.ico')) {
-            resource = store.getResources('client', {}, 'asset-ico-favicon');
+            resource = store.getResources('client', {}, {mojit: 'shared', id: 'asset-ico-favicon'});
         }
         if (!resource && (path === '/robots.txt')) {
-            resource = store.getResources('client', {}, 'asset-txt-robots');
+            resource = store.getResources('client', {}, {mojit: 'shared', id: 'asset-txt-robots'});
         }
         if (!resource && (path === '/crossdomain.xml')) {
-            resource = store.getResources('client', {}, 'asset-xml-crossdomain');
+            resource = store.getResources('client', {}, {mojit: 'shared', id: 'asset-xml-crossdomain'});
         }
 
         if (!resource) {
             return next();
+        }
+        if (Array.isArray(resource)) {
+            if (resource.length === 0) {
+                return next();
+            }
+            resource = resource[0];
         }
 
         // Cache hit

--- a/tests/unit/lib/app/middleware/test-handler-static.js
+++ b/tests/unit/lib/app/middleware/test-handler-static.js
@@ -234,7 +234,7 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                 handler(req, res, function() {
                     callCount++;
                 });
-                A.isTrue(0 === callCount, 'next() handler should not have been called')
+                A.areEqual(0, callCount, 'next() handler should not have been called')
                 A.isTrue(resourceContentCalled, 'getResourceContent was not called for url: ' + req.url);
             }
 
@@ -291,7 +291,7 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                 A.fail('next() handler 1 should not have been called');
             });
 
-            //
+            // 
             // handle res of type array
             store.getAllURLResources = function() {
                 return {};


### PR DESCRIPTION
Appears that static middleware does not quite work for the following: /robots.txt, /crossdomain.xml and /favicon.ico.

This PR addresses this, with unit tests.
