### PR TITLE
fix arrow version to v67 for debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "async": "*",
         "commander": "1.0.1",
         "node-static": ">0.6",
-        "yahoo-arrow": "~0.0.64"
+        "yahoo-arrow": "0.0.67"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {


### PR DESCRIPTION
From using arrow v68 and ynodejs08(happened at the same time), arrow only run one tests from descriptor then exit. This change is only for debugging purpose.
