### PR TITLE
resolving yui module name collision

### DIFF
--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -149,7 +149,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
             this.yuiConfig = (this.staticAppConfig.yui && this.staticAppConfig.yui.config) || {};
             this.langs = {};            // keys are list of languages in the app, values are simply "true"
             this.resContents    = {};      // res.id: contents
-            this.appModulesRess = {};      // res.yui.name: module ress
+            this.appModulesRess = {};      // res.yui.name: module ress accessible over the network
             this.yuiModulesRess = {};      // res.yui.name: fake ress
         },
 
@@ -375,8 +375,14 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 res.name = res.yui.name;
                 res.id = [res.type, res.subtype, res.name].join('-');
                 this.langs[res.yui.lang] = true;
-                // caching the res
-                this.appModulesRess[res.yui.name] = res;
+                // caching the lang res
+                if (this.appModulesRess[res.yui.name]) {
+                    Y.log('Language bundle collision for name=' + res.yui.name +
+                        '. Choosing: ' + this.appModulesRess[res.yui.name].source.fs.fullPath +
+                        ' over ' + res.source.fs.fullPath, 'warn', NAME);
+                } else {
+                    this.appModulesRess[res.yui.name] = res;
+                }
                 if (res.yui.name === 'lang/' + res.yui.langFor) {
                     res.yui.isRootLang = true;
                 }
@@ -405,8 +411,17 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 this._captureYUIModuleDetails(res);
                 res.name = res.yui.name;
                 res.id = [res.type, res.subtype, res.name].join('-');
-                // caching the res
-                this.appModulesRess[res.yui.name] = res;
+                // caching the res if it is accesible form client since
+                // the appModulesRes is used to server static files.
+                if (res.affinity !== 'server') {
+                    if (this.appModulesRess[res.yui.name]) {
+                        Y.log('YUI module collision for name=' + res.yui.name +
+                            '. Choosing: ' + this.appModulesRess[res.yui.name].source.fs.fullPath +
+                            ' over ' + res.source.fs.fullPath, 'warn', NAME);
+                    } else {
+                        this.appModulesRess[res.yui.name] = res;
+                    }
+                }
                 return new Y.Do.Halt(null, res);
             }
         },

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -861,7 +861,13 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 for (r = 0; r < ress.length; r += 1) {
                     res = ress[r];
                     if (res.url && res.source.fs.isFile) {
-                        urls[res.url] = res;
+                        if (urls[res.url]) {
+                            Y.log('Url collision for ' + res.url +
+                                '. Choosing: ' + urls[res.url].source.fs.fullPath +
+                                ' over ' + res.source.fs.fullPath, 'warn', NAME);
+                        } else {
+                            urls[res.url] = res;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- solve the case where a developer wants to override mojito-client or any other client or common affinity file defined by mojito core.
