### PR TITLE
Add support for a shared app levellang bundle

### DIFF
--- a/lib/app/addons/ac/intl.common.js
+++ b/lib/app/addons/ac/intl.common.js
@@ -14,6 +14,19 @@
  */
 YUI.add('mojito-intl-addon', function(Y, NAME) {
 
+    function getLang(ac, module, label, args) {
+        var lang, string;
+        lang = Y.mojito.util.findClosestLang(ac.context.lang, ac.instance.langs) ||
+                ac.instance.defaultLang || 'en';
+        Y.Intl.setLang(module, lang);
+        string = Y.Intl.get(module, label);
+        if (string && args) {
+            // simple string substitution
+            return Y.Lang.sub(string, Y.Lang.isString(args) ? [args] : args);
+        }
+        return string;
+    }
+
     /**
      * <strong>Access point:</strong> <em>ac.intl.*</em>
      * Internationalization addon
@@ -21,6 +34,8 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
      */
     function IntlAddon(command, adapter, ac) {
         this.ac = ac;
+        this.appConfig = ac.app ? ac.app.config : ac.config.getAppConfig();
+        this.config = this.appConfig['mojito-intl-addon'] || {};
     }
 
 
@@ -36,16 +51,22 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
          * @return {string|Object} translated string for label or if no label was provided an object containing all resources.
          */
         lang: function(label, args) {
-            var lang, string;
-            lang = Y.mojito.util.findClosestLang(this.ac.context.lang, this.ac.instance.langs) ||
-                    this.ac.instance.defaultLang || 'en';
-            Y.Intl.setLang(this.ac.instance.controller, lang);
-            string = Y.Intl.get(this.ac.instance.controller, label);
-            if (string && args) {
-                // simple string substitution
-                return Y.Lang.sub(string, Y.Lang.isString(args) ? [args] : args);
-            }
-            return string;
+            var module = this.ac.instance.controller;
+            return getLang(this.ac, module, label, args);
+        },
+
+        /**
+         * Returns translated string from an app level yui-lang bundle.
+         * The bundle module name can be configured in application.json under "mojito-intl-addon.appBundle" key.
+         * I the configuration is not present, the bundle name defaults to "shared".
+         * @method lang
+         * @param label {string} Optional. The initial label to be translated. If not provided, returns a copy of all resources.
+         * @param args {string|Array|Object} optional parameters for the string
+         * @return {string|Object} translated string for label or if no label was provided an object containing all resources.
+         */
+        appLang: function(label, args) {
+            var module = this.config.appBundle || 'shared';
+            return getLang(this.ac, module, label, args);
         },
 
 

--- a/lib/app/addons/ac/intl.common.js
+++ b/lib/app/addons/ac/intl.common.js
@@ -34,8 +34,6 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
      */
     function IntlAddon(command, adapter, ac) {
         this.ac = ac;
-        this.appConfig = ac.app ? ac.app.config : ac.config.getAppConfig();
-        this.config = this.appConfig['mojito-intl-addon'] || {};
     }
 
 
@@ -56,16 +54,14 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
         },
 
         /**
-         * Returns translated string from an app level yui-lang bundle.
-         * The bundle module name can be configured in application.json under "mojito-intl-addon.appBundle" key.
-         * I the configuration is not present, the bundle name defaults to "shared".
+         * Returns translated string from an app level 'shared' yui-lang bundle.
          * @method lang
          * @param label {string} Optional. The initial label to be translated. If not provided, returns a copy of all resources.
          * @param args {string|Array|Object} optional parameters for the string
          * @return {string|Object} translated string for label or if no label was provided an object containing all resources.
          */
         appLang: function(label, args) {
-            var module = this.config.appBundle || 'shared';
+            var module = 'shared';
             return getLang(this.ac, module, label, args);
         },
 

--- a/tests/unit/lib/app/addons/ac/test-intl.common.js
+++ b/tests/unit/lib/app/addons/ac/test-intl.common.js
@@ -24,6 +24,13 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                     }
                 };
 
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: {}
+            });
+            ac.config = mockConfig;
+
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
                 method: 'setLang',
@@ -46,6 +53,7 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
             Mock.verify(mockYIntl);
+            Mock.verify(mockConfig);
         },
 
         'test lang() formats translation from Y.Intl': function() {
@@ -58,6 +66,13 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                         langs: { foo: true }
                     }
                 };
+
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: {}
+            });
+            ac.config = mockConfig;
 
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
@@ -81,6 +96,155 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation param1 param2', value, 'The return value of Y.Intl.get() was not formatted');
             Mock.verify(mockYIntl);
+            Mock.verify(mockConfig);
+        },
+
+        'test appLang() gets translation from Y.Intl with default module name': function() {
+            var command = {},
+                adapter = null,
+                bundleName = 'shared',
+                ac = {
+                    context: { lang: 'foo' },
+                    instance: {
+                        controller: 'controller-yui-module-name',
+                        langs: { foo: true }
+                    }
+                };
+
+            var mockYIntl = Mock();
+            Mock.expect(mockYIntl, {
+                method: 'setLang',
+                args: [bundleName, 'foo'],
+                returns: 'true'
+            });
+            Mock.expect(mockYIntl, {
+                method: 'get',
+                args: [bundleName, 'key'],
+                returns: 'translation'
+            });
+
+            var yIntl = Y.Intl;
+            Y.Intl = mockYIntl;
+
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: {}
+            });
+
+            ac.config = mockConfig;
+
+            var addon = new Y.mojito.addons.ac.intl(command, adapter, ac);
+
+            var value = addon.appLang('key');
+
+            Y.Intl = yIntl;
+
+            Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
+            Mock.verify(mockYIntl);
+            Mock.verify(mockConfig);
+        },
+
+        'test appLang() gets translation from Y.Intl with module name from app config': function() {
+            var command = {},
+                adapter = null,
+                bundleName = 'app-bundle-name',
+                appConfig = {
+                    "mojito-intl-addon": {
+                        appBundle: bundleName
+                    }
+                },
+                ac = {
+                    context: { lang: 'foo' },
+                    instance: {
+                        controller: 'controller-yui-module-name',
+                        langs: { foo: true }
+                    }
+                };
+
+            var mockYIntl = Mock();
+            Mock.expect(mockYIntl, {
+                method: 'setLang',
+                args: [bundleName, 'foo'],
+                returns: 'true'
+            });
+            Mock.expect(mockYIntl, {
+                method: 'get',
+                args: [bundleName, 'key'],
+                returns: 'translation'
+            });
+
+            var yIntl = Y.Intl;
+            Y.Intl = mockYIntl;
+
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: appConfig
+            });
+
+            ac.config = mockConfig;
+
+            var addon = new Y.mojito.addons.ac.intl(command, adapter, ac);
+
+            var value = addon.appLang('key');
+
+            Y.Intl = yIntl;
+
+            Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
+            Mock.verify(mockYIntl);
+            Mock.verify(mockConfig);
+        },
+
+        'test appLang() formats translation from Y.Intl': function() {
+            var command = {},
+                adapter = null,
+                bundleName = 'app-bundle-name';
+                appConfig = {
+                    "mojito-intl-addon": {
+                        appBundle: bundleName
+                    }
+                },
+                ac = {
+                    context: { lang: 'foo' },
+                    instance: {
+                        controller: 'controller-yui-module-name',
+                        langs: { foo: true }
+                    }
+                };
+
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: appConfig
+            });
+
+            ac.config = mockConfig;
+
+            var mockYIntl = Mock();
+            Mock.expect(mockYIntl, {
+                method: 'setLang',
+                args: [bundleName, 'foo'],
+                returns: 'true'
+            });
+            Mock.expect(mockYIntl, {
+                method: 'get',
+                args: [bundleName, 'key'],
+                returns: 'translation {0} {1}'
+            });
+
+            var yIntl = Y.Intl;
+            Y.Intl = mockYIntl;
+
+            var addon = new Y.mojito.addons.ac.intl(command, adapter, ac);
+
+            var value = addon.appLang('key', ['param1', 'param2']);
+
+            Y.Intl = yIntl;
+
+            Assert.areEqual('translation param1 param2', value, 'The return value of Y.Intl.get() was not formatted');
+            Mock.verify(mockYIntl);
+            Mock.verify(mockConfig);
         },
 
         'test formatDate() delegates to Y.DataType.Date.format': function() {
@@ -96,6 +260,14 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                     langs: { foo: true }
                 }
             };
+
+            var mockConfig = Mock();
+            Mock.expect(mockConfig, {
+                method: 'getAppConfig',
+                returns: {}
+            });
+
+            ac.config = mockConfig;
 
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
@@ -130,6 +302,7 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
             Assert.areEqual('formattedDate', value, 'The return value of Y.DataType.Date.format() was not used');
             Mock.verify(mockYIntl);
             Mock.verify(mockYDataTypeDate);
+            Mock.verify(mockConfig);
         }
 
     }));

--- a/tests/unit/lib/app/addons/ac/test-intl.common.js
+++ b/tests/unit/lib/app/addons/ac/test-intl.common.js
@@ -24,13 +24,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                     }
                 };
 
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: {}
-            });
-            ac.config = mockConfig;
-
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
                 method: 'setLang',
@@ -53,7 +46,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
             Mock.verify(mockYIntl);
-            Mock.verify(mockConfig);
         },
 
         'test lang() formats translation from Y.Intl': function() {
@@ -66,13 +58,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                         langs: { foo: true }
                     }
                 };
-
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: {}
-            });
-            ac.config = mockConfig;
 
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
@@ -96,10 +81,9 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation param1 param2', value, 'The return value of Y.Intl.get() was not formatted');
             Mock.verify(mockYIntl);
-            Mock.verify(mockConfig);
         },
 
-        'test appLang() gets translation from Y.Intl with default module name': function() {
+        'test appLang() gets translation from Y.Intl': function() {
             var command = {},
                 adapter = null,
                 bundleName = 'shared',
@@ -126,14 +110,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
             var yIntl = Y.Intl;
             Y.Intl = mockYIntl;
 
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: {}
-            });
-
-            ac.config = mockConfig;
-
             var addon = new Y.mojito.addons.ac.intl(command, adapter, ac);
 
             var value = addon.appLang('key');
@@ -142,64 +118,12 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
             Mock.verify(mockYIntl);
-            Mock.verify(mockConfig);
-        },
-
-        'test appLang() gets translation from Y.Intl with module name from app config': function() {
-            var command = {},
-                adapter = null,
-                bundleName = 'app-bundle-name',
-                appConfig = {
-                    "mojito-intl-addon": {
-                        appBundle: bundleName
-                    }
-                },
-                ac = {
-                    context: { lang: 'foo' },
-                    instance: {
-                        controller: 'controller-yui-module-name',
-                        langs: { foo: true }
-                    }
-                };
-
-            var mockYIntl = Mock();
-            Mock.expect(mockYIntl, {
-                method: 'setLang',
-                args: [bundleName, 'foo'],
-                returns: 'true'
-            });
-            Mock.expect(mockYIntl, {
-                method: 'get',
-                args: [bundleName, 'key'],
-                returns: 'translation'
-            });
-
-            var yIntl = Y.Intl;
-            Y.Intl = mockYIntl;
-
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: appConfig
-            });
-
-            ac.config = mockConfig;
-
-            var addon = new Y.mojito.addons.ac.intl(command, adapter, ac);
-
-            var value = addon.appLang('key');
-
-            Y.Intl = yIntl;
-
-            Assert.areEqual('translation', value, 'The return value of Y.Intl.get() was not used');
-            Mock.verify(mockYIntl);
-            Mock.verify(mockConfig);
         },
 
         'test appLang() formats translation from Y.Intl': function() {
             var command = {},
                 adapter = null,
-                bundleName = 'app-bundle-name';
+                bundleName = 'shared';
                 appConfig = {
                     "mojito-intl-addon": {
                         appBundle: bundleName
@@ -212,14 +136,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                         langs: { foo: true }
                     }
                 };
-
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: appConfig
-            });
-
-            ac.config = mockConfig;
 
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
@@ -244,7 +160,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
 
             Assert.areEqual('translation param1 param2', value, 'The return value of Y.Intl.get() was not formatted');
             Mock.verify(mockYIntl);
-            Mock.verify(mockConfig);
         },
 
         'test formatDate() delegates to Y.DataType.Date.format': function() {
@@ -260,14 +175,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                     langs: { foo: true }
                 }
             };
-
-            var mockConfig = Mock();
-            Mock.expect(mockConfig, {
-                method: 'getAppConfig',
-                returns: {}
-            });
-
-            ac.config = mockConfig;
 
             var mockYIntl = Mock();
             Mock.expect(mockYIntl, {
@@ -302,7 +209,6 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
             Assert.areEqual('formattedDate', value, 'The return value of Y.DataType.Date.format() was not used');
             Mock.verify(mockYIntl);
             Mock.verify(mockYDataTypeDate);
-            Mock.verify(mockConfig);
         }
 
     }));


### PR DESCRIPTION
This change is to allow using a "shared app level" lang bundle for getting localized strings available for the whole application.

The yui lang module will be located in: `<app_root>/lang/shared.js`.

This is similar to the `config` addon, where you have `ac.config.get()` for mojit level configs vs `ac.config.getAppConfig()` to get the app level config.
In this case it would be `ac.intl.lang()` for mojit level langs vs `ac.intl.appLang()` for app level strings.

For example:
The default shared app level lang bundle would be:
`<app_root>/lang/shared.js`

``` javascript
YUI.add("lang/shared", function (Y) {
    "use strict";

    Y.Intl.add(
        "shared",
        "",
        {
            "APP_TITLE": "This is my app title"
        }
    );
}, "0.0.1", {
    requires: ["intl"]
});
```

The localized files (i.e. spanish), would be:
`<app_root>/lang/shared_es-MX.js`

``` javascript
YUI.add("lang/shared_es-MX", function (Y) {
    "use strict";

    Y.Intl.add(
        "shared",
        "es-MX",
        {
            "APP_TITLE": "Este es el título de mi aplicación"
        }
    );
}, "0.0.1", {
    requires: ["intl"]
});
```

And so any controller can get app level strings from the `intl` addon:

``` javascript
YUI.add('CustomHTMLFrameMojit', function (Y, NAME) {

    Y.mojito.controllers[NAME] = {

        index: function (ac) {
            var title = ac.intl.appLang('APP_TITLE');
```

An example use case is for dynamically changing/translating the application title.
