### PR TITLE
modify run.js so that when context param is null, no --context flag in mojito command

### DIFF
--- a/tests/run.js
+++ b/tests/run.js
@@ -307,10 +307,10 @@ function runMojitoApp (basePath, path, port, params, callback) {
     params = params || '';
     console.log('Starting ' + path + ' at port ' + port + ' with params ' + (params || 'empty'));
     var p;
-    if (params) {
-        p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port, "--context", params], function () {});
-    } else {
+    if (params === '') {
         p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port], function () {});
+    } else {
+        p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port, "--context", params], function () {});
     }
     pids.push(p.pid);
     pidNames[p.pid] = libpath.basename(path) + ':' + port + (params ? '?' + params : '');

--- a/tests/run.js
+++ b/tests/run.js
@@ -187,7 +187,7 @@ function deploy (cmd, callback) {
                             });
                         })();
                     }
-                } else if (app.enabled === "true" && app.path && port) {
+                } else if (app.enabled === "true" && app.path) {
                     appSeries.push(function (callback) {
                         runMojitoApp(cmd.funcPath + '/applications', app.path, port, app.param, callback);
                     });
@@ -306,7 +306,12 @@ function runCommand (path, command, argv, callback) {
 function runMojitoApp (basePath, path, port, params, callback) {
     params = params || '';
     console.log('Starting ' + path + ' at port ' + port + ' with params ' + (params || 'empty'));
-    var p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port, "--context", params], function () {});
+    var p;
+    if (params) {
+        p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port, "--context", params], function () {});
+    } else {
+        p = runCommand(basePath + '/' + path, cwd + "/../bin/mojito", ["start", port], function () {});
+    }
     pids.push(p.pid);
     pidNames[p.pid] = libpath.basename(path) + ':' + port + (params ? '?' + params : '');
     // Give each app a second to start


### PR DESCRIPTION
"mojito start --context" gives error "Invalid command line". Modify run.js to avoid this error when starting apps.  Also, when there is no port number is specified for an app in apps.json, the app should be started with port specified in app configs or using mojito default. 
