### PR TITLE
Add logic to time out contexts in 60 seconds if they don't call ac.done or ac.error

### DIFF
--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -123,6 +123,10 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         done,
         error,
 
+        // zombie timeout. user processes must call ac.done or ac.error in this
+        // time limit or the framework will call ac.error with a timeout code.
+        CONTEXT_TIMEOUT = 60000,
+
         // serializer container
         serializer,
         CACHE = { renderers: { } };
@@ -306,6 +310,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         // in here we should whitelist the stuff we need
         this.staticAppConfig = {
+            contextTimeout: staticAppConfig.contextTimeout || CONTEXT_TIMEOUT,
             pathToRoot: staticAppConfig.pathToRoot,
             cacheViewTemplates: staticAppConfig.cacheViewTemplates,
             viewEngineOptions: staticAppConfig.viewEngine
@@ -339,6 +344,27 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         perf = Y.mojito.perf.timeline('mojito', 'action:call',
             'the initial syncronous part of the action', command);
 
+        // Reap the request/ac process within the timeout. If ac.done or
+        // ac.error is invoked by user code prior to the time limit this timer
+        // will be cleared.
+        this.timer = setTimeout(function() {
+            var err,
+                msg = 'Killing potential zombie context for ' +
+                    my.type + '/' + my.instance.controller +
+                    '[' + actionFunction + '](...);';
+
+            // Clear the timer reference so our invocation of error() doesn't
+            // try to clear it. 
+            my.timer = null;
+
+            // Create an HTTP Timeout error with controller/action info.
+            err = new Error(msg);
+            err.code = 408;
+
+            my.error(err);
+
+        }, this.staticAppConfig.contextTimeout);
+
         controller[actionFunction](this);
 
         perf.done(); // closing the 'action:call' timeline
@@ -363,6 +389,12 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         * @param {object} meta Any meta-data required to service the request.
         */
         done: function(data, meta, more) {
+
+            // If we have an active timer clear it immediately. 
+            if (this.timer) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
 
             var callbackFunc = more ? 'flush' : 'done',
                 instance = this.command.instance,
@@ -568,6 +600,11 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         *     "This does not exist in my app".
         */
         error: function(err) {
+            // If we have an active timer clear it immediately. 
+            if (this.timer) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
             this._adapter.error(err);
         }
     };

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -123,10 +123,6 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         done,
         error,
 
-        // zombie timeout. user processes must call ac.done or ac.error in this
-        // time limit or the framework will call ac.error with a timeout code.
-        CONTEXT_TIMEOUT = 60000,
-
         // serializer container
         serializer,
         CACHE = { renderers: { } };
@@ -310,7 +306,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
 
         // in here we should whitelist the stuff we need
         this.staticAppConfig = {
-            contextTimeout: staticAppConfig.contextTimeout || CONTEXT_TIMEOUT,
+            actionTimeout: staticAppConfig.actionTimeout,
             pathToRoot: staticAppConfig.pathToRoot,
             cacheViewTemplates: staticAppConfig.cacheViewTemplates,
             viewEngineOptions: staticAppConfig.viewEngine
@@ -345,25 +341,28 @@ YUI.add('mojito-action-context', function(Y, NAME) {
             'the initial syncronous part of the action', command);
 
         // Reap the request/ac process within the timeout. If ac.done or
-        // ac.error is invoked by user code prior to the time limit this timer
-        // will be cleared.
-        this.timer = setTimeout(function() {
-            var err,
-                msg = 'Killing potential zombie context for ' +
-                    my.type + '/' + my.instance.controller +
-                    '[' + actionFunction + '](...);';
+        // ac.error is invoked by user code prior to the time limit this
+        // timer will be cleared.
+        if (this.staticAppConfig.actionTimeout) {
+            this._timer = setTimeout(function() {
+                var err,
+                    msg = 'Killing potential zombie context for Mojit type: ' +
+                        my.instance.type +
+                        ', controller: ' + my.instance.controller +
+                        ', action: ' + actionFunction;
 
-            // Clear the timer reference so our invocation of error() doesn't
-            // try to clear it. 
-            my.timer = null;
+                // Clear the timer reference so our invocation of error() 
+                // doesn't try to clear it. 
+                my._timer = null;
 
-            // Create an HTTP Timeout error with controller/action info.
-            err = new Error(msg);
-            err.code = 408;
+                // Create an HTTP Timeout error with controller/action info.
+                err = new Error(msg);
+                err.code = 408;
 
-            my.error(err);
+                my.error(err);
 
-        }, this.staticAppConfig.contextTimeout);
+            }, this.staticAppConfig.actionTimeout);
+        }
 
         controller[actionFunction](this);
 
@@ -391,9 +390,9 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         done: function(data, meta, more) {
 
             // If we have an active timer clear it immediately. 
-            if (this.timer) {
-                clearTimeout(this.timer);
-                this.timer = null;
+            if (this._timer) {
+                clearTimeout(this._timer);
+                this._timer = null;
             }
 
             var callbackFunc = more ? 'flush' : 'done',
@@ -601,9 +600,9 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         */
         error: function(err) {
             // If we have an active timer clear it immediately. 
-            if (this.timer) {
-                clearTimeout(this.timer);
-                this.timer = null;
+            if (this._timer) {
+                clearTimeout(this._timer);
+                this._timer = null;
             }
             this._adapter.error(err);
         }

--- a/lib/config.json
+++ b/lib/config.json
@@ -2,6 +2,7 @@
     "###": "Copyright (c) 2012 Yahoo! Inc. All rights reserved.",
 
     "appConfigBase": {
+        "actionTimeout": 60000,
         "mojitsDirs": [ "mojits" ],
         "routesFiles": [ "routes.json" ],
         "tunnelPrefix": "/tunnel",


### PR DESCRIPTION
It's possible for user code to overlook calling ac.done or ac.error and those processes will just quietly fill up the server without any notice. This code provides notice of such cases and triggers ac.error directly to advise the developer of possible issues. The value can be overridden by setting an MS count in the application config for contextTimeout.
