### PR TITLE
allow command execution for third party modules

### DIFF
--- a/lib/management/cli.js
+++ b/lib/management/cli.js
@@ -93,11 +93,12 @@ function parseArgs(args, optionInfo) {
 function main() {
     var args = process.argv.slice(2),
         commandName = (args.length === 0 ? 'help' : args.shift()),
+        currentPath = process.cwd(),
         command,
         argInfo;
 
     try {
-        command = require('mojito-cli-cmd-' + commandName);
+        command = require(libpath.join(currentPath, 'node_modules', 'mojito-' + commandName));
     } catch (e) {
         try {
             command = require(libpath.join(__dirname, '../app/commands/', commandName));


### PR DESCRIPTION
Before,  in order to execute a command:
command = require('mojito-cli-cmd-' + commandName);

Which is kinda wrong since it will look for the relative internal node_modules folder within mojito or to a global installation.

This way you can include a external command which is in the same folder as your app is executing.
