### PR TITLE
coverage reports to artifacts/test/coverage not artifacts/testcoverage

### DIFF
--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -19,7 +19,7 @@ var pathlib = require('path'),
     fwTestsRoot = BASE + 'lib/tests',
     resultsDir = 'artifacts/test',
     resultsFile = 'artifacts/test/result.xml',
-    coverageDir = 'artifacts/testcoverage',
+    coverageDir = 'artifacts/test/coverage',
     coverageFile = coverageDir + '/coverage.json',
 
     utils = require(BASE + 'lib/management/utils'),


### PR DESCRIPTION
path was incorrect

after patch:

```
% cd examples/newsboxes/
% mojito test app -c .
% open artifacts/test/coverage/lcov-report/index.html
% ll artifacts/test/coverage/coverage.json
-rw-r--r--  1 isao  staff  12482 Nov 13 15:44 artifacts/test/coverage/coverage.json
```
