### PR TITLE
fix build html5/hybrid bug for shared mojits

### DIFF
--- a/lib/app/commands/build/shared.js
+++ b/lib/app/commands/build/shared.js
@@ -30,7 +30,9 @@ function mapSpecUris(buildmap, conf, name, store) {
         specs = store.getResources('client', conf.context, opts);
 
     Object.keys(specs).forEach(function (spec) {
-        buildmap[conf.tunnelpf + spec.url + conf.contextqs] = spec.url;
+        if (spec.hasOwnProperty('url')) { // see mapDefxUris [urls] comment
+            buildmap[conf.tunnelpf + spec.url + conf.contextqs] = spec.url;
+        }
     });
 }
 
@@ -39,10 +41,15 @@ function mapDefxUris(buildmap, conf, store) {
     var mojits = store.getResources('client', conf.context, {type: 'mojit'});
 
     mojits.forEach(function (mojit) {
-        var uri = mojit.url + '/definition.json';
-
-        buildmap[conf.tunnelpf + uri + conf.contextqs] = uri;
-        mapSpecUris(buildmap, conf, mojit.name, store);
+        var uri;
+        /* [urls] note not all client mojits are url-addressable; resources in
+           "app-level" (aka shared) mojits get uris via a special RS mojit named
+           "Shared", not via the mojit they came in */
+        if (mojit.hasOwnProperty('url')) {
+            uri = mojit.url + '/definition.json';
+            buildmap[conf.tunnelpf + uri + conf.contextqs] = uri;
+            mapSpecUris(buildmap, conf, mojit.name, store);
+        }
     });
 }
 


### PR DESCRIPTION
this change skips processing client mojit metadata without a url (url metadata for shared/app-level mojits is in a special mojit named "Shared", not via the mojit it was packaged in.). It fixes the `mojito build` failure for a app with shared resources; i.e. `mojito build` in ./tests/func/applications/frameworkapp/common before this patch threw an error like this:

```
error: (outputhandler.server): { [Error: Cannot expand instance [tunnelundefined.definition], or instance.controller is undefined] code: 500 }
```
