### PR TITLE
[bz5800733] Handlebars Template Helpers

### DIFF
--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -26,6 +26,16 @@ YUI.add('mojito-hb', function(Y, NAME) {
         this.viewId = viewId;
     }
 
+    /**
+     * Registers a Handlebars template helper method.
+     * See http://handlebarsjs.com/block_helpers.html
+     * @param {string} name Helper name.
+     * @param {function} helper Helper function.
+     */
+    HandleBarsAdapter.register = function(name, helper) {
+        HB.registerHelper(name, helper);
+    };
+
     HandleBarsAdapter.prototype = {
 
         /**

--- a/tests/unit/lib/app/addons/view-engines/test-hb.server.js
+++ b/tests/unit/lib/app/addons/view-engines/test-hb.server.js
@@ -20,7 +20,8 @@ YUI({useBrowserConsole: true}).use(
         var suite = new Y.Test.Suite("mojito-hb server tests"),
             TEMPLATES = {
                 'oldObjNotation.hb.html': '<div>{{#tester}}{{test}}{{/tester}}</div>',
-                'dotNotation.hb.html': '<div>{{tester.test}}</div>'
+                'dotNotation.hb.html': '<div>{{tester.test}}</div>',
+                'helperMethod.hb.html': '<div>{{helper}}</div>'
             };
 
         suite.add(new Y.Test.Case({
@@ -77,6 +78,28 @@ YUI({useBrowserConsole: true}).use(
                     args: ['<div>test</div>', meta]
                 });
                 this.viewEngine.render(data, 'test', 'dotNotation.hb.html', adapter, meta);
+            },
+
+            'test register helper method': function () {
+                var adapter = Y.Mock(),
+                    meta = {
+                        view: {}
+                    };
+                Y.mojito.addons.viewEngines.hb.register('helper', function (options) {
+                    return 'helperTest';
+                });
+                Y.Mock.expect(adapter, {
+                    method: 'flush',
+                    args: [Y.Mock.Value.String, meta],
+                    run: function (output, metaResult) {
+                        Y.Assert.areEqual('<div>helperTest</div>', output);
+                    }
+                });
+                Y.Mock.expect(adapter, {
+                    method: 'done',
+                    args: ['<div>helperTest</div>', meta]
+                });
+                this.viewEngine.render({}, 'test', 'helperMethod.hb.html', adapter, meta);
             }
         }));
 


### PR DESCRIPTION
Now that Handlebars is the default view engine, it would be great to expose more functionality. Template helpers can simplify common patterns in templates. I added `HandleBarsAdapter.register` in `hb.server.js` and a test. Since this is only applicable to Handlebars, user must require 'mojito-hb' and register like so:

```
Y.namespace('mojito.addons.viewEngines.hb').register('helper', function (options) {
    return 'CustomHelper';
});
```

You would use it like so within your template:

```
{{helper}} or {{#helper}}{{/helper}}
```

For now, server side only. See http://handlebarsjs.com/block_helpers.html for more info.
