### PR TITLE
yui sandbox fixes

### DIFF
--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -513,9 +513,9 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
 
             // using the loader at the server side to compute the loader metadata
             // to avoid loading the whole thing on demand.
-            loader = new Ysandbox.Loader({
+            loader = new Ysandbox.Loader(Ysandbox.merge(Ysandbox.config, {
                 require: Ysandbox.Object.keys(modules_config)
-            });
+            }));
             resolved = loader.resolve(true);
 
             this._processMeta(resolved.jsMods,  modules, expanded_modules, conditions);

--- a/lib/app/middleware/mojito-combo-handler.js
+++ b/lib/app/middleware/mojito-combo-handler.js
@@ -140,7 +140,7 @@ function staticProvider(store, globalLogger) {
 
     // used to find the the modules in YUI itself
     Y.use('loader');
-    loader = new Y.Loader();
+    loader = new Y.Loader(Y.config);
 
     if (cache && !maxAge) {
         maxAge = cache;

--- a/lib/yui-sandbox.js
+++ b/lib/yui-sandbox.js
@@ -38,6 +38,9 @@ exports.getYUI = function (filter) {
         module: module,
         setTimeout: setTimeout,
         setInterval: setInterval,
+        clearTimeout: clearTimeout,
+        clearInterval: clearInterval,
+        JSON: JSON,
         __filename: __filename,
         __dirname: path.join(__dirname, '..', 'node_modules', 'yui', 'yui-nodejs'),
         exports: {}


### PR DESCRIPTION
- extending the sandbox scope to include clearTimeout, clearInterval and JSON (bugfix for search). 
- passing Y.config into the loader initialization routine when using a sandbox to preserve the filter and other properties.
