### PR TITLE
adding a default category (lowest in priority) if a Y.log call is issed ...

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -384,6 +384,10 @@ MojitoServer.prototype._configureLogger = function(Y, yuiConfig) {
             var c = Y.config,
                 cat = e && e.cat && e.cat.toLowerCase();
 
+            // this covers the case Y.log(msg) without category
+            // by using the low priority category from logLevelOrder.
+            cat = cat || c.logLevelOrder[0];
+
             // applying logLevel filters
             if (cat && ((c.logLevel === cat) || (c.logLevelOrder.indexOf(cat) >= 0))) {
                 log(c, e.msg, cat, e.src);


### PR DESCRIPTION
this fixes the case when Y.log('msg') is call without a second argument
