### PR TITLE
[bz6023234] prefix for hybridapp/crt "//yahoo.com"

### DIFF
--- a/lib/app/archetypes/app/hybrid/application.json.hb
+++ b/lib/app/archetypes/app/hybrid/application.json.hb
@@ -38,7 +38,7 @@
                 "groups": {
                     "app": {
                         "combine": false,
-                        "base": "/",
+                        "base": "//yahoo.com",
                         "root": ""
                     }
                 }

--- a/lib/app/archetypes/app/hybrid/mojits/top_frame/specs/default.json.hb
+++ b/lib/app/archetypes/app/hybrid/mojits/top_frame/specs/default.json.hb
@@ -23,7 +23,7 @@
         "config": {
             "assets": {
                 "bottom": {
-                    "js": ["/yahoo.crt.lib/yui-cfg.js"]
+                    "js": ["//yahoo.com/yahoo.crt.lib/yui-cfg.js"]
                 }
             }
         }


### PR DESCRIPTION
bz 6023234 - (preferred solution is to restore relative pathing in hybridapp builds)
