### PR TITLE
fix bz 5904449 garbled console output on node 0.8+

### DIFF
--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -5,55 +5,43 @@
  */
 
 
-/*jslint anon:true, sloppy:true, nomen:true, stupid:true, regexp:true*/
-
+/*jslint stupid:true, todo:true, node:true*/
+'use strict';
 
 var fs = require('fs'),
     util = require('util'),
     path = require('path'),
     existsSync = fs.existsSync || path.existsSync,
     hb = require('yui/handlebars').Handlebars,
-    tty = require('tty'),
-    archetypes_dir = path.join(__dirname, '../app/archetypes'),
-    isatty = tty.isatty(1) && tty.isatty(2);
+    tty = require('tty'), // use process.stdin/err.isTTY instead
+    colors = require('colors');
 
 
-if (!isatty) {
-    // fake out the getters that the "color" library would have added
-    (['bold', 'underline', 'italic', 'inverse', 'grey', 'yellow', 'red',
-        'green', 'blue', 'white', 'cyan', 'magenta']).forEach(function(style) {
-        try {
-            Object.defineProperty(String.prototype, style, {
-                get: function() {
-                    return this;
-                }
-            });
-        } catch (e) {
-            // just ignore
-        }
-    });
-} else {
-    require('colors');
-}
+colors.mode = (tty.isatty(1) && tty.isatty(2)) ? 'console' : 'none';
 
 
 function log(message) {
-    console.log(message.cyan);
+    console.log(message.cyan.toString());
 }
 
-
 function error(message, usage, die) {
+    var msgs = [];
+
     if (message instanceof Error) {
-        console.log(('✖ ' + message.message).red.bold);
+        msgs.push(('✖ ' + message.message).red.bold);
         if (message.stack) {
-            console.log(('\t' + message.stack).red.bold);
+            msgs.push('\n' + message.stack.red);
         }
     } else {
-        console.log(('✖ ' + message).red.bold);
+        msgs.push(('✖ ' + message).red.bold);
     }
+
     if (usage) {
-        console.log('usage:\n' + usage.grey);
+        msgs.push('\nusage: ' + usage.grey);
     }
+
+    console.error(msgs.join(' '));
+
     if (die) {
         process.exit(-1);
     }
@@ -61,12 +49,12 @@ function error(message, usage, die) {
 
 
 function success(message) {
-    console.log(('✔ ' + message).green.bold);
+    console.log(('✔ ' + message).green.bold.toString());
 }
 
 
 function warn(message) {
-    console.log(('⚠ ' + message).yellow);
+    console.warn(('⚠ ' + message).yellow.toString());
 }
 
 
@@ -86,7 +74,8 @@ function heir(o) {
  */
 // FUTURE:  find a node module that can do this well
 function decodeHTMLEntities(txt) {
-    txt = txt.replace(/(&[^;]+;)/g, function(all, ent) {
+    /*jslint regexp:true, unparam: true */
+    txt = txt.replace(/(&[^;]+;)/g, function (all, ent) {
         if ('&#x' === ent.substr(0, 3)) {
             return String.fromCharCode(parseInt(ent.substring(3, ent.length - 1), 16));
         }
@@ -105,7 +94,6 @@ function process_template(archetype_path, file, mojit_dir, template) {
 
     var archetype_file = path.join(archetype_path, file),
         new_file = path.join(mojit_dir, file.substring(0, file.length - 3)),
-        buffer = '',
         stat,
         tmpl,
         compiled,
@@ -135,7 +123,7 @@ function process_file(archetype_path, file, mojit_dir, template) {
         util.pump(
             fs.createReadStream(path.join(archetype_path, file)),
             fs.createWriteStream(path.join(mojit_dir, file)),
-            function(err) {
+            function (err) {
                 if (err) {
                     warn('Failed to copy file: ' + file);
                 }
@@ -171,7 +159,7 @@ function process_directory(archetype_path, dir, mojit_dir, template, force) {
     // console.log('reading dir: ' + path.join(archetype_path, dir));
 
     files = fs.readdirSync(path.join(archetype_path, dir));
-    files.forEach(function(f) {
+    files.forEach(function (f) {
         var s = fs.statSync(path.join(archetype_path, '/', dir, '/', f));
 
         if (f.charAt(0) === '.') {
@@ -460,10 +448,9 @@ function isMojitoApp(dir, usage, die) {
     // - the file above must require('mojito')
 
     var requiresMojito = /require\s*\(\s*'mojito'\s*\)/,
-        isMojito = false,
-        checker;
+        isMojito = false;
 
-    checker = function(file) {
+    function checker(file) {
         var filepath,
             contents;
 
@@ -473,7 +460,7 @@ function isMojitoApp(dir, usage, die) {
             contents = fs.readFileSync(filepath, 'utf-8');
             isMojito = requiresMojito.test(contents);
         }
-    };
+    }
 
     ['server.js', 'index.js'].forEach(checker);
 


### PR DESCRIPTION
if process.stdout is not a tty (i.e. a pipe) the
console.log interpreted the message as an object,
not a (colorized) string.

note: warn() & error() previously wrote to stdout,
now write to stderr.

cherry-picked from 3fd55c9f975bd44c59f5bfd8db7f89322010d981 and b19c53f021ca0a21d0edd5f37f1ee56241f8ebc6

Conflicts:
    lib/management/utils.js
