### PR TITLE
fix bz 5886351 cli bin/mojito uses wrong copy 

### DIFF
--- a/bin/mojito
+++ b/bin/mojito
@@ -4,14 +4,7 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-var libpath, libmojito;
-try {
-    // this is the normal location
-    libmojito = require('mojito');
-}
-catch (e) {
-    libpath = require('path'),
-    // need to do this if mojito is installed via `npm link`
-    libmojito = require(libpath.join(__dirname, '..', 'lib/mojito'));
-}
-libmojito.include('management/cli');
+var resolve = require('path').resolve,
+    mojito = require(resolve(__dirname, '../lib/mojito'));
+
+mojito.include('management/cli');


### PR DESCRIPTION
the cli entry point bin/mojito should always load and run the code it belongs with, and not from further up the require path chain.
