### PR TITLE
fix bz5472979 server resources in build

### DIFF
--- a/lib/app/addons/rs/url.server.js
+++ b/lib/app/addons/rs/url.server.js
@@ -181,8 +181,9 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 rollupParts = [],
                 rollupFsPath;
 
-            // Don't clobber a URL calculated by another RS addon.
-            if (res.hasOwnProperty('url')) {
+            // Don't clobber a URL calculated by another RS addon, or bother to
+            // proceed for server affinity resources that don't need uris
+            if (res.hasOwnProperty('url') || ('server' === res.affinity)) {
                 return;
             }
 


### PR DESCRIPTION
server affinity resources do not need to be uri-
addressable. With this change store.getAllUrls()
will no longer include foo.server.js resources,
and hence be omitted from `mojito build`
