### PR TITLE
Reduced memory consumption at server start

### DIFF
--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -1912,7 +1912,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if (versions.hasOwnProperty(resid)) {
                     highest = Math.max.apply(Math, Object.keys(versions[resid]));
                     //console.log('--DEBUG-- highest=' + highest + ' -- ' + resid);
-                    chosen = Y.mojito.util.copy(versions[resid][highest]);
+                    chosen = versions[resid][highest];
                     out.push(chosen);
                 }
             }


### PR DESCRIPTION
This meta-data copy operation seems unnecessary to me, although I would like someone else to confirm before merging this PR. This change reduces the memory consumption at server start by almost 40% in our case (from ~160MB to <100 MB) because we have so many language resource bundles.
