### PR TITLE
replace express with connect ">1.8.2"

### DIFF
--- a/lib/app/middleware/mojito-parser-body.js
+++ b/lib/app/middleware/mojito-parser-body.js
@@ -8,13 +8,13 @@
 /*jslint anon:true, sloppy:true*/
 
 
-var express = require('express');
+var connect = require('connect');
 
 /**
  * Export a function which can create a body parser.
  * @return {Object} The newly constructed body parser.
  */
 module.exports = function() {
-    return express.bodyParser();
+    return connect.bodyParser();
 };
 

--- a/lib/app/middleware/mojito-parser-cookies.js
+++ b/lib/app/middleware/mojito-parser-cookies.js
@@ -8,13 +8,13 @@
 /*jslint anon:true, sloppy:true*/
 
 
-var express = require('express');
+var connect = require('connect');
 
 /**
  * Export a function which can create a cookie parser.
  * @return {Object} The newly constructed cookie parser.
  */
 module.exports = function() {
-    return express.cookieParser();
+    return connect.cookieParser();
 };
 

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -14,7 +14,7 @@
 
 
 var YUI = require('yui').YUI,
-    express = require('express'), // TODO: [Issue 80] go back to connect?
+    connect = require('connect'),
     http = require('http'),
     OutputHandler = require('./output-handler.server'),
     libpath = require('path'),
@@ -63,8 +63,8 @@ function MojitoServer(options) {
     this._options = options || {};
     this._options.port = this._options.port || process.env.PORT || 8666;
 
-    // TODO: Note we could pass some options to the express server instance.
-    this._app = express.createServer();
+    // TODO: Note we could pass some options to the connect server instance.
+    this._app = connect.createServer();
     this._configureAppInstance(this._app, this._options);
 
     return this;
@@ -112,7 +112,7 @@ MojitoServer.MOJITO_MIDDLEWARE = [
 
 
 /**
- * The Express application (server) instance.
+ * The Connect application (server) instance.
  * @type {Object}
  */
 MojitoServer.prototype._app = null;
@@ -164,9 +164,9 @@ MojitoServer.prototype._startupTime = null;
 
 
 /**
- * Adds Mojito framework components to the Express application instance.
+ * Adds Mojito framework components to the Connect application instance.
  * @method _configureAppInstance
- * @param {Object} app The Express application instance to Mojito-enable.
+ * @param {Object} app The Connect application instance to Mojito-enable.
  * @param {{port: number,
  *          dir: string,
  *          context: Object,
@@ -654,7 +654,7 @@ MojitoServer.prototype.setLogWriter = function(writer) {
 /**
  * The Mojito object is the primary server construction interface for Mojito.
  * This object is used to create new server instances but given that the raw
- * Express application object is expected/returned there's no need for a true
+ * Connect application object is expected/returned there's no need for a true
  * constructor since there are no true instances of a Mojito server object.
  */
 // TODO: Merge what we put on this object with the 'mojito' module/namespace.
@@ -688,7 +688,7 @@ Mojito.NOOP = function() {};
  * Creates a properly configured MojitoServer instance and returns it.
  * @method createServer
  * @param {Object} options Options for starting the app.
- * @return {Object} Express application.
+ * @return {Object} Connect application.
  */
 Mojito.createServer = function(options) {
     // NOTE that we use the exported name here. This allows us to mock that

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "async": "*",
         "colors": "*",
         "commander": "1.0.1",
-        "express": "2.5.10",
+        "connect": ">1.8.2",
         "glob": "~3.1.11",
         "jslint": "~0.1.9",
         "mime": "1.2.4",


### PR DESCRIPTION
Mojito does not use express-specific apis, only the underlying connect ones. This PR replaces references to express with connect.

Connect docs state: 1.x is compatible with node 0.4.x, 2.x (master) is compatible with node 0.6.x

Not sure if just saying >1.8.2 is what we want, but will submit for discussion.
