### PR TITLE
do not colorize test.js output if there is no tty [gh809,bz5964521]

### DIFF
--- a/examples/newsboxes/mojits/Read/tests/controller.common-tests.js
+++ b/examples/newsboxes/mojits/Read/tests/controller.common-tests.js
@@ -9,10 +9,10 @@
 /*global YUI, YUITest*/
 
 
-YUI.add('ReadController-tests', function(Y) {
+YUI.add('ReadController-tests', function(Y, NAME) {
     'use strict';
 
-    var suite = new YUITest.TestSuite('ShelfController-tests'),
+    var suite = new YUITest.TestSuite(NAME),
         A = YUITest.Assert,
 
         boomtown_feedmeta = {

--- a/examples/newsboxes/mojits/Shelf/tests/controller.common-tests.js
+++ b/examples/newsboxes/mojits/Shelf/tests/controller.common-tests.js
@@ -9,9 +9,9 @@
 /*global YUI,YUITest*/
 
 
-YUI.add('ShelfController-tests', function(Y) {
+YUI.add('ShelfController-tests', function(Y, NAME) {
 
-    var suite = new YUITest.TestSuite('ShelfController-tests'),
+    var suite = new YUITest.TestSuite(NAME),
         controller = null,
         A = YUITest.Assert;
 

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -17,7 +17,6 @@ var libpath = require('path'),
     targetMojitoPath = BASE,
     mojitoTmp = '/tmp/mojitotmp',
     mojitoInstrumentedDir = '/tmp/mojito-lib-inst',
-    fwTestsRoot = BASE + 'lib/tests',
     resultsDir = 'artifacts/test',
     resultsFile = 'artifacts/test/result.xml',
     coverageDir = 'artifacts/test/coverage',
@@ -49,7 +48,6 @@ var libpath = require('path'),
 
     usage,
     inputOptions,
-    runTests,
     Y = require('yui').YUI({useSync: true}).use('json-parse', 'json-stringify');
 
 
@@ -548,22 +546,7 @@ function instrumentDirectory(from, verbose, testType, callback) {
             if (verbose) {
                 utils.log('Copy other files for testing');
             }
-
-            if (testType === 'fw') {
-                if (verbose) {
-                    utils.log('copying non-js files to instrumented' +
-                        ' coverage directory');
-                }
-                // copy remaining non-js files into instrumented directory
-                copyExclude(nodeModulesFrom, nodeModulesTo, [/\.svn/]);
-                copyExclude(testsFrom, testsTo, [/\.svn/]);
-                copyFile(packageFrom, packageTo);
-                copyFile(cfgFrom, cfgTo);
-                copyFile(dimFrom, dimTo);
-                callback();
-            } else {
-                callback();
-            }
+            callback();
         }
     });
 }
@@ -575,7 +558,7 @@ function runTests(opts) {
         ttn,
         targetTests,
         testName = opts.name,
-        testType = opts.type || 'fw',
+        testType = opts.type || 'app',
         path = libpath.resolve(opts.path),
         coverage = inputOptions.coverage,
         verbose = inputOptions.verbose,
@@ -615,9 +598,7 @@ function runTests(opts) {
 
             configureYUI(YUI, store);
 
-            if (testType === 'fw') {
-                testConfigs = store.yui.getConfigShared('server', {}, true).modules;
-            } else if (testType === 'app') {
+            if (testType === 'app') {
                 testConfigs = merge(
                     store.yui.getConfigShared('server', {}, true).modules,
                     store.yui.getConfigAllMojits('server', {}).modules
@@ -638,9 +619,6 @@ function runTests(opts) {
 
                 for (i = 0; i < targetTests.length; i += 1) {
                     ttn = targetTests[i];
-                    if (testType === 'fw' && ttn.indexOf('mojito-') !== 0) {
-                        ttn = 'mojito-' + ttn;
-                    }
                     if (ttn === name || ttn + '-tests' === name) {
                         testModuleNames.push(name);
                     }

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
-/*jslint anon:true, regexp:true, nomen:true, stupid:true*/
+/*jslint anon:true, regexp:true, nomen:true, stupid:true node:true*/
 'use strict';
 
 var libpath = require('path'),
@@ -370,9 +370,8 @@ function processResults() {
         libfs.writeFileSync(coverageFile, coverageResult, 'utf8');
         utils.log('Creating coverage report...');
         // generate coverage reports in html
-        // TODO:  find home for fixed path string
-        exec('java -jar ' + ytcrJar +
-             ' --format LCOV -o ' + coverageDir + ' ' + coverageFile,
+        exec(['java -jar', ytcrJar, '--format LCOV -o', coverageDir,
+            coverageFile].join(' '),
             function(error, stdout, stderr) {
                 if (inputOptions.verbose) {
                     utils.log('stdout: ' + stdout);
@@ -439,6 +438,7 @@ function executeTestsWithinY(tests, cb) {
         }
     }
 
+    /*jslint unparam:true*/
     function testRunner(Y) {
         TestRunner.subscribe(TestRunner.BEGIN_EVENT, handleEvent);
         TestRunner.subscribe(TestRunner.TEST_SUITE_BEGIN_EVENT, handleEvent);

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -710,7 +710,7 @@ function run(params, opts) {
     libfs.mkdirSync(resultsDir, MODE_ALL);
 
     if (testOption === 'app' || testOption === 'mojit') {
-        testName = params[2];
+        testName = params[2] || '';
         if (!dir) {
             utils.error('Please specify ' + testOption + ' directory to test.',
                 usage,
@@ -727,7 +727,7 @@ function run(params, opts) {
         }
         runTests({path: dir, type: testOption, name: testName});
     } else {
-        utils.error('Invalid parameter.', usage, true);
+        utils.error('Please specify "app" or "mojit" test type.', usage, true);
     }
 }
 

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
-/*jslint anon:true, regexp:true, nomen:true, stupid:true node:true*/
+/*jslint anon:true, regexp:true, nomen:true, stupid:true, node:true*/
 'use strict';
 
 var libpath = require('path'),

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -39,8 +39,6 @@ var libpath = require('path'),
     YUITest = require('yuitest').YUITest,
     TestRunner = YUITest.TestRunner,
 
-    testStart,
-
     // for asynch testing
     testQueue = [],
 
@@ -591,8 +589,6 @@ run = function(params, opts) {
         mojitoTmp = libpath.join(inputOptions.tmpdir, 'mojitotmp');
         mojitoInstrumentedDir = libpath.join(inputOptions.tmpdir, 'mojitoinst');
     }
-
-    testStart = new Date().getTime();
 
     if (!existsSync(artifactsDir)) {
         libfs.mkdirSync(artifactsDir, MODE_ALL);

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -47,13 +47,11 @@ var libpath = require('path'),
     collectedJUnitXML = [],
     collectedCoverage = {},
 
-    colorFactory,
-    run,
     usage,
-    options,
     inputOptions,
     runTests,
     Y = require('yui').YUI({useSync: true}).use('json-parse', 'json-stringify');
+
 
 Y.applyConfig({useSync: false});
 
@@ -128,6 +126,16 @@ function configureYUI(YUI, store) {
             'mojito-mojits': store.yui.getConfigAllMojits('server', {})
         }
     });
+}
+
+
+function colorFactory(code) {
+    function color(code, string) {
+        return '\u001b[' + code + 'm' + string + '\u001b[0m';
+    }
+    return function(string) {
+        return color(code, string);
+    };
 }
 
 
@@ -561,67 +569,7 @@ function instrumentDirectory(from, verbose, testType, callback) {
 }
 
 
-colorFactory = function(code) {
-    function color(code, string) {
-        return '\u001b[' + code + 'm' + string + '\u001b[0m';
-    }
-    return function(string) {
-        return color(code, string);
-    };
-};
-
-
-run = function(params, opts) {
-    var artifactsDir = 'artifacts',
-        testOption = params[0],
-        dir = params[1],
-        testName,
-        stat;
-
-    inputOptions = opts || {};
-
-    if (inputOptions.tmpdir) {
-        if (!existsSync(inputOptions.tmpdir)) {
-            utils.warn('The temporary directory you specified does not exist.' +
-                ' It will be created.');
-            libfs.mkdirSync(inputOptions.tmpdir, MODE_ALL);
-        }
-        mojitoTmp = libpath.join(inputOptions.tmpdir, 'mojitotmp');
-        mojitoInstrumentedDir = libpath.join(inputOptions.tmpdir, 'mojitoinst');
-    }
-
-    if (!existsSync(artifactsDir)) {
-        libfs.mkdirSync(artifactsDir, MODE_ALL);
-    }
-    if (existsSync(resultsDir)) {
-        utils.removeDir(libfs.realpathSync(resultsDir));
-        libfs.rmdirSync(libfs.realpathSync(resultsDir));
-    }
-    libfs.mkdirSync(resultsDir, MODE_ALL);
-
-    if (testOption === 'app' || testOption === 'mojit') {
-        testName = params[2];
-        if (!dir) {
-            utils.error('Please specify ' + testOption + ' directory to test.',
-                usage,
-                true
-                );
-        }
-        try {
-            stat = libfs.statSync(dir);
-            if (!stat.isDirectory()) {
-                utils.error('"' + dir + '" is not a directory.', usage, true);
-            }
-        } catch (err) {
-            utils.error('Invalid directory: \'' + dir + '\'', usage, true);
-        }
-        runTests({path: dir, type: testOption, name: testName});
-    } else {
-        utils.error('Invalid parameter.', usage, true);
-    }
-};
-
-runTests = function(opts) {
+function runTests(opts) {
 
     var i,
         ttn,
@@ -752,7 +700,58 @@ runTests = function(opts) {
         testRunner(path);
     }
 
-};
+}
+
+
+function run(params, opts) {
+    var artifactsDir = 'artifacts',
+        testOption = params[0],
+        dir = params[1],
+        testName,
+        stat;
+
+    inputOptions = opts || {};
+
+    if (inputOptions.tmpdir) {
+        if (!existsSync(inputOptions.tmpdir)) {
+            utils.warn('The temporary directory you specified does not exist.' +
+                ' It will be created.');
+            libfs.mkdirSync(inputOptions.tmpdir, MODE_ALL);
+        }
+        mojitoTmp = libpath.join(inputOptions.tmpdir, 'mojitotmp');
+        mojitoInstrumentedDir = libpath.join(inputOptions.tmpdir, 'mojitoinst');
+    }
+
+    if (!existsSync(artifactsDir)) {
+        libfs.mkdirSync(artifactsDir, MODE_ALL);
+    }
+    if (existsSync(resultsDir)) {
+        utils.removeDir(libfs.realpathSync(resultsDir));
+        libfs.rmdirSync(libfs.realpathSync(resultsDir));
+    }
+    libfs.mkdirSync(resultsDir, MODE_ALL);
+
+    if (testOption === 'app' || testOption === 'mojit') {
+        testName = params[2];
+        if (!dir) {
+            utils.error('Please specify ' + testOption + ' directory to test.',
+                usage,
+                true
+                );
+        }
+        try {
+            stat = libfs.statSync(dir);
+            if (!stat.isDirectory()) {
+                utils.error('"' + dir + '" is not a directory.', usage, true);
+            }
+        } catch (err) {
+            utils.error('Invalid directory: \'' + dir + '\'', usage, true);
+        }
+        runTests({path: dir, type: testOption, name: testName});
+    } else {
+        utils.error('Invalid parameter.', usage, true);
+    }
+}
 
 
 /**
@@ -763,7 +762,17 @@ YUITest.Assert.skip = function() {
 };
 
 
-options = [
+exports.run = run;
+
+exports.usage = usage = [
+    'Options: -c --coverage  Instruments code under test and prints coverage report',
+    '         -v --verbose   Verbose logging',
+    'To test a mojit:',
+    '    mojito test mojit ./path/to/mojit/directory',
+    'To test a Mojito app:',
+    '    mojito test app ./path/to/mojito/app/directory'].join('\n');
+
+exports.options = [
     {
         longName: 'coverage',
         shortName: 'c',
@@ -780,26 +789,3 @@ options = [
         hasValue: true
     }
 ];
-
-
-usage = 'Options: -c --coverage  Instruments code under test and prints ' +
-    'coverage report\n' +
-    '         -v --verbose   Verbose logging\n' +
-    'To test a mojit:\n' +
-    '    mojito test mojit ./path/to/mojit/directory\n' +
-    'To test a Mojito app:\n' +
-    '    mojito test app ./path/to/mojito/app/directory\n' +
-    '    \n' +
-    'NOTE: You cannot generate test coverage for a Mojito application,' +
-    ' only individual mojits.';
-
-/**
- */
-exports.run = run;
-/**
- */
-exports.usage = usage;
-
-/**
- */
-exports.options = options;

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -718,7 +718,7 @@ function run(params, opts) {
         }
         runTests({path: dir, type: testOption, name: testName});
     } else {
-        utils.error('Please specify "app" or "mojit" test type.', usage, true);
+        utils.error('Please specify test type "app" or "mojit".', usage, true);
     }
 }
 

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -33,6 +33,7 @@ var libpath = require('path'),
 
     MODE_ALL = parseInt('777', 8),
     RX_TESTS = /-tests$/,
+    NO_TTY = !process.stdin.isTTY || !process.stderr.isTTY,
 
     YUI = require('yui').YUI,
     YUITest = require('yuitest').YUITest,
@@ -132,7 +133,7 @@ function colorFactory(code) {
         return '\u001b[' + code + 'm' + string + '\u001b[0m';
     }
     return function(string) {
-        return color(code, string);
+        return NO_TTY ? string : color(code, string);
     };
 }
 

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -527,16 +527,6 @@ function instrumentDirectory(from, verbose, testType, callback) {
             utils.log('coverage instrumentation finished for ' +
                 mojitoInstrumentedDir);
         }
-        var testsFrom = libpath.join(realPathFrom, 'lib/tests'),
-            testsTo = libpath.join(mojitoInstrumentedDir, 'lib/tests'),
-            packageFrom = libpath.join(mojitoTmp, 'package.json'),
-            packageTo = libpath.join(mojitoInstrumentedDir, 'package.json'),
-            cfgFrom = libpath.join(mojitoTmp, 'lib/config.json'),
-            cfgTo = libpath.join(mojitoInstrumentedDir, 'lib/config.json'),
-            dimFrom = libpath.join(mojitoTmp, 'lib/dimensions.json'),
-            dimTo = libpath.join(mojitoInstrumentedDir, 'lib/dimensions.json'),
-            nodeModulesFrom = libpath.join(realPathFrom, 'node_modules'),
-            nodeModulesTo = libpath.join(mojitoInstrumentedDir, 'node_modules');
         if (verbose) {
             utils.log('stdout: ' + stdout);
             utils.log('stderr: ' + stderr);

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -33,7 +33,7 @@ var libpath = require('path'),
 
     MODE_ALL = parseInt('777', 8),
     RX_TESTS = /-tests$/,
-    NO_TTY = !process.stdin.isTTY || !process.stderr.isTTY,
+    NO_TTY = !process.stdout.isTTY || !process.stderr.isTTY,
 
     YUI = require('yui').YUI,
     YUITest = require('yuitest').YUITest,

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -14,7 +14,7 @@ var fs = require('fs'),
     existsSync = fs.existsSync || path.existsSync,
     hb = require('yui/handlebars').Handlebars,
     colors = require('colors'),
-    NO_TTY = !process.stdin.isTTY || !process.stderr.isTTY;
+    NO_TTY = !process.stdout.isTTY || !process.stderr.isTTY;
 
 
 colors.mode = NO_TTY ? 'none' : 'console';

--- a/lib/management/utils.js
+++ b/lib/management/utils.js
@@ -13,15 +13,17 @@ var fs = require('fs'),
     path = require('path'),
     existsSync = fs.existsSync || path.existsSync,
     hb = require('yui/handlebars').Handlebars,
-    tty = require('tty'), // use process.stdin/err.isTTY instead
-    colors = require('colors');
+    colors = require('colors'),
+    NO_TTY = !process.stdin.isTTY || !process.stderr.isTTY;
 
-colors.mode = (tty.isatty(1) && tty.isatty(2)) ? 'console' : 'none';
+
+colors.mode = NO_TTY ? 'none' : 'console';
 
 
 function log(message) {
     console.log(message.cyan.toString());
 }
+
 
 function error(message, usage, die) {
     var msgs = [];


### PR DESCRIPTION
- use process.*.isTTY instead of require('tty').istty()
- tested on node 0.6, 0.8
- n.b. some app and addon Y.log() messages remain tty unaware.
