### PR TITLE
fix `mojito compile` fatal error

### DIFF
--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -42,7 +42,7 @@ var libpath = require('path'),
     options,
     run,
     YuiModuleCacher,
-    Y = libutils.yuiuse({
+    Y = libutils.getYUIInstance({
         'async-queue': null,
         'json-parse': null,
         'json-stringify': null,

--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -12,9 +12,12 @@
 var libpath = require('path'),
     libfs = require('fs'),
     existsSync = libfs.existsSync || libpath.existsSync,
-    libutils = require(libpath.join(__dirname, '../../management/utils')),
-    Mojito = require(libpath.join(__dirname, '../../mojito')),
-    Store = require(libpath.join(__dirname, '../../store')),
+
+    // paths
+    BASE = libpath.resolve(__dirname, '../../../') + '/',
+    libutils = require(BASE + 'lib/management/utils'),
+    Mojito = require(BASE + 'lib/mojito'),
+    Store = require(BASE + 'lib/store'),
 
     // private compilation function container
     compile = {},
@@ -39,10 +42,13 @@ var libpath = require('path'),
     options,
     run,
     YuiModuleCacher,
-    Y = require('yui').YUI({useSync: true}).use('json-parse', 'json-stringify', 'async-queue');
-
-Y.applyConfig({useSync: false});
-
+    Y = libutils.yuiuse({
+        'async-queue': null,
+        'json-parse': null,
+        'json-stringify': null,
+        'mojito-hb': BASE + 'lib/app/addons/view-engines/mu.server.js',
+        'mojito-mu': BASE + 'lib/app/addons/view-engines/hb.server.js'
+    });
 
 usage = 'mojito compile {options} {type}\n' +
     '\nOPTIONS: \n' +
@@ -506,8 +512,6 @@ compile.rollups = function(context, options, callback) {
         shortDest,
         rollupBody;
 
-    store.preload();
-
     libutils.log((options.remove ? 'Removing' : 'Creating') + ' rollups...');
 
     if (options.app || options.core) {
@@ -615,7 +619,6 @@ compile.views = function(context, options, callback) {
         store = makeStore({root: cwd}),
         compiledFilename = '/autoload/compiled/views.common.js',
         mojits,
-        yuiConfig,
         renderer,
         renderedView,
         action = options.remove ? 'Removed' : 'Created',
@@ -625,7 +628,6 @@ compile.views = function(context, options, callback) {
         source,
         engine,
         mojitViews = {},
-        YUI = require('yui').YUI,
         compilerQueue = new Y.AsyncQueue();
 
     // there are no views in the app, so no need to do this
@@ -633,8 +635,6 @@ compile.views = function(context, options, callback) {
         libutils.warn('Compiling app-level views not supported\n');
         return callback();
     }
-
-    store.preload();
 
     libutils.log((options.remove ? 'Removing compiled' : 'Compiling') +
         ' views...');
@@ -651,12 +651,11 @@ compile.views = function(context, options, callback) {
             mojitNs = mojitName.replace(/\./g, '_'),
             yuiModuleCacheWriter,
             viewName,
-            MojY,
             compileFunction;
 
         mojitRes = store.getResources('server', context, {type: 'mojit', name: mojitName});
         if (!mojitRes || !mojitRes.length) {
-            callback('Unknown mojit "' + options.mojit + '"');
+            return callback('Unknown mojit "' + options.mojit + '"');
         }
         mojitRes = mojitRes[0];
 
@@ -703,14 +702,12 @@ compile.views = function(context, options, callback) {
                         // We have a view to compile
                         source = view['content-path'];
                         engine = view.engine;
-                        yuiConfig = mojit.yui.config;
-                        yuiConfig.useSync = true;
 
-                        MojY = YUI(yuiConfig).use('mojito-' + engine);
-                        renderer = new (MojY.mojito.addons.viewEngines[engine])();
-
-                        if (typeof renderer.compiler === 'function') {
+                        if (Y.mojito.addons.viewEngines[engine]) {
+                            renderer = new (Y.mojito.addons.viewEngines[engine])();
                             compilerQueue.add(Y.bind(compileFunction, self, renderer, source, mojitNs, viewName));
+                        } else {
+                            libutils.warn('engine not supported: ' + engine);
                         }
                     }
                 }
@@ -773,8 +770,6 @@ compile.json = function(context, options, callback) {
         libutils.warn('Compiling app-level json not supported\n');
         return callback();
     }
-
-    store.preload();
 
     if (options.mojit) {
         mojitNames = [ options.mojit ];

--- a/lib/app/commands/compile.js
+++ b/lib/app/commands/compile.js
@@ -655,7 +655,8 @@ compile.views = function(context, options, callback) {
 
         mojitRes = store.getResources('server', context, {type: 'mojit', name: mojitName});
         if (!mojitRes || !mojitRes.length) {
-            return callback('Unknown mojit "' + options.mojit + '"');
+            callback('Unknown mojit "' + options.mojit + '"');
+            return;
         }
         mojitRes = mojitRes[0];
 

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -500,29 +500,35 @@ function contextCsvToObject(s) {
 }
 
 /**
- * some sugar for instantiating a Y object and attaching any YUI or Mojito (or
- * any other local) modules to it, with useSync == true. So instead of:
+ * Some sugar for syncronously instantiating a Y object and attaching YUI,
+ * Mojito, or other local modules to it. Intended to replace the type of
+ * boilerplate in cli code for toggling useSync, loading some modules, applying
+ * modules, loading others. So instead of:
  *
  *   var Y = YUI({useSync: true}).use('oop', ...);
  *   Y.applyConfig({useSync: true, modules:{'mymodule1: ...}});
  *   Y.use('mymodule1', ...);
+ *   Y.applyConfig({useSync: false});
  *
- * ...specify all modules and optional module configs in one go
+ * ...specify all modules and optional module configs in one go:
  *
- *   var Y = yuiuse({oop: null, mymodule1: 'path/to/it', foo: {base:...}, ...}
+ *   var Y = getYUIInstance({
+ *          oop: null,
+ *          mymodule1: 'path/to/it',
+ *          foo: {base:...},
+ *          ...
+ *      });
  *
  * @method yuiuse
  * @param {Object} modules A hash of module names. If value is falsey, YUI
  *  will load it by name. If it's a string, it's the path of the module file to
  *  load, otherwise assume it's a modules config
- * @param {String} some_particular_yui optional require() param to load YUI lib
- *  from somewhere besides default modules.path
  * @param {Function} callback Optional for YUI().use(.. callback); Loading is
  *  synchronous if omitted
  * @return {Object} yui instance
  */
-function yuiuse(modules, my_yui, callback) {
-    var yui = require(my_yui || 'yui').YUI,
+function getYUIInstance(modules, callback) {
+    var yui = require('yui').YUI,
         names = Object.keys(modules || {}),
         local = {},
         y = yui({useSync: !callback});
@@ -541,7 +547,7 @@ function yuiuse(modules, my_yui, callback) {
     return callback ? callback(y) : y;
 }
 
-exports.yuiuse = yuiuse;
+exports.getYUIInstance = getYUIInstance;
 
 /**
  */

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -544,7 +544,11 @@ function getYUIInstance(modules, callback) {
     y.use(names);
     y.applyConfig({useSync: false});
 
-    return callback ? callback(y) : y;
+    if (callback) {
+        callback(y);
+    }
+
+    return y;
 }
 
 exports.getYUIInstance = getYUIInstance;

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -500,6 +500,50 @@ function contextCsvToObject(s) {
 }
 
 /**
+ * some sugar for instantiating a Y object and attaching any YUI or Mojito (or
+ * any other local) modules to it, with useSync == true. So instead of:
+ *
+ *   var Y = YUI({useSync: true}).use('oop', ...);
+ *   Y.applyConfig({useSync: true, modules:{'mymodule1: ...}});
+ *   Y.use('mymodule1', ...);
+ *
+ * ...specify all modules and optional module configs in one go
+ *
+ *   var Y = yuiuse({oop: null, mymodule1: 'path/to/it', foo: {base:...}, ...}
+ *
+ * @method yuiuse
+ * @param {Object} modules A hash of module names. If value is falsey, YUI
+ *  will load it by name. If it's a string, it's the path of the module file to
+ *  load, otherwise assume it's a modules config
+ * @param {String} some_particular_yui optional require() param to load YUI lib
+ *  from somewhere besides default modules.path
+ * @param {Function} callback Optional for YUI().use(.. callback); Loading is
+ *  synchronous if omitted
+ * @return {Object} yui instance
+ */
+function yuiuse(modules, my_yui, callback) {
+    var yui = require(my_yui || 'yui').YUI,
+        names = Object.keys(modules || {}),
+        local = {},
+        y = yui({useSync: !callback});
+
+    names.forEach(function (name) {
+        var val = modules[name];
+        if (val) {
+            local[name] = typeof val === 'string' ? {fullpath: val} : val;
+        }
+    });
+
+    y.applyConfig({modules: local});
+    y.use(names);
+    y.applyConfig({useSync: false});
+
+    return callback ? callback(y) : y;
+}
+
+exports.yuiuse = yuiuse;
+
+/**
  */
 exports.process_directory = process_directory;
 


### PR DESCRIPTION
minimal fix for getting a mu or hb view renderer.
- removed store.preload() calls that were made
  redundant by store.js:createStore()
- add return callback to exit on error.
- copy utils func from develop

[trello issue](https://trello.com/card/cli-mojito-compile-is-broken-in-pr4/504e5e3b7cd1578456fc430f/150)

n.b. I'm not sure that custom view renderers were loaded successfully before, but they aren't now (issue #779).  
