### PR TITLE
fix bz 5892364 (archetype) mojito-client not loaded for hybdridapp

### DIFF
--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -17,6 +17,7 @@
 
         "builds": {
             "hybridapp": {
+                "forceRelativePaths": true,
                 "urls": ["/yahoo.application.{{name}}/index.html"]
             }
         },

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -23,7 +23,7 @@
         },
 
         "yui": {
-            "dependencyCalculations": "precomputed+ondemand",
+            "dependencyCalculations": "precomputed",
             "base": "/yahoo.libs.yui/",
             "url": "$$yui.base$$yui/yui-min.js",
             "loader": "loader/loader-min.js"


### PR DESCRIPTION
- turn on forceRelativePaths so CRT behavior works and is testable without webview/httpd
- remove "ondemand" part of dependencyCalculations to fix js error in hybdridapp
