### PR TITLE
Clean up process for junebug/hook infrastructure

### DIFF
--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -217,7 +217,7 @@ callback({
             }
 
             // HookSystem::StartBlock
-            Y.mojito.hooks.hook('addon', this.hook, 'start', my, cfg);
+            Y.mojito.hooks.hook('addon', this.adapter.hook, 'start', my, cfg);
             // HookSystem::EndBlock
 
             meta.children = cfg.children;
@@ -250,7 +250,7 @@ callback({
                     }
 
                     // HookSystem::StartBlock
-                    Y.mojito.hooks.hook('addon', my.hook, 'end', my);
+                    Y.mojito.hooks.hook('addon', my.adapter.hook, 'end', my);
                     // HookSystem::EndBlock
 
                     cb(content, meta);
@@ -341,6 +341,12 @@ callback({
 
                     childAdapter = new AdapterBuffer(buffer, childName,
                             callback);
+
+                    // HookSystem::StartBlock
+                    // piping the hook handler into the child mojits
+                    childAdapter.hook = this.adapter.hook;
+                    // HookSystem::EndBlock
+
                     // HookSystem::StartBlock
                     Y.mojito.hooks.hook('adapterBuffer', this.adapter.hook, 'start', childAdapter);
                     // HookSystem::EndBlock

--- a/lib/app/autoload/hooks.common.js
+++ b/lib/app/autoload/hooks.common.js
@@ -5,8 +5,9 @@
  */
 
 
-/*jslint anon:true, sloppy:true*/
+/*jslint anon:true*/
 /*global YUI*/
+
 
 /**
  * The hook system provides a way for application or add on developers to access the inner working of mojito.
@@ -14,148 +15,101 @@
  * registerHook with the name of the hook and a callback function. The second step involves enabling a hook
  * your addon to recieve hooks. You need to call the enableHookGroup with the name of your addon.
  *
- * List of hooks
- *
- * <ul>
- * <li>Y.mojito.hooks.hook('adapterBuffer', hook_ctx, 'start', this);
- * <li>Y.mojito.hooks.hook('adapterBuffer', this.__hook_ctx, 'end', this);
- * <li>Y.mojito.hooks.hook('addon', this.adapter.hook, 'start', self, cfg);
- * <li>Y.mojito.hooks.hook('addon', this.adapter.hook, 'end', self);
- * <li>Y.mojito.hooks.hook('hb', adapter.hook, 'start', tmpl);
- * <li>Y.mojito.hooks.hook('hb', adapter.hook, 'end');
- * <li>Y.mojito.hooks.hook('attachActionContext', adapter.hook, 'start', command);
- * <li>Y.mojito.hooks.hook('attachActionContext', adapter.hook, 'end');
- * <li>Y.mojito.hooks.hook('actionContext', opts.adapter.hook, 'start', my, opts);
- * <li>Y.mojito.hooks.hook('actionContext', opts.adapter.hook, 'end1', my, opts);
- * <li>Y.mojito.hooks.hook('actionContext', opts.adapter.hook, 'end2', my, opts);
- * <li>Y.mojito.hooks.hook('actionContextDone', adapter.hook, 'start', this);
- * <li>Y.mojito.hooks.hook('actionContextDone', adapter.hook, 'end1', this);
- * <li>Y.mojito.hooks.hook('actionContextDone', adapter.hook, 'end2', this);
- * <li>Y.mojito.hooks.hook('dispatchCreateAction', adapter.hook, 'start', command);
- * <li>Y.mojito.hooks.hook('dispatchCreateAction', adapter.hook, 'end');
- * <li>Y.mojito.hooks.hook('dispatch', adapter.hook, 'start', command);
- * <li>Y.mojito.hooks.hook('dispatch', adapter.hook, 'end');
- * <li>Y.mojito.hooks.hook('storeTypeDetails', instance.hook, 'start', spec);
- * <li>Y.mojito.hooks.hook('storeTypeDetails', instance.hook, 'end');
- * <li>Y.mojito.hooks.hook('mojitoClient', null, 'start', this);
- * <li>Y.mojito.hooks.hook('mojitoClient', null, 'end', this);
- * <li>Y.mojito.hooks.hook('mojitoClientBind', null, 'start', this);
- * <li>Y.mojito.hooks.hook('mojitoClientBind', null, 'resume', this);
- * <li>Y.mojito.hooks.hook('mojitoClientBind', null, 'end', this);
- * <li>Y.mojito.hooks.hook('mojitoClientBindComplete', null, 'start', this);
- * <li>Y.mojito.hooks.hook('mojitoClientBindComplete', null, 'end', this);
- * <li>Y.mojito.hooks.hook('AppDispatch', req.hook, req, res);
- * </ul>
  * @module MojitoHooks
  */
 
 
-YUI.add('mojito-hooks', function(Y, NAME) {
-    var map_hook_tool = {};
+YUI.add('mojito-hooks', function (Y, NAME) {
 
-    Y.namespace('mojito.hooks');
+    'use strict';
 
-    /**
-     * Trigger a hook
-     * @method hook
-     * @param {String} hook_name
-     * @param {Object} hook context (from req.hook, or adapter.hook)
-     * @param {} hook specific data
-     *
-     * Example:
-     * <pre>
-     * Y.mojito.hooks.hook('test_hook', ctx, ...);
-     * </pre>
-     */
-    Y.mojito.hooks.hook = function (hook) {
-        Y.log("hooks disabled (" + hook + ")", 'debug', NAME);
-    };
+    var mapping = {};
 
-    Y.mojito.hooks.real_hook = function (hook, ctx) {
-        Y.log("in hook handler: " + hook, 'debug', NAME);
-        var tool,
-            ds_args;
+    Y.mojito.hooks = {
 
-        if (!map_hook_tool[hook] || (!ctx && !Y.mojito.hooks.global_hooks_ctx)) {
-            return;
-        }
-        ds_args = [].slice.apply(arguments).slice(2);
-        for (tool in map_hook_tool[hook]) {
-            if (map_hook_tool[hook].hasOwnProperty(tool)) {
-                if (ctx && ctx[tool]) {
-                    map_hook_tool[hook][tool].apply(ctx[tool], ds_args);
+        /**
+         * Shim for the hooks trigger mechanism. Under normal conditions
+         * the shim will do nothing, but if there is at least one hook
+         * registered, and enabled, it will try to proces the hook.
+         * @method hook
+         * @param {String} name The name of the hook.
+         * @param {Object} handler A placeholder for a collection of
+         * hooks enabled during the runtime. Usually req.hook or
+         * adapter.hook object.
+         * @param {} hook specific data
+         *
+         * Example:
+         * <pre>
+         * Y.mojito.hooks.hook('test_hook', ctx, ...);
+         * </pre>
+         */
+        hook: function (name, handler) {
+
+            var group;
+
+            if (!handler || !mapping[name]) {
+                return;
+            }
+
+            Y.log("in hook handler: " + name, 'debug', NAME);
+
+            for (group in mapping[name]) {
+                if (mapping[name].hasOwnProperty(group) &&
+                        handler.hasOwnProperty(group)) {
+                    mapping[name][group].apply(handler[group], Y.Array(arguments, 2));
                 }
-                if (Y.mojito.hooks.global_hooks_ctx && Y.mojito.hooks.global_hooks_ctx[tool]) {
-                    map_hook_tool[hook][tool].apply(Y.mojito.hooks.global_hooks_ctx[tool], ds_args);
-                }
+            }
+        },
+
+        /**
+         * A Mojito entity can register an interest in a hook. The call context for all groups
+         * will be the same for all hooks registered for a group, and it will be new and unique for
+         * each request. The params to the call back function are hook specific.
+         *
+         * @method registerhook
+         * @param {String} group the name of the group for the hook
+         * @param {String} name the hook name
+         * @param {Function} fn the callback function that implements
+         * the hook logic.
+         *
+         * Example:
+         * <pre>
+         * Y.mojito.hooks.registerHook('test_group', 'test_hook', function (reg, data) {});
+         * </pre>
+         */
+        registerHook: function (group, name, fn) {
+            if (!mapping[name]) {
+                mapping[name] = {};
+            }
+            mapping[name][group] = fn;
+
+            Y.log("register group: " + group + ", hook name: " + name, 'debug', NAME);
+        },
+
+        /**
+         * Enable a group for a request.
+         *
+         * @method enableHookGroup
+         * @param {Object} handler A placeholder for a collection of
+         * hooks enabled during the runtime. Usually req.hook or
+         * adapter.hook object.
+         * @param {String} group The name of the group to enable
+         *
+         * Example:
+         * <pre>
+         * Y.mojito.hooks.enableHookGroup(req.hook, 'test_group');
+         * </pre>
+         */
+        enableHookGroup: function (handler, group) {
+
+            Y.log("enable group: " + group, 'debug', NAME);
+
+            // TODO: what is we enable a group that is not defined
+            if (!handler[group]) {
+                handler[group] = {};
             }
         }
+
     };
 
-    /**
-     * A Mojito addon/tool can register an interest in a hook. The call context for all tools
-     * will be the same for all hooks registered for a tool, and it will be new and unique for
-     * each request. The params to the call back function are hook specific.
-     *
-     * @method registerhook
-     * @param {String} tool tool name for this hook
-     * @param {String} hook name of hook
-     * @param {Function} cb call back function
-     *
-     * Example:
-     * <pre>
-     * Y.mojito.hooks.registerHook('test_tool, 'test_hook', function (reg, data) {});
-     * </pre>
-     */
-    Y.mojito.hooks.registerHook = function (tool, hook, cb) {
-        if (!map_hook_tool[hook]) {
-            map_hook_tool[hook] = {};
-        }
-        map_hook_tool[hook][tool] = cb;
-
-        Y.mojito.hooks.hook = Y.mojito.hooks.real_hook;
-
-        Y.log("register tool: " + tool + ", hook: " + hook, 'debug', NAME);
-    };
-
-    /**
-     * Enable a tool for a request.
-     *
-     * @method enableHookGroup
-     * @param {Object} req Request object to enable hook on
-     * @param {String} tool Name of tool to enable
-     * @return {Object} this tools context used for its hook callbacks
-     *
-     * Example:
-     * <pre>
-     * Y.mojito.hooks.enableHookGroup(req, 'test_tool');
-     * </pre>
-     */
-    Y.mojito.hooks.enableHookGroup = function (req, tool) {
-        var ret = {};
-        Y.log("enable tool: " + tool, 'debug', NAME);
-
-        // if called in client, use single global context.
-        if (!req) {
-            if (!Y.mojito.hooks.global_hooks_ctx) {
-                Y.mojito.hooks.global_hooks_ctx = {};
-            }
-            if (!Y.mojito.hooks.global_hooks_ctx[tool]) {
-                Y.mojito.hooks.global_hooks_ctx[tool] = {};
-            }
-            ret = Y.mojito.hooks.global_hooks_ctx[tool];
-        } else {
-            if (!req.hook) {
-                req.hook = {};
-            }
-
-            if (!req.hook[tool]) {
-                req.hook[tool] = {};
-            }
-            ret = req.hook[tool];
-        }
-
-        return ret;
-    };
-
-}, '0.1.0', {requires: []});
+}, '0.1.0', {requires: ['mojito']});

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -45,7 +45,9 @@ YUI.add('mojito-client', function(Y, NAME) {
         State = {
             PAUSED: 'paused',
             ACTIVE: 'active'
-        };
+        },
+        // hook system handler
+        globalHookHandler;
 
 
     // because there is a moment during startup when we need it, cache the
@@ -218,6 +220,18 @@ YUI.add('mojito-client', function(Y, NAME) {
         this.timeLogStack = [];
         this.yuiConsole = null;
         this._pauseQueue = [];
+
+        // HookSystem::StartBlock
+        // TODO: validate that config.perf could be set for client.
+        if (config.perf) {
+            globalHookHandler = {};
+            // enabling perf group
+            // TODO: this should not be executed here.
+            Y.mojito.hooks.enableHookGroup(globalHookHandler, 'mojito-perf');
+        }
+        // HookSystem::EndBlock
+
+
         if (config) {
             // Note the server sends cleased config data directly to the
             // constructor from the deploy.server.js initializer to allow markup
@@ -318,7 +332,7 @@ YUI.add('mojito-client', function(Y, NAME) {
         init: function(config) {
             fireLifecycle('pre-init', {config: config});
             // HookSystem::StartBlock
-            Y.mojito.hooks.hook('mojitoClient', null, 'start', this);
+            Y.mojito.hooks.hook('mojitoClient', globalHookHandler, 'start', this);
             // HookSystem::EndBlock
             var that = this,
                 appConfig = config.appConfig;
@@ -359,7 +373,7 @@ YUI.add('mojito-client', function(Y, NAME) {
             this._mojits = {};
 
             // HookSystem::StartBlock
-            Y.mojito.hooks.hook('mojitoClient', null, 'end', this);
+            Y.mojito.hooks.hook('mojitoClient', globalHookHandler, 'end', this);
             // HookSystem::EndBlock
             /* FUTURE -- perhaps only do this once a user needs it
             var singletons;
@@ -442,16 +456,16 @@ YUI.add('mojito-client', function(Y, NAME) {
             parentId = eventData.parentId;
             topLevelMojitViewId = eventData.topLevelMojitViewId;
             // HookSystem::StartBlock
-            Y.mojito.hooks.hook('mojitoClientBind', null, 'start', this);
+            Y.mojito.hooks.hook('mojitoClientBind', globalHookHandler, 'start', this);
             // HookSystem::EndBlock
 
             if (!totalBinders) {
                 // HookSystem::StartBlock
-                Y.mojito.hooks.hook('mojitoClientBind', null, 'resume', this);
+                Y.mojito.hooks.hook('mojitoClientBind', globalHookHandler, 'resume', this);
                 // HookSystem::EndBlock
                 me.resume();
                 // HookSystem::StartBlock
-                Y.mojito.hooks.hook('mojitoClientBind', null, 'end', this);
+                Y.mojito.hooks.hook('mojitoClientBind', globalHookHandler, 'end', this);
                 // HookSystem::EndBlock
                 fireLifecycle('post-attach-binders', {});
                 return;
@@ -496,11 +510,11 @@ YUI.add('mojito-client', function(Y, NAME) {
                 });
 
                 // HookSystem::StartBlock
-                Y.mojito.hooks.hook('mojitoClientBindComplete', null, 'start', this);
+                Y.mojito.hooks.hook('mojitoClientBindComplete', globalHookHandler, 'start', this);
                 // HookSystem::EndBlock
                 me.resume();
                 // HookSystem::StartBlock
-                Y.mojito.hooks.hook('mojitoClientBindComplete', null, 'end', this);
+                Y.mojito.hooks.hook('mojitoClientBindComplete', globalHookHandler, 'end', this);
                 // HookSystem::EndBlock
                 fireLifecycle('post-attach-binders', {});
             };
@@ -644,7 +658,7 @@ YUI.add('mojito-client', function(Y, NAME) {
 
             // HookSystem::StartBlock
             if (Y.mojito.hooks) {
-                outputHandler.hook = Y.mojito.hooks.global_hooks_ctx;
+                outputHandler.hook = globalHookHandler;
             }
             // HookSystem::EndBlock
 

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -221,18 +221,17 @@ YUI.add('mojito-client', function(Y, NAME) {
         this.yuiConsole = null;
         this._pauseQueue = [];
 
-        // HookSystem::StartBlock
-        // TODO: validate that config.perf could be set for client.
-        if (config.perf) {
-            globalHookHandler = {};
-            // enabling perf group
-            // TODO: this should not be executed here.
-            Y.mojito.hooks.enableHookGroup(globalHookHandler, 'mojito-perf');
-        }
-        // HookSystem::EndBlock
-
-
         if (config) {
+            // HookSystem::StartBlock
+            // TODO: validate that config.perf could be set for client.
+            if (config.perf) {
+                globalHookHandler = {};
+                // enabling perf group
+                // TODO: this should not be executed here.
+                Y.mojito.hooks.enableHookGroup(globalHookHandler, 'mojito-perf');
+            }
+            // HookSystem::EndBlock
+
             // Note the server sends cleased config data directly to the
             // constructor from the deploy.server.js initializer to allow markup
             // to move over the wire in config strings without triggering

--- a/lib/app/autoload/mojito.common.js
+++ b/lib/app/autoload/mojito.common.js
@@ -20,18 +20,6 @@ YUI.add('mojito', function(Y, NAME) {
     Y.namespace('mojito.addons.ac');
     Y.namespace('mojito.addons.viewEngines');
 
-    // this is a facade for the real implementation from mojito-perf module
-    // that will have to be plugged manually to get the metrics in the
-    // console or a log file.
-    Y.mojito.perf = {
-        timeline: function () {
-            return {
-                done: function () {}
-            };
-        },
-        mark: function () {}
-    };
-
     // internal mojito framework cache (this is probably legacy)
     YUI.namespace('_mojito._cache');
 

--- a/lib/app/autoload/perf.client.js
+++ b/lib/app/autoload/perf.client.js
@@ -112,10 +112,6 @@ YUI.add('mojito-perf', function(Y, NAME) {
         }
     };
 
-    if (perfEnabled) {
-        Y.mojito.hooks.enableHookGroup(null, 'mojito-perf');
-    }
-
     Y.mojito.hooks.registerHook(NAME, 'adapterBuffer', function(w, adapter) {
         if (w === 'start') {
             this.ab_perf = Y.mojito.perf.timeline('mojito-composite-addon', 'child', 'the whole child', adapter.id);
@@ -198,6 +194,7 @@ YUI.add('mojito-perf', function(Y, NAME) {
     });
 
     Y.namespace('mojito').perf = perf;
+
 }, '0.1.0', {requires: [
     'mojito-hooks'
 ]});

--- a/lib/app/autoload/perf.server.js
+++ b/lib/app/autoload/perf.server.js
@@ -294,6 +294,7 @@ YUI.add('mojito-perf', function (Y, NAME) {
     }
 
     if (config) {
+        Y.namespace('mojito.perf');
         Y.mojito.perf.idFromCommand = idFromCommand;
         Y.mojito.perf.instrumentMojitoRequest = instrumentMojitoRequest;
         Y.mojito.perf.dump = dump;
@@ -371,13 +372,6 @@ YUI.add('mojito-perf', function (Y, NAME) {
             this.dis_perf = Y.mojito.perf.timeline('mojito', 'dispatch:expandInstance', 'gather details about mojit', command);
         } else {
             this.dis_perf.done();
-        }
-    });
-    Y.mojito.hooks.registerHook(NAME, 'storeTypeDetails', function(w, spec) {
-        if (w === 'start') {
-            this.st_perf = Y.mojito.perf.timeline('mojito', 'store:getMojitTypeDetails', 'expand mojit spec', spec.type);
-        } else {
-            this.st_perf.done();
         }
     });
     Y.mojito.hooks.registerHook(NAME, 'AppDispatch', function(req, res) {

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -205,22 +205,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             // We'll start with just our "config" addon. Note that since we're
             // forcing the load we have to also include mojito-util.
             this._yuiUseSync({
-                'mojito-util': {
-                    fullpath: this._libs.path.join(
-                        this._config.mojitoRoot,
-                        'app/autoload/util.common.js'
-                    )
-                },
                 'addon-rs-config': {
                     fullpath: this._libs.path.join(
                         this._config.mojitoRoot,
                         'app/addons/rs/config.js'
-                    )
-                },
-                'mojito-hooks': {
-                    fullpath: this._libs.path.join(
-                        this._config.mojitoRoot,
-                        'app/autoload/hooks.common.js'
                     )
                 }
             });
@@ -595,17 +583,9 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             // type details
             try {
-                // HookSystem::StartBlock
-                Y.mojito.hooks.hook('storeTypeDetails', instance.hook, 'start', spec);
-                // HookSystem::EndBlock
-
                 typeDetails = this.getMojitTypeDetails(env, ctx, spec.type, null, true);
             } catch (err2) {
                 return cb(err2);
-            } finally {
-                // HookSystem::StartBlock
-                Y.mojito.hooks.hook('storeTypeDetails', instance.hook, 'end');
-                // HookSystem::EndBlock
             }
 
             // priority (most important to least):
@@ -2132,6 +2112,5 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 }, '0.0.1', { requires: [
     'base',
     'oop',
-    'mojito-util',
-    'mojito-hooks'
+    'mojito-util'
 ]});

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -282,38 +282,22 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         outputHandler.setLogger({
             log: Y.log
         });
-        // HookSystem::StartBlock
-        if (!req.hook) {
-            req.hook = null;
-        }
-        outputHandler.hook = req.hook;
-        command.hook = req.hook;
-        // HookSystem::EndBlock
-        if (appConfig.debugMemory) {
-            outputHandler.setMemoryDebugObjects({
-                'YUI.Env': YUI.Env,
-                'YUI.config': YUI.config,
-                'YUI.process': YUI.process,
-                Y: Y,
-                store: store
-            });
-        }
 
         // HookSystem::StartBlock
-        Y.mojito.hooks.hook('AppDispatch', req.hook, req, res);
+        // enabling perf group
+        if (appConfig.perf) {
+            // in case another middleware has enabled hooks before
+            outputHandler.hook = req.hook || {};
+            Y.mojito.hooks.enableHookGroup(outputHandler.hook, 'mojito-perf');
+        }
+        // HookSystem::EndBlock
+
+        // HookSystem::StartBlock
+        Y.mojito.hooks.hook('AppDispatch', outputHandler.hook, req, res);
         // HookSystem::EndBlock
 
         singleton_dispatcher.dispatch(command, outputHandler);
     };
-
-    // HookSystem::StartBlock
-    if (appConfig.perf) {
-        app.use(function(req, res, next) {
-            Y.mojito.hooks.enableHookGroup(req, 'mojito-perf');
-            next();
-        });
-    }
-    // HookSystem::EndBlock
 
     // attaching middleware pieces
     for (m = 0; m < middleware.length; m += 1) {

--- a/lib/output-handler.server.js
+++ b/lib/output-handler.server.js
@@ -39,10 +39,6 @@ OutputHandler.prototype = {
         this.logger = logger;
     },
 
-    setMemoryDebugObjects: function(objs) {
-        this.memDebugObjects = objs;
-    },
-
 
     flush: function(data, meta) {
         this._readMeta(meta);
@@ -66,28 +62,6 @@ OutputHandler.prototype = {
         }
         this.res.end(data);
         this.logger.log('END', 'mojito', NAME);
-
-        // special memory debugging
-        if (this.memDebugObjects) {
-            for (name in this.memDebugObjects) {
-                if (this.memDebugObjects.hasOwnProperty(name)) {
-                    obj = this.memDebugObjects[name];
-                    try {
-                        size = libutil.inspect(obj, false, null).length;
-                    } catch (err) {
-                        this.logger.log(err, 'error', NAME);
-                    }
-                    memDebug[name] = size;
-                }
-            }
-            obj = process.memoryUsage();
-            for (name in obj) {
-                if (obj.hasOwnProperty(name)) {
-                    memDebug[name] = obj[name];
-                }
-            }
-            this.logger.log('--MEMDEBUG-- ' + JSON.stringify(memDebug), 'debug', NAME);
-        }
     },
 
 

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -26,25 +26,6 @@ YUI.add('mojito', function(Y, NAME) {
     Y.namespace('mojito.addons');
     Y.namespace('mojito.addons.ac');
     Y.namespace('mojito.addons.viewEngines');
-    // HookSystem::StartBlock
-    Y.mojito.hooks = {
-        hook: function () {},
-        registerHook: function () {},
-        enableHookGroup: function () {}
-    };
-    // HookSystem::EndBlock
-
-    // this is a facade for the real implementation from mojito-perf module
-    // that will have to be plugged manually to get the metrics in the
-    // console or a log file.
-    Y.mojito.perf = {
-        timeline: function () {
-            return {
-                done: function () {}
-            };
-        },
-        mark: function () {}
-    };
 
     // internal mojito framework cache (this is probably legacy)
     YUI.namespace('_mojito._cache');
@@ -89,6 +70,15 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {});
 YUI.add('mojito-mojit-proxy', function(Y, NAME) {});
 YUI.add('mojito-output-handler', function(Y, NAME) {});
 YUI.add('mojito-perf', function(Y, NAME) {});
+YUI.add('mojito-hooks', function(Y, NAME) {
+
+    Y.namespace('mojito').hooks = {
+        hook: function () {},
+        registerHook: function () {},
+        enableHookGroup: function () {}
+    };
+
+});
 YUI.add('mojito-resource-store', function(Y, NAME) {});
 YUI.add('mojito-rest-lib', function(Y, NAME) {});
 YUI.add('mojito-route-maker', function(Y, NAME) {});

--- a/tests/unit/lib/app/addons/ac/test-composite.common.js
+++ b/tests/unit/lib/app/addons/ac/test-composite.common.js
@@ -34,7 +34,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                 },
                 datamock = {data: 'mock'},
                 metamock = {meta: 'mock'},
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {
                     done: function(data, meta) {
                         doneCalled = true;
@@ -82,7 +82,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
 
         'test execute dispatches each child': function() {
             var command = {instance: {}},
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {
                     _dispatch: function(command, adapter) {
                         A.isObject(command, "bad command object to dispatch");
@@ -130,7 +130,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                         }
                     }
                 },
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {
                     done: function(data, meta) {
                         doneCalled = true;
@@ -161,7 +161,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
 
         'test error is thrown when children is an array': function() {
             var command = {instance: {}},
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {},
                 c = new Y.mojito.addons.ac.composite(command, adapter, ac),
                 config = {
@@ -182,7 +182,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
 
         'test proxied mojits are processed properly': function() {
             var command = {instance: {}},
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {
                     _dispatch: function(command, adapter) {
                         A.isObject(command, "bad command object to dispatch");
@@ -223,7 +223,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
 
         'test defered mojits are processed properly': function() {
             var command = {instance: {}},
-                adapter = null,
+                adapter = Y.Mock(),
                 ac = {
                     _dispatch: function(command, adapter) {
                         A.isObject(command, "bad command object to dispatch");
@@ -264,7 +264,7 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
 
         'test null or undefined child should be skipped': function() {
             var command = {instance: {}},
-                adapter = null,
+                adapter = Y.Mock(),
                 countDispatched = 0,
                 ac = {
                     _dispatch: function(command, adapter) {

--- a/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
+++ b/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
@@ -18,7 +18,7 @@
             },
             "hb.server" : {
                 "params" : {
-                    "lib": "$$config.lib$$/app/autoload/perf.server.js,./../../../../../../lib/app/addons/view-engines/hb.server.js",
+                    "lib": "./../../../../../../lib/app/addons/view-engines/hb.server.js",
                     "test" : "./test-hb.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -56,6 +56,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
+                adapter: Y.Mock(),
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -87,6 +88,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
+                adapter: Y.Mock(),
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -118,6 +120,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
+                adapter: Y.Mock(),
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -148,6 +151,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
+                adapter: Y.Mock(),
                 models: {},
                 controller: {index: function() {}},
                 dispatcher: 'the dispatcher',
@@ -173,6 +177,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         acAddons: ['custom']
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -196,6 +201,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
+                adapter: Y.Mock(),
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -251,6 +257,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         ]
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -276,6 +283,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         acAddons: []
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -305,6 +313,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -337,6 +346,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -375,6 +385,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -408,6 +419,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -441,6 +453,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -494,6 +507,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         }
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -539,6 +553,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         }
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -744,6 +759,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
+                adapter: Y.Mock(),
                 controller: {index: function() {}},
                 store: store
             });
@@ -777,6 +793,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 ac = new Y.mojito.ActionContext({
                     dispatch: 'the dispatch',
                     command: command,
+                    adapter: Y.Mock(),
                     controller: {
                         // no index() action
                     },
@@ -803,6 +820,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             var ac = new Y.mojito.ActionContext({
                     dispatch: 'the dispatch',
                     command: command,
+                    adapter: Y.Mock(),
                     controller: {
                         __call: function() {
                             callCalled = true;

--- a/tests/unit/lib/app/autoload/test-perf.server.js
+++ b/tests/unit/lib/app/autoload/test-perf.server.js
@@ -12,28 +12,11 @@ YUI().use('mojito-perf', 'test', function(Y) {
     suite.add(new Y.Test.Case({
 
         setUp: function() {
+
         },
 
         tearDown: function() {
-        },
 
-        /*
-        This is a low-level component, the only thing that is very important
-        for us is to make sure that after including mojito-perf, the original
-        facade is still in place without any change.
-        */
-
-        'test perf facade': function () {
-            A.isObject(Y.mojito.perf);
-            A.isFunction(Y.mojito.perf.mark);
-            A.isFunction(Y.mojito.perf.timeline);
-            A.isUndefined(Y.mojito.perf.instrumentMojitoRequest, 'the default facade should not enable this');
-        },
-
-        'test perf timeline facade': function () {
-            var t = Y.mojito.perf.timeline('group', 'label', 'msg', 'id');
-            A.isObject(t);
-            A.isFunction(t.done);
         }
 
     }));


### PR DESCRIPTION
- Run missing tests
- Restore perf levels by not doing extra work when hooks are not enabled
- Remove hooks from store in preparation for the split
