### PR TITLE
fix missing snapshot.packages in build hybridapp

### DIFF
--- a/lib/app/commands/build/index.js
+++ b/lib/app/commands/build/index.js
@@ -46,7 +46,7 @@ function getConfigs(opts, buildtype, builddir, store) {
         snapshot: {
             name: opts.snapshotName || '',
             tag: opts.snapshotTag || '',
-            packages: dotbuild.snapshotPackages || {}
+            packages: dotbuild.packages || {}
         },
         build: {
             attachManifest: dotbuild.attachManifest || false,


### PR DESCRIPTION
this commit fixes missing build.snapshot.packages described below

per Ji Liang 1/10 email: 

Expected-- as of mojito 0.4 (mojito 0.4.8-31) when run as mojito hybrid
build the packages info in snapshot.json is like:

```
"packages": {
    "yahoo.libs.yui": "3.4.1",
    "yahoo.application.test04": "0.0.2"
}
```

Actual:

```
"packages": {
    "yahoo.application.test05": "0.0.1"
}
```
