### PR TITLE
new mojito build hybridapp behavior

### DIFF
--- a/lib/app/commands/build/hybridapp.js
+++ b/lib/app/commands/build/hybridapp.js
@@ -21,7 +21,7 @@ function makeSnapshot(conf) {
         snap = {
             'name': conf.snapshot.name,
             'tag': conf.snapshot.tag,
-            'packages': {'yahoo.libs.yui': '*' /* hardcoded for now */}
+            'packages': conf.snapshot.packages
         };
 
     snap.packages[conf.app.name] = conf.app.version;

--- a/lib/app/commands/build/index.js
+++ b/lib/app/commands/build/index.js
@@ -52,8 +52,9 @@ function getConfigs(opts, buildtype, builddir, store) {
             dir: pkgmeta.fs.rootDir // should be same as CWD
         },
         snapshot: {
-            name: opts.snapshotName || 'missing --snapshotName',
-            tag: opts.snapshotTag || 'missing --snapshotTag'
+            name: opts.snapshotName,
+            tag: opts.snapshotTag,
+            packages: dotbuild.snapshotPackages || {}
         },
         build: {
             attachManifest: dotbuild.attachManifest,
@@ -87,7 +88,11 @@ function run(args, opts, cb) {
 
     switch (buildtype) {
     case 'html5app':
+        break;
     case 'hybridapp':
+        if (!opts.snapshotName || !opts.snapshotTag) {
+            die('Build hybridapp requires --snapshotName and --snapshotTag');
+        }
         break;
     case 'undefined':
         die('Missing type');


### PR DESCRIPTION
- snapshot name and tag are required
- builds.hybridapp.snapshotPackages config can populate snapshot.json:packages
