### PR TITLE
Stop running cli on import. This makes it untestable.

### DIFF
--- a/bin/mojito
+++ b/bin/mojito
@@ -4,7 +4,9 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-var resolve = require('path').resolve,
+var cli,
+    resolve = require('path').resolve,
     mojito = require(resolve(__dirname, '../lib/mojito'));
 
-mojito.include('management/cli');
+cli = mojito.include('management/cli');
+cli.run();

--- a/lib/management/cli.js
+++ b/lib/management/cli.js
@@ -132,7 +132,4 @@ function main() {
     });
 }
 
-// Execute the main() function. Note that this occurs as part of the
-// require/import process so simply importing/require()ing the cli.js will cause
-// the main() operation to be invoked.
-main();
+exports.run = main;


### PR DESCRIPTION
Running the cli on import makes it untestable. New version exports a run function the importer can invoke when ready.
