### PR TITLE
mv run.js/arrow deps to devDependencies for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,12 @@
         "Michael Ridgway <mridgway@yahoo-inc.com>"
     ],
     "dependencies": {
-        "async": "*",
         "colors": "*",
-        "commander": "1.0.1",
         "express": "2.5.10",
         "glob": "~3.1.11",
         "jslint": "~0.1.9",
         "mkdirp": ">0.3",
         "mime": "1.2.4",
-        "node-static": "*",
         "rimraf": ">2",
         "semver": "1.0.14",
         "wrench": "~1.3.9",
@@ -49,7 +46,9 @@
         "npm": ">1.0"
     },
     "devDependencies": {
-        "node-static": "~0.6.1",
+        "async": "*",
+        "commander": "1.0.1",
+        "node-static": ">0.6",
         "yahoo-arrow": "0.0.59"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",


### PR DESCRIPTION
async, commander & node-static are only used by run.js (node-static was listed twice). 

these are currently only used for mojito-dev, so the move makes sense and saves some bandwidth.
