### PR TITLE
Preliminary CLI test infrastructure.

### DIFF
--- a/tests/cli/lib/lib_test_descriptor.json
+++ b/tests/cli/lib/lib_test_descriptor.json
@@ -1,0 +1,23 @@
+[
+    {
+        "settings": [ "master" ],
+        "name": "lib-cli-tests",
+        "config": {
+            "lib": "../../../lib",
+            "base": "../../base"
+        },
+        "commonlib": "$$config.base$$/mojito-test.js",
+        "dataprovider" : {
+            "cli.js": {
+                "params": {
+                    "test": "./management/test-cli.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,cli"
+            }
+        }
+    },
+    {
+        "settings": [ "environment:development" ]
+    }
+]

--- a/tests/cli/lib/management/test-cli.js
+++ b/tests/cli/lib/management/test-cli.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2012, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+// NOTE the dependency on 'test' here, but not 'cli', since cli.js is NOT a YUI
+// module...and most command files aren't either.
+YUI().use('test', function(Y) {
+
+    var suite = new Y.Test.Suite('cli tests'),
+        A = Y.Assert,
+        OA = Y.ObjectAssert,
+        libpath = require('path');
+
+    suite.add(new Y.Test.Case({
+
+        name: 'cli tests',
+
+        'load check': function() {
+            var cli = require(libpath.join(__dirname,
+                '../../../../lib/management/cli.js'));
+
+            A.isNotNull(cli);
+            A.isFunction(cli.run);
+        }
+
+    }));
+
+    Y.Test.Runner.add(suite);
+});


### PR DESCRIPTION
Added -c and --cli options to run.js so we can run CLI tests. When no flag is provided all three of the unit, func, and cli tests are run. Arrow server starts only when unit or func tests are run.

Also included here are sample tests just to ensure the run.js stuff works :). run.js test -c runs the single "load check" cli test provided here.
