### PR TITLE
Configuration for user-provided middlewares

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -199,6 +199,11 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
     if (!options.context) {
         options.context = {};
     }
+    if (!options.midDir) {
+      options.midDir = 'middleware';
+    }
+
+
 
     // all logging that comes from YUI comes from here
     // We need to do this early, since creating a Y instance appears to copy
@@ -394,7 +399,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         } else {
             // backwards-compatibility: user-provided middleware is
             // specified by path
-            midPath = libpath.join(options.dir, 'middleware', midName);
+            midPath = libpath.join(options.dir, options.midDir, midName);
             //console.log("======== MIDDLEWARE user " + midPath);
             midBase = libpath.basename(midPath);
             if (0 === midBase.indexOf('mojito-')) {

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -394,7 +394,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         } else {
             // backwards-compatibility: user-provided middleware is
             // specified by path
-            midPath = libpath.join(options.dir, midName);
+            midPath = libpath.join(options.dir, 'middleware', midName);
             //console.log("======== MIDDLEWARE user " + midPath);
             midBase = libpath.basename(midPath);
             if (0 === midBase.indexOf('mojito-')) {
@@ -404,6 +404,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
                 midFactory = require(midPath);
                 app.use(midFactory(midConfig));
             } else {
+                // Load user-provided middleware from middleware folder
                 app.use(require(midPath));
             }
         }


### PR DESCRIPTION
Now the developer can load custom middlewares from a folder. If options.midDir is empty, the folder ./middleware is assumed to be the default location to store custom middlewares. This new configuration is useful for middlewares that need to be loaded before the server starts.

Example of configuration:
# server.js

options.midDir = 'middleware'; 
// options.midDir = './custom-scripts/middleware'; works too

// Some middlewares
options.appConfig = { 
  middleware: [
    'middleware-passport-init',
    'middleware-passport-session',
    'middleware-facebook-auth'
  ]
};

var app = Mojito.createServer(options);
