### PR TITLE
support for custom version of yui at the app level

### DIFF
--- a/lib/yui-sandbox.js
+++ b/lib/yui-sandbox.js
@@ -2,17 +2,32 @@
 
 'use strict';
 
-var fs = require('fs'),
-    path = require('path'),
-    vm = require('vm'),
-    code = {
-        min: fs.readFileSync(path.join(__dirname, '..',
-            'node_modules', 'yui', 'yui-nodejs', 'yui-nodejs-min.js'), 'utf8'),
-        raw: fs.readFileSync(path.join(__dirname, '..',
-            'node_modules', 'yui', 'yui-nodejs', 'yui-nodejs.js'), 'utf8'),
-        debug: fs.readFileSync(path.join(__dirname, '..',
-            'node_modules', 'yui', 'yui-nodejs', 'yui-nodejs-debug.js'), 'utf8')
-    };
+var libfs   = require('fs'),
+    libpath = require('path'),
+    libvm   = require('vm'),
+    appRoot = process.cwd(),
+    // trying to use the yui version installed at the app level
+    // since thats the only way to customize it per app.
+    yuiRoot = libpath.join(appRoot, 'node_modules', 'yui'),
+    code;
+
+if (!(libfs.existsSync || libpath.existsSync)(yuiRoot)) {
+    // using the yui bundle with mojito by default if the yui
+    // is not installed as part of the app.
+    yuiRoot = libpath.join(__dirname, '..', 'node_modules', 'yui');
+} else {
+    console.warn('This application is using a custom version of YUI [' +
+        yuiRoot + '] instead of the official version bundled with mojito.');
+}
+
+code = {
+    min: libfs.readFileSync(libpath.join(yuiRoot,
+        'yui-nodejs', 'yui-nodejs-min.js'), 'utf8'),
+    raw: libfs.readFileSync(libpath.join(yuiRoot,
+        'yui-nodejs', 'yui-nodejs.js'), 'utf8'),
+    debug: libfs.readFileSync(libpath.join(yuiRoot,
+        'yui-nodejs', 'yui-nodejs-debug.js'), 'utf8')
+};
 
 /*
     This is a hack to get an isolated YUI object. This is EXPERIMENTAL,
@@ -42,10 +57,10 @@ exports.getYUI = function (filter) {
         clearInterval: clearInterval,
         JSON: JSON,
         __filename: __filename,
-        __dirname: path.join(__dirname, '..', 'node_modules', 'yui', 'yui-nodejs'),
+        __dirname: libpath.join(yuiRoot, 'yui-nodejs'),
         exports: {}
     };
     filter = (filter && code.hasOwnProperty(filter)) ? filter : 'raw';
-    vm.runInNewContext(code[filter], sandbox, 'build/yui-new/yui-new.js');
+    libvm.runInNewContext(code[filter], sandbox, 'build/yui-new/yui-new.js');
     return sandbox.exports.YUI;
 };


### PR DESCRIPTION
- by using `npm i yui@<some-version>` in the app folder, at the same level then `mojito`, it will force mojito to rely on that version of `yui`.
- a warning message will be issued to announce the detection of the new `yui` version.
- this version will affect server and client.
- for customization of the client side only for online apps, you can use application.json->yui->config settings instead.

TODO:
- test this in manhattan
- add unit test
