### PR TITLE
whitelist raw comboSep in yui config

### DIFF
--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -160,6 +160,9 @@ YUI.add('mojito-deploy-addon', function(Y, NAME) {
             // Unicode escape the various strings in the config data to help
             // fight against possible script injection attacks.
             yuiConfigEscaped = Y.mojito.util.cleanse(yuiConfig);
+            if (yuiConfig.comboSep) {
+                yuiConfigEscaped.comboSep = yuiConfig.comboSep;
+            }
             yuiConfigStr = JSON.stringify(yuiConfigEscaped);
             clientConfigEscaped = Y.mojito.util.cleanse(clientConfig);
             clientConfigStr = JSON.stringify(clientConfigEscaped);


### PR DESCRIPTION
I thought it better to take a whitelist approach, since the escaping was done for security reasons.
