### PR TITLE
splitting dispatch logic

### DIFF
--- a/lib/app/autoload/dispatch.client.js
+++ b/lib/app/autoload/dispatch.client.js
@@ -113,8 +113,8 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             // TODO: we need to find a way to clean this for apps
             // that attent to create and destroy mojits from the page
             // but maybe we can just wait for the YAF refactor.
-            if (!_cacheControllers[command.instanceId]) {
-                _cacheControllers[command.instanceId] =
+            if (!_cacheControllers[command.instance.instanceId]) {
+                _cacheControllers[command.instance.instanceId] =
                     Y.mojito.util.heir(Y.mojito.controllers[command.instance.controller]);
             }
 
@@ -123,7 +123,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             try {
                 ac = new Y.mojito.ActionContext({
                     command: command,
-                    controller: _cacheControllers[command.instanceId],
+                    controller: _cacheControllers[command.instance.instanceId],
                     dispatcher: this,         // NOTE passing dispatcher.
                     adapter: adapter,
                     store: this.store
@@ -186,10 +186,10 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                 return;
             }
 
-            if (command.instanceId && _cacheInstances[command.instanceId]) {
+            if (command.instance.instanceId && _cacheInstances[command.instance.instanceId]) {
                 Y.log('Re-using instance with instanceId=' +
-                    command.instanceId, 'info', NAME);
-                command.instance = _cacheInstances[command.instanceId];
+                    command.instance.instanceId, 'info', NAME);
+                command.instance = _cacheInstances[command.instance.instanceId];
                 this._useController(command, adapter);
                 return;
             }
@@ -220,7 +220,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                     // TODO: we need to find a way to clean this for apps
                     // that attent to create and destroy mojits from the page
                     // but maybe we can just wait for the YAF refactor.
-                    _cacheInstances[command.instanceId] = instance;
+                    _cacheInstances[instance.instanceId] = instance;
 
                     // We replace the given instance with the expanded instance.
                     command.instance = instance;

--- a/lib/app/autoload/dispatch.client.js
+++ b/lib/app/autoload/dispatch.client.js
@@ -18,6 +18,12 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
 
     'use strict';
 
+    // on the server side, controllers are stateless, but on
+    // the client, things are different, we can cache them by
+    // instanceId to re-use them when possible.
+    var _cacheInstances = {},
+        _cacheControllers = {};
+
     Y.namespace('mojito').Dispatcher = {
 
         /**
@@ -60,17 +66,11 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                 instance = command.instance,
                 modules = [];
 
-            // For performance reasons we don't want to support
-            // this ondemand "use" in the server side since
-            // all the requirements are already in place.
-            if (command.context.runtime === 'server') {
-                adapter.error(new Error('Invalid controller name [' +
-                    instance.controller + '] for mojit [' +
-                    instance.type + '].'));
-                return;
-            }
+            // TODO: part of the optimization here can be to
+            // avoid calling use when the controller already exists.
 
-            // attach controller to Y ondemand
+            // use controller's yui module name to attach
+            // the controller to Y ondemand
             modules.push(instance.controller);
 
             // TODO: this is a hack to attach the correct engine, the problem
@@ -105,23 +105,32 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
          */
         _createActionContext: function (command, adapter) {
             var ac,
-                controller = Y.mojito.controllers[command.instance.controller],
                 perf = Y.mojito.perf.timeline('mojito', 'ac:ctor',
                     'create ControllerContext', command);
+
+            // the controller is not stateless on the client, we
+            // store it for re-use.
+            // TODO: we need to find a way to clean this for apps
+            // that attent to create and destroy mojits from the page
+            // but maybe we can just wait for the YAF refactor.
+            if (!_cacheControllers[command.instanceId]) {
+                _cacheControllers[command.instanceId] =
+                    Y.mojito.util.heir(Y.mojito.controllers[command.instance.controller]);
+            }
 
             // Note that creation of an ActionContext current causes
             // immediate invocation of the dispatch() call.
             try {
                 ac = new Y.mojito.ActionContext({
                     command: command,
-                    controller: Y.mojito.util.heir(controller),
+                    controller: _cacheControllers[command.instanceId],
                     dispatcher: this,         // NOTE passing dispatcher.
                     adapter: adapter,
                     store: this.store
                 });
             } catch (e) {
                 Y.log('Error from dispatch on instance \'' +
-                    (command.instance.id || '@' + command.instance.type) +
+                    (command.instance.base || '@' + command.instance.type) +
                     '\':', 'error', NAME);
                 Y.log(e.message, 'error', NAME);
                 Y.log(e.stack, 'error', NAME);
@@ -146,8 +155,8 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
 
             } else {
 
-                adapter.error(new Error('RPC tunnel is not available in the ' +
-                    command.context.runtime + ' runtime.'));
+                adapter.error(new Error('RPC tunnel is not available in the [' +
+                    command.context.runtime + '] runtime.'));
 
             }
         },
@@ -171,11 +180,22 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             store.validateContext(command.context);
 
             if (command.rpc) {
-                // forcing to dispatch command through RPC tunnel
+                Y.log('Command with rpc flag, dispatching through RPC tunnel',
+                    'info', NAME);
                 this.rpc(command, adapter);
                 return;
             }
 
+            if (command.instanceId && _cacheInstances[command.instanceId]) {
+                Y.log('Re-using instance with instanceId=' +
+                    command.instanceId, 'info', NAME);
+                command.instance = _cacheInstances[command.instanceId];
+                this._useController(command, adapter);
+                return;
+            }
+
+            // if no rpc flag and no instance cached, we try to
+            // expand the instance before creating the ActionContext.
             store.expandInstance(command.instance, command.context,
                 function (err, instance) {
 
@@ -195,19 +215,19 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
 
                     }
 
+                    // the instance is not stateless on the client, we
+                    // store it for re-use.
+                    // TODO: we need to find a way to clean this for apps
+                    // that attent to create and destroy mojits from the page
+                    // but maybe we can just wait for the YAF refactor.
+                    _cacheInstances[command.instanceId] = instance;
+
                     // We replace the given instance with the expanded instance.
                     command.instance = instance;
 
-                    // if this controller does not exist yet, we should try
-                    // to require it along with it depedencies.
-                    if (!Y.mojito.controllers[instance.controller]) {
-                        // requiring the controller and its dependencies
-                        // before dispatching AC
-                        my._useController(command, adapter);
-                    } else {
-                        // dispatching AC
-                        my._createActionContext(command, adapter);
-                    }
+                    // requiring the controller and its dependencies
+                    // before dispatching AC
+                    my._useController(command, adapter);
 
                 });
         }

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*jslint anon:true, nomen:true*/
+/*global YUI*/
+
+
+/**
+ * This object is responsible for running mojits.
+ * @class MojitoDispatcher
+ * @static
+ * @public
+ */
+YUI.add('mojito-dispatcher', function (Y, NAME) {
+
+    'use strict';
+
+    Y.namespace('mojito').Dispatcher = {
+
+        /**
+         * Initializes the dispatcher instance.
+         * @method init
+         * @public
+         * @param {Y.mojito.ResourceStore} resourceStore the store to use.
+         * @param {Y.mojito.TunnelClient} rpcTunnel optional tunnel client for RPC calls
+         * @return {Y.mojito.Dispatcher}
+         */
+        init: function (resourceStore, rpcTunnel) {
+
+            if (!resourceStore) {
+                throw new Error(
+                    'Mojito cannot instantiate without a resource store.'
+                );
+            }
+
+            // Cache parameters as instance variables for the dispatch() call to
+            // reference.
+            this.store = resourceStore;
+            this.tunnel = rpcTunnel;
+
+            Y.log('Dispatcher created', 'debug', NAME);
+
+            return this;
+        },
+
+        /**
+         * Create AC object for a particular controller.
+         * @method _createActionContext
+         * @protected
+         * @param {object} command the command to dispatch
+         * @param {OutputAdapter} adapter the output adapter
+         */
+        _createActionContext: function (command, adapter) {
+            var ac,
+                controller = Y.mojito.controllers[command.instance.controller],
+                perf = Y.mojito.perf.timeline('mojito', 'ac:ctor',
+                    'create ControllerContext', command);
+
+            // Note that creation of an ActionContext current causes
+            // immediate invocation of the dispatch() call.
+            try {
+                ac = new Y.mojito.ActionContext({
+                    command: command,
+                    controller: Y.mojito.util.heir(controller),
+                    dispatcher: this,         // NOTE passing dispatcher.
+                    adapter: adapter,
+                    store: this.store
+                });
+            } catch (e) {
+                Y.log('Error from dispatch on instance \'' +
+                    (command.instance.id || '@' + command.instance.type) +
+                    '\':', 'error', NAME);
+                Y.log(e.message, 'error', NAME);
+                Y.log(e.stack, 'error', NAME);
+                adapter.error(e);
+            }
+            perf.done(); // closing the 'ac:ctor' timeline
+        },
+
+        /**
+         * Executes a command in a remote runtime if possible.
+         * @method rpc
+         * @public
+         * @param {object} command the command to dispatch
+         * @param {OutputAdapter} adapter the output adapter
+         */
+        rpc: function (command, adapter) {
+            if (this.tunnel) {
+
+                Y.log('Dispatching instance "' + (command.instance.base || '@' +
+                    command.instance.type) + '" through RPC tunnel.', 'info', NAME);
+                this.tunnel.rpc(command, adapter);
+
+            } else {
+
+                adapter.error(new Error('RPC tunnel is not available in the ' +
+                    command.context.runtime + ' runtime.'));
+
+            }
+        },
+
+        /**
+         * Dispatch a command in the current runtime, or fallback
+         * to a remote runtime when posible.
+         * @method dispatch
+         * @public
+         * @param {object} command the command to dispatch
+         * @param {OutputAdapter} adapter the output adapter
+         */
+        dispatch: function (command, adapter) {
+
+            var my = this,
+                store = this.store,
+                perf = Y.mojito.perf.timeline('mojito',
+                    'dispatch:expandInstance',
+                    'gather details about mojit', command);
+
+            store.validateContext(command.context);
+
+            if (command.rpc) {
+                // forcing to dispatch command through RPC tunnel
+                this.rpc(command, adapter);
+                return;
+            }
+
+            store.expandInstance(command.instance, command.context,
+                function (err, instance) {
+
+                    perf.done(); // closing 'dispatch:expandInstance' timeline
+
+                    if (err || !instance || !instance.controller) {
+
+                        adapter.error(new Error('Cannot expand instance [' + (command.instance.base || '@' +
+                            command.instance.type) + '], or instance.controller is undefined'));
+                        return;
+
+                    }
+
+                    // We replace the given instance with the expanded instance.
+                    command.instance = instance;
+
+                    if (!Y.mojito.controllers[instance.controller]) {
+                        // the controller was not found, we should halt
+                        adapter.error(new Error('Invalid controller name [' +
+                            command.instance.controller + '] for mojit [' +
+                            command.instance.type + '].'));
+                    } else {
+                        // dispatching AC
+                        my._createActionContext(command, adapter);
+                    }
+
+                });
+        }
+
+    };
+
+}, '0.1.0', {requires: [
+    'mojito-action-context',
+    'mojito-util'
+]});

--- a/tests/unit/lib/app/autoload/autoload_test_descriptor.json
+++ b/tests/unit/lib/app/autoload/autoload_test_descriptor.json
@@ -16,13 +16,21 @@
                 },
                 "group": "fw,unit,client,server"
             },
-            "dispatch.common": {
+            "dispatch.server": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",
-                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.common.js",
-                    "test": "./test-dispatch.common.js"
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.server.js",
+                    "test": "./test-dispatch.server.js"
                 },
-                "group": "fw,unit,client,server"
+                "group": "fw,unit,server"
+            },
+            "dispatch.client": {
+                "params": {
+                    "page": "$$config.base$$/mojito-test.html",
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.client.js",
+                    "test": "./test-dispatch.client.js"
+                },
+                "group": "fw,unit,client"
             },
             "mojit-proxy.client": {
                 "params": {

--- a/tests/unit/lib/app/autoload/test-dispatch.client.js
+++ b/tests/unit/lib/app/autoload/test-dispatch.client.js
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+YUI.add('mojito-dispatcher-client-tests', function(Y, NAME) {
+
+    var suite = new Y.Test.Suite(NAME),
+        A = Y.Assert,
+        dispatcher = Y.mojito.Dispatcher,
+        store,
+        command,
+        adapter;
+
+    suite.add(new Y.Test.Case({
+
+        name: 'dispatch',
+
+        'setUp': function() {
+            store = {
+                getAppConfig: function() {
+                    return { yui: { dependencyCalculations: 'ondemand' } };
+                },
+                getStaticContext: function () {
+                },
+                getRoutes: function() {
+                },
+                validateContext: function() {
+                },
+                expandInstance: function(instance, context, cb) {
+                    cb(null, {
+                        type: instance.type,
+                        id: 'xyz123',
+                        instanceId: 'xyz123',
+                        'controller-module': 'dispatch',
+                        yui: {
+                            config: {},
+                            langs: [],
+                            requires: [],
+                            sorted: ['mojito', 'mojito-action-context'],
+                            sortedPaths: {}
+                        }
+                    });
+                }
+            };
+
+            command = {
+                action: 'index',
+                instance: {
+                    type: 'M'
+                },
+                context: {
+                    lang: 'klingon',
+                    langs: 'klingon'
+                }
+            };
+
+            adapter = {};
+        },
+
+        'tearDown': function() {
+            store = null;
+            command = null;
+            adapter = null;
+        },
+
+        'test rpc with tunnel': function () {
+            var tunnel,
+                tunnelCommand;
+
+            tunnel = {
+                rpc: function (c, a) {
+                    tunnelCommand = c;
+                }
+            };
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            dispatcher.rpc(command, {
+                error: function () {
+                    A.fail('tunnel should be called instead');
+                }
+            });
+            A.areSame(command, tunnelCommand, 'delegate command to tunnel');
+        },
+
+        'test rpc without tunnel available': function () {
+            var tunnel,
+                errorTriggered,
+                tunnelCommand;
+
+            tunnel = null;
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            dispatcher.rpc(command, {
+                error: function () {
+                    errorTriggered = true;
+                }
+            });
+            A.isTrue(errorTriggered, 'if tunnel is not set, it should call adapter.error');
+        },
+
+        'test dispatch with command.rpc=1': function () {
+            var tunnel,
+                tunnelCommand;
+
+            tunnel = {
+                rpc: function (c, a) {
+                    tunnelCommand = c;
+                }
+            };
+            command.rpc = 1;
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            dispatcher.rpc(command, {
+                error: function () {
+                    A.fail('tunnel should be called instead');
+                }
+            });
+            A.areSame(command, tunnelCommand, 'delegate command to tunnel');
+        },
+
+        'test dispatch with invalid mojit': function () {
+            var tunnel,
+                tunnelCommand;
+
+            tunnel = {
+                rpc: function (c, a) {
+                    tunnelCommand = c;
+                }
+            };
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            // if the expandInstance calls with an error, the tunnel
+            // should be tried.
+            store.expandInstance = function (instance, context, callback) {
+                callback({error: 1});
+            };
+            dispatcher.dispatch(command, {
+                error: function () {
+                    A.fail('tunnel should be called instead');
+                }
+            });
+            A.areSame(command, tunnelCommand, 'delegate command to tunnel');
+        },
+
+        'test dispatch with valid controller': function () {
+            var tunnel,
+                useCommand,
+                _useController = dispatcher._useController;
+
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            // if the expandInstance calls with an error, the tunnel
+            // should be tried.
+            store.expandInstance = function (instance, context, callback) {
+                instance.controller = 'foo';
+                Y.mojito.controllers[instance.controller] = {
+                    fakeController: true
+                };
+                callback(null, instance);
+            };
+            dispatcher._useController = function (c) {
+                useCommand = c;
+            };
+            dispatcher.dispatch(command, {
+                error: function () {
+                    A.fail('_useController should be called instead');
+                }
+            });
+            A.areSame(command, useCommand, '_useController should be issued to attach modules.');
+
+            // restoring references
+            dispatcher._useController = _useController;
+        },
+
+        'test dispatch with invalid controller': function () {
+            var tunnel,
+                useCommand,
+                acCommand,
+                _createActionContext = dispatcher._createActionContext,
+                _useController = dispatcher._useController;
+
+            errorTriggered = false;
+            dispatcher.init(store, tunnel);
+            // if the expandInstance calls with an error, the tunnel
+            // should be tried.
+            store.expandInstance = function (instance, context, callback) {
+                instance.controller = 'foo';
+                Y.mojito.controllers[instance.controller] = null;
+                callback(null, instance);
+            };
+            dispatcher._useController = function (c) {
+                useCommand = c;
+            };
+            dispatcher._createActionContext = function (c) {
+                A.fail('_createActionContext should be called instead');
+            };
+            dispatcher.dispatch(command, {
+                error: function () {
+                    A.fail('_useController should be called instead');
+                }
+            });
+            A.areSame(command, useCommand, '_useController should be called based on the original command');
+
+            // restoring references
+            dispatcher._createActionContext = _createActionContext;
+            dispatcher._useController = _useController;
+        }
+
+    }));
+
+
+    Y.Test.Runner.add(suite);
+
+}, '0.0.1', {requires: ['mojito-dispatcher']});


### PR DESCRIPTION
- client and server controllers have different nature (stateless vs long live)
- this solves the problem of calling the actions in the same mojit in the client side, in which case the same instance and dispatcher should be used.
