### PR TITLE
unformatted logs when running in production systems

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -7,6 +7,7 @@
 
 /*jslint anon:true, sloppy:true, nomen:true, node:true*/
 
+'use strict';
 
 //  ----------------------------------------------------------------------------
 //  Prerequisites
@@ -349,12 +350,17 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
 MojitoServer.prototype._configureLogger = function(Y) {
     var logLevel = (Y.config.logLevel || 'debug').toLowerCase(),
         logLevelOrder = Y.config.logLevelOrder || [],
-        defaultLogLevel = logLevelOrder[0] || 'info';
+        defaultLogLevel = logLevelOrder[0] || 'info',
+        isatty = process.stdout.isTTY;
 
     function log(c, msg, cat, src) {
         var f,
             m = (src) ? src + ': ' + msg : msg;
-        if (Y.Lang.isFunction(c.logFn)) {
+
+        // if stdout is bound to the tty, we should try to
+        // use the fancy logs implemented by 'yui-log-nodejs'.
+        // TODO: eventually YUI should take care of this piece.
+        if (isatty && Y.Lang.isFunction(c.logFn)) {
             c.logFn.call(Y, msg, cat, src);
         } else if (typeof console !== undefined && console.log) {
             f = (cat && console[cat]) ? cat : 'log';


### PR DESCRIPTION
when running on production, we should rely on console.log directly instead of std.err used by yui-log-nodejs.

fixes #bz5908204
