### PR TITLE
optimizing the cache key for instances by relying on type and base only

### DIFF
--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -528,11 +528,12 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          */
         expandInstanceForEnv: function(env, instance, ctx, cb) {
 
+            // TODO: fakeInstance could be even more optimized, where
+            // type has priority over base, and only one of them is really
+            // needed.
             var fakeInstance = {
                     base: instance.base,
-                    action: instance.action,
-                    type: instance.type,
-                    id: instance.id
+                    type: instance.type
                 },
                 posl = this.selector.getPOSLFromContext(ctx),
                 // We need to include the lang, since it's a part of the context
@@ -561,7 +562,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 return cb(err);
             }
             spec.config = spec.config || {};
-            spec.action = spec.action || 'index';
             if (!spec.instanceId) {
                 spec.instanceId = Y.guid();
             }


### PR DESCRIPTION
this should fix any memory allocation when using id as part of the instance object before expanding it. also, shaker does not use action anymore, so we are removing it.
