### PR TITLE
resolve loader config for Hybridapp in 0.5.x

### DIFF
--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -1,20 +1,16 @@
 [
     {
         "settings": [ "master" ],
-
         "appPort": "{{port}}",
-
         "specs": {
             "frame": {
                 "base": "top_frame"
             }
         },
-
         "staticHandling": {
             "appName": "yahoo.application.{{name}}",
             "prefix": "yahoo.application.{{name}}"
         },
-
         "builds": {
             "hybridapp": {
                 "forceRelativePaths": true,
@@ -25,23 +21,19 @@
             }
         }
     },
-
     {
         "settings": ["build:debug"],
-
         "yui": {
             "config": {
-                "base": "../yahoo.libs.yui/",
+                "base": "/yahoo.lib.yui/",
                 "combine": false,
                 "comboBase": "",
-                "loader": "loader/loader-debug.js",
                 "root": "",
-                "url": "$$yui.base$$yui/yui-debug.js",
                 "groups": {
                 	"app": {
                         "combine": false,
                         "comboBase": "",
-                        "base": "",
+                        "base": "/",
                         "root": ""
                 	}
                 }

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -25,7 +25,7 @@
         "settings": ["build:debug"],
         "yui": {
             "config": {
-                "base": "/yahoo.lib.yui/",
+                "base": "/yui/",
                 "combine": false,
                 "comboBase": "",
                 "root": "",

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -31,10 +31,20 @@
 
         "yui": {
             "config": {
+                "base": "../yahoo.libs.yui/",
                 "combine": false,
-                "base": "/yahoo.libs.yui/",
+                "comboBase": "",
+                "loader": "loader/loader-debug.js",
+                "root": "",
                 "url": "$$yui.base$$yui/yui-debug.js",
-                "loader": "loader/loader-debug.js"
+                "groups": {
+                	"app": {
+                        "combine": false,
+                        "comboBase": "",
+                        "base": "",
+                        "root": ""
+                	}
+                }
             }
         }
     }

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -30,7 +30,7 @@
                     "/yahoo.libs.yui/loader-base/loader-base-min.js",
                     "loader-yui3-resolved{langPath}",
                     "loader-app",
-                    "loader-app-base{langPath}"
+                    "loader-app-resolved{langPath}"
                 ],
                 "base": "../yahoo.libs.yui/",
                 "combine": false,

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -25,17 +25,24 @@
         "settings": ["build:debug"],
         "yui": {
             "config": {
-                "base": "/yui/",
+                "seed": [
+                    "/yahoo.libs.yui/yui-base/yui-base-min.js",
+                    "/yahoo.libs.yui/loader-base/loader-base-min.js",
+                    "loader-yui3-resolved{langPath}",
+                    "loader-app",
+                    "loader-app-base{langPath}"
+                ],
+                "base": "../yahoo.libs.yui/",
                 "combine": false,
                 "comboBase": "",
                 "root": "",
                 "groups": {
-                	"app": {
+                    "app": {
                         "combine": false,
                         "comboBase": "",
-                        "base": "/",
+                        "base": "..",
                         "root": ""
-                	}
+                    }
                 }
             }
         }

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -34,12 +34,10 @@
                 ],
                 "base": "../yahoo.libs.yui/",
                 "combine": false,
-                "comboBase": "",
                 "root": "",
                 "groups": {
                     "app": {
                         "combine": false,
-                        "comboBase": "",
                         "base": "..",
                         "root": ""
                     }

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -30,10 +30,12 @@
         "settings": ["build:debug"],
 
         "yui": {
-            "dependencyCalculations": "precomputed",
-            "base": "/yahoo.libs.yui/",
-            "url": "$$yui.base$$yui/yui-debug.js",
-            "loader": "loader/loader-debug.js"
+            "config": {
+                "combine": false,
+                "base": "/yahoo.libs.yui/",
+                "url": "$$yui.base$$yui/yui-debug.js",
+                "loader": "loader/loader-debug.js"
+            }
         }
     }
 ]

--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -13,7 +13,7 @@
         },
         "builds": {
             "hybridapp": {
-                "forceRelativePaths": true,
+                "forceRelativePaths": false,
                 "urls": ["/yahoo.application.{{name}}/index.html"],
                 "packages": {
                     "yahoo.libs.yui": "*"
@@ -32,13 +32,13 @@
                     "loader-app",
                     "loader-app-resolved{langPath}"
                 ],
-                "base": "../yahoo.libs.yui/",
+                "base": "/yahoo.libs.yui/",
                 "combine": false,
                 "root": "",
                 "groups": {
                     "app": {
                         "combine": false,
-                        "base": "..",
+                        "base": "/",
                         "root": ""
                     }
                 }


### PR DESCRIPTION
- use 0.5.x yui.config.x instead of older yui.x
- use relatve config.base and config.group.app.base
- rm obsolete, add some empty properties to override new defaults
- use yui.config.seed to point to resolved synthetic files, per @caridy. this avoids having to create a symlink to emulate the «static-prefix»/yui/ uri

only changes are to archetype/hybrid/app/application.json
