### PR TITLE
guard against empty module info return value

### DIFF
--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
-/*jslint anon:true, sloppy:true, nomen:true, stupid:true, node:true*/
+/*jslint anon:true, nomen:true, stupid:true, continue:true, node:true*/
 /*global YUI*/
 
 

--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -577,7 +577,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
 
             // used to find the the modules in YUI itself
             Ysandbox.use('loader');
-            modules = (new Ysandbox.Loader(Ysandbox.config)).moduleInfo;
+            modules = (new Ysandbox.Loader(Ysandbox.config)).moduleInfo || {};
 
             for (name in modules) {
                 if (modules.hasOwnProperty(name)) {


### PR DESCRIPTION
Should prevent the following error, referenced in the favicon trello task

```
  TypeError: Cannot read property 'name' of undefined

  at RSAddonYUI.getResourceContent (/home/y/share
  node/manhattan_app_search_apps_news/node_modules
  /mojito/lib/app/addons/rs/yui.js:573:31)
```

also rm sloppy jslint config, as it's no longer needed
