### PR TITLE
minimal port of develop-perf api changes to build

### DIFF
--- a/lib/app/commands/build/index.js
+++ b/lib/app/commands/build/index.js
@@ -8,11 +8,8 @@ var path = require('path'),
     CWD = process.cwd(),
 
     writer = require('./writer'),
-    util = require(BASE + 'lib/management/utils'),
-
-    Y = util.yuiuse({
-        'mojito-resource-store': BASE + 'lib/store.server.js'
-    });
+    Store = require(BASE + 'lib/store'),
+    util = require(BASE + 'lib/management/utils');
 
 
 function getConfigs(opts, buildtype, builddir, store) {
@@ -103,8 +100,10 @@ function run(args, opts, cb) {
     opts.context = typeof opts.context === 'string' ? csvctx(opts.context) : {};
 
     // init resource store
-    store = new Y.mojito.ResourceStore({root: CWD, context: opts.context});
-    store.preload();
+    store = Store.createStore({
+        root: CWD,
+        context: opts.context
+    });
 
     // normalize inputs
     conf = getConfigs(opts, buildtype, args[1], store);

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -491,7 +491,7 @@ function contextCsvToObject(s) {
  *          ...
  *      });
  *
- * @method yuiuse
+ * @method getYUIInstance
  * @param {Object} modules A hash of module names. If value is falsey, YUI
  *  will load it by name. If it's a string, it's the path of the module file to
  *  load, otherwise assume it's a modules config


### PR DESCRIPTION
use handy `Store = require('lib/store')` instead
of the YUI multi-step & preload()

mojito build html5app and hybridapp commands no longer fail
