### PR TITLE
Y.config.debug is true by default per YUI default settings

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -6,7 +6,18 @@
         "mojitsDirs": [ "mojits" ],
         "routesFiles": [ "routes.json" ],
         "tunnelPrefix": "/tunnel",
-        "yui": {},
+        "yui": {
+            "config": {
+                "logLevelOrder": [
+                    "debug",
+                    "mojito",
+                    "info",
+                    "warn",
+                    "error",
+                    "none"
+                ]
+            }
+        },
         "specs": {
             "tunnelProxy": {
                 "type": "TunnelProxy"

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -214,7 +214,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         useSync: true
     });
 
-    this._configureLogger(Y, yuiConfig);
+    this._configureLogger(Y);
     this._configureYUI(Y, store, modules);
 
     // attaching all modules available for this application for the server side
@@ -342,9 +342,10 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
  * Configures YUI logger to honor the logLevel and logLevelOrder
  * TODO: this should be done at the low level in YUI.
  */
-MojitoServer.prototype._configureLogger = function(Y, yuiConfig) {
-    var logLevel = (yuiConfig.logLevel || 'debug').toLowerCase(),
-        logLevelOrder = ['debug', 'mojito', 'info', 'warn', 'error', 'none'];
+MojitoServer.prototype._configureLogger = function(Y) {
+    var logLevel = (Y.config.logLevel || 'debug').toLowerCase(),
+        logLevelOrder = Y.config.logLevelOrder || [],
+        defaultLogLevel = logLevelOrder[0] || 'info';
 
     function log(c, msg, cat, src) {
         var f,
@@ -361,32 +362,28 @@ MojitoServer.prototype._configureLogger = function(Y, yuiConfig) {
     // to be able to listen for Y.on.
     Y.use('base');
 
-    if (yuiConfig.debug) {
+    if (Y.config.debug) {
 
-        logLevelOrder = yuiConfig.logLevelOrder || logLevelOrder;
         logLevel = (logLevelOrder.indexOf(logLevel) >= 0 ? logLevel : logLevelOrder[0]);
 
         // logLevel index defines the begining of the logLevelOrder structure
         // e.g: ['foo', 'bar', 'baz'], and logLevel 'bar' should produce: ['bar', 'baz']
-        yuiConfig.logLevel = logLevel;
-        yuiConfig.logLevelOrder = (logLevel ? logLevelOrder.slice(logLevelOrder.indexOf(logLevel)) : []);
+        logLevelOrder = (logLevel ? logLevelOrder.slice(logLevelOrder.indexOf(logLevel)) : []);
 
         Y.applyConfig({
             useBrowserConsole: false,
-            logLevel: yuiConfig.logLevel,
-            logLevelOrder: yuiConfig.logLevelOrder
+            logLevel: logLevel,
+            logLevelOrder: logLevelOrder
         });
 
         // listening for low level log events to filter some of them.
         Y.on('yui:log', function (e) {
-            // we want to use Y.config instead of the original yuiConfig so
-            // people can switch that value on runtime for debugging
             var c = Y.config,
                 cat = e && e.cat && e.cat.toLowerCase();
 
             // this covers the case Y.log(msg) without category
             // by using the low priority category from logLevelOrder.
-            cat = cat || c.logLevelOrder[0];
+            cat = cat || defaultLogLevel;
 
             // applying logLevel filters
             if (cat && ((c.logLevel === cat) || (c.logLevelOrder.indexOf(cat) >= 0))) {


### PR DESCRIPTION
- we should honor that. 
- Making sure that default log level is computed correctly based on the initial definition of logLevelOrder
- moving that default definition to the configuration config.json
