### PR TITLE
support custom meta and custom template data for ac.composite.done() issue #948

### DIFF
--- a/examples/newsboxes/mojits/Shelf/controller.common.js
+++ b/examples/newsboxes/mojits/Shelf/controller.common.js
@@ -25,7 +25,11 @@ YUI.add('ShelfController', function (Y, NAME) {
             vudata.tiles.push(feed);
         });
 
-        ac.composite.done({template: vudata});
+        ac.composite.done(vudata, {
+            view: {
+                name: 'index'
+            }
+        });
     }
 
     /**

--- a/examples/sandbox/view_refresh/mojits/Parent/controller.server.js
+++ b/examples/sandbox/view_refresh/mojits/Parent/controller.server.js
@@ -9,7 +9,7 @@ YUI.add('Parent', function(Y, NAME) {
     Y.namespace('mojito.controllers')[NAME] = {
 
         index: function(ac) {
-            ac.composite.done({template: {time: new Date().toString()}});
+            ac.composite.done({time: new Date().toString()});
         }
 
     };

--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -154,17 +154,17 @@ Y.mojito.controller = {
             }
 
             this.execute(cfg, function(data, meta) {
-                // clearing the metas collected from childs to avoid a child
-                // to dictate how the parent will behave.
-                meta.view = {};
-
+                parentMeta.assets = Y.mojito.util.metaMerge(
+                    parentMeta.assets || {},
+                    meta.assets || {}
+                );
                 // 1. templateData and data are normally exclusive, in which case
-                // the prority is not relevent.
+                // the prority is not relevent. In which case we set D
                 // 2. parentMeta and meta should be merged to preserve the children
                 // binders map, assets, etc. but giving parentMeta the priority in case
                 // a custom configuration in the parent should overrule something coming
                 // from the chindren merged meta
-                ac.done(Y.merge(templateData, data), Y.mojito.util.metaMerge(meta, parentMeta));
+                ac.done(Y.merge(data, templateData), Y.mojito.util.metaMerge(parentMeta, meta));
             }, this);
         },
 

--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -154,15 +154,17 @@ Y.mojito.controller = {
             }
 
             this.execute(cfg, function(data, meta) {
-                if (meta.assets) {
-                    // for metas, the parent meta is preserved, and all assets for all
-                    // childs will be added into the mix if they exists.
-                    parentMeta.assets = Y.mojito.util.metaMerge(meta.assets, (parentMeta.assets || {}));
-                }
+                // clearing the metas collected from childs to avoid a child
+                // to dictate how the parent will behave.
+                meta.view = {};
 
-                // templateData and data are normally exclusive, in which case
+                // 1. templateData and data are normally exclusive, in which case
                 // the prority is not relevent.
-                ac.done(Y.merge(templateData, data), parentMeta);
+                // 2. parentMeta and meta should be merged to preserve the children
+                // binders map, assets, etc. but giving parentMeta the priority in case
+                // a custom configuration in the parent should overrule something coming
+                // from the chindren merged meta
+                ac.done(Y.merge(templateData, data), Y.mojito.util.metaMerge(meta, parentMeta));
             }, this);
         },
 

--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -119,29 +119,33 @@ YUI.add('mojito-composite-addon', function(Y, NAME) {
 Y.mojito.controller = {
     index: function(ac) {
         ac.composite.done({
-            template: { title: 'Hello there' } // for the view only
+            title: 'Hello there'
         });
     }
-        };
+};
 </pre>
          * This will execute the child intances of the "FooMojit" and
          * "BarMojit", returning their rendered values into the parent's view
          * template, thus rendering the full parent view including the children.
-         * All the parent parameters are passed along to children.
+         * The API of this method is equivalent to ac.done().
          * @method done
-         * @param {object} opts The configuration object to be used.
-         *     <em>template<em> can be used to provide additional
-         * view template values.
+         * @param {object} templateData The data you want return by the request.
+         * @param {object} parentMeta Any meta-data required to service the request.
          */
-        done: function(opts) {
-            var template,
-                ac = this.ac,
+        done: function(templateData, parentMeta) {
+            var ac = this.ac,
                 cfg = this.command.instance.config,
                 children = cfg.children;
 
-            opts = opts || {};
+            templateData = templateData || {};
+            parentMeta   = parentMeta || {};
 
-            template = opts.template || {};
+            // Backward Compatibility block
+            if (templateData.template) {
+                Y.log('ac.composite.done({template:{title: "..."}}) is a legacy API, ' +
+                        'use ac.composite.done({title: "..."}) instead.', 'warn', NAME);
+                templateData = templateData.template;
+            }
 
             if (!children || Y.Object.size(children) === 0) {
                 throw new Error('Cannot run composite mojit children because' +
@@ -150,9 +154,15 @@ Y.mojito.controller = {
             }
 
             this.execute(cfg, function(data, meta) {
-                var merged = Y.merge(template, data);
-                ac.done(merged, meta);
+                if (meta.assets) {
+                    // for metas, the parent meta is preserved, and all assets for all
+                    // childs will be added into the mix if they exists.
+                    parentMeta.assets = Y.mojito.util.metaMerge(meta.assets, (parentMeta.assets || {}));
+                }
 
+                // templateData and data are normally exclusive, in which case
+                // the prority is not relevent.
+                ac.done(Y.merge(templateData, data), parentMeta);
             }, this);
         },
 

--- a/tests/func/applications/frameworkapp/common/mojits/BroadCast/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/BroadCast/controller.common.js
@@ -25,9 +25,9 @@ YUI.add('BroadCast', function(Y, NAME) {
             ac.assets.addCss('/static/BroadCast/assets/static.css');
             ac.composite.done();
         },
-        
+
         'destroychild': function(ac) {
-            Y.log("inside destroy controller")
+            Y.log("inside destroy controller");
             ac.assets.addCss('/static/BroadCast/assets/static.css');
             ac.composite.done();
         },
@@ -72,7 +72,7 @@ YUI.add('BroadCast', function(Y, NAME) {
                 ac.done(template, meta);
             });
         },
-        
+
         'destroydynochild': function(ac) {
 
             var children = {
@@ -108,15 +108,13 @@ YUI.add('BroadCast', function(Y, NAME) {
                 ac.done(template, meta);
             });
         },
-        
+
         'selfinvoke': function(ac){
             //var foovalue = ac.params.getFromBody('foo');
             //Y.log("Here11111....."+foovalue);
-            ac.composite.done({ 
-                template: { 
-    			    title: 'foovalue=' 
-    		    }
-		    });
+            ac.composite.done({
+                title: 'foovalue='
+            });
         }
 
     };

--- a/tests/func/applications/frameworkapp/common/mojits/CM_Layout/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/CM_Layout/controller.common.js
@@ -23,16 +23,16 @@ YUI.add('CM_Layout', function(Y, NAME) {
          * @param ac {Object} The action context that provides access
          *        to the Mojito API.
          */
-		index: function(ac) {
-			ac.composite.done();
-		},
+        index: function(ac) {
+            ac.composite.done();
+        },
         myIndex: function(ac) {
             Y.log('index()', 'debug', NAME);
 
             var passParams = ac.params.getFromUrl('pass_params') || 'false';
 
             var parentConfig = ac.config.get();
-			var myId = parentConfig.id;
+            var myId = parentConfig.id;
             var childrenConfig = parentConfig.children;
 
             var childInfo = [];
@@ -46,24 +46,19 @@ YUI.add('CM_Layout', function(Y, NAME) {
                 childInfo.push(info);
             });
 
-			if (passParams === "false")
-			{
-				ac.composite.done({ 
-					template: { 
-						title: 'This is the title from controller.js of ' + myId, childData: childInfo 
-					} 
-				});
-			}
+            if (passParams === "false")
+            {
+                ac.composite.done({
+                    title: 'This is the title from controller.js of ' + myId,
+                    childData: childInfo
+                });
+            }
             else
             {
-            	ac.composite.done({ 
-            		template: { 
-            			title: 'This is the title from controller.js of ' + myId, childData: childInfo 
-            		},
-            		params: {
-            			fromParent: "I am from parent"
-            		}
-            	});
+                ac.composite.done({
+                    title: 'This is the title from controller.js of ' + myId,
+                    childData: childInfo
+                });
             }
         }
     };

--- a/tests/func/applications/frameworkapp/common/mojits/DepCheckParent/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/DepCheckParent/controller.common.js
@@ -4,36 +4,38 @@
 YUI.add('DepCheckParent', function(Y, NAME) {
 
     Y.namespace('mojito.controllers')[NAME] = {
-         'index': function(ac) {
-             ac.done();
-         },
-         'mytest': function(ac) {
-             //ac.models.AppLevelMojit.getData(function(mydata){
-             ac.models.get('DepCheckModel').getData(function(mydata){
-                 Y.log("data....."+mydata);
-                 ac.done({data:mydata});
-             });
-         },
-         'metachild': function(ac) {
-             ac.composite.done({ 
-  				template: { 
-          			title: 'My Child Mojits:' 
-          		} 
-          	});
-          },
-          'retrievedata': function(ac) {
-               //var retrieved = "old data";
-               var retrieved;
-               Y.log("data.....");
-               ac.meta.retrieve(function(data){
-                   Y.log("data1.....");
-                   retrieved = data["mydata"];
-                   Y.log("data....."+ retrieved);
-                   ac.done({retrieved:"any....data"});
-               });
-              // ac.done({retrieved:retrieved});
-            }
-     };
+        'index': function(ac) {
+            ac.done();
+        },
+        'mytest': function(ac) {
+            //ac.models.AppLevelMojit.getData(function(mydata){
+            ac.models.get('DepCheckModel').getData(function(mydata) {
+                Y.log("data....." + mydata);
+                ac.done({
+                    data: mydata
+                });
+            });
+        },
+        'metachild': function(ac) {
+            ac.composite.done({
+                title: 'My Child Mojits:'
+            });
+        },
+        'retrievedata': function(ac) {
+            //var retrieved = "old data";
+            var retrieved;
+            Y.log("data.....");
+            ac.meta.retrieve(function(data) {
+                Y.log("data1.....");
+                retrieved = data["mydata"];
+                Y.log("data....." + retrieved);
+                ac.done({
+                    retrieved: "any....data"
+                });
+            });
+            // ac.done({retrieved:retrieved});
+        }
+    };
 
 }, '0.0.1', {requires: [
     'mojito',

--- a/tests/func/applications/frameworkapp/common/mojits/MojitContainer/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/MojitContainer/controller.common.js
@@ -29,12 +29,10 @@ YUI.add('MojitContainer', function(Y, NAME) {
         myMojits: function(ac) {
             Y.log('index()', 'debug', NAME);
 
-			ac.composite.done({ 
-				template: { 
-        			title: 'My Child Mojits:' 
-        		} 
-        	});
-		
+            ac.composite.done({
+                title: 'My Child Mojits:'
+            });
+
         }
 
     };

--- a/tests/func/applications/frameworkapp/serveronly/mojits/Container/controller.server.js
+++ b/tests/func/applications/frameworkapp/serveronly/mojits/Container/controller.server.js
@@ -38,12 +38,11 @@ YUI.add('Container', function(Y, NAME) {
                 Y.log("***********************************************ChildName: " + childName + " and child spec: " +  JSON.stringify(childSpec));
                 childInfo.push(info);
             });
-    
+
             ac.composite.done({
-                template: {
-                    title: "There are two children in this Container:", childData: childInfo 
-                }
-            })
+                title: "There are two children in this Container:",
+                childData: childInfo
+            });
         }
 
     };

--- a/tests/func/applications/frameworkapp/serveronly/mojits/RefreshParent/controller.server.js
+++ b/tests/func/applications/frameworkapp/serveronly/mojits/RefreshParent/controller.server.js
@@ -38,12 +38,10 @@ YUI.add('RefreshParent', function(Y, NAME) {
                 Y.log("**************ChildName: " + childName + " and child spec: " +  JSON.stringify(childSpec));
                 childInfo.push(info);
             });
-    
+
             ac.composite.done({
-                template: {
-                    childData: childInfo 
-                }
-            })
+                childData: childInfo
+            });
         }
 
     };

--- a/tests/unit/lib/app/addons/ac/test-composite.common.js
+++ b/tests/unit/lib/app/addons/ac/test-composite.common.js
@@ -32,14 +32,14 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                         }
                     }
                 },
-                datamock = {data: 'mock'},
-                metamock = {meta: 'mock'},
+                datamock = {bar: 'mock'},
+                metamock = {assets: {foo: 'mock'}},
                 adapter = Y.Mock(),
                 ac = {
                     done: function(data, meta) {
                         doneCalled = true;
-                        OA.areEqual(datamock, data, "wrong data value");
-                        OA.areEqual(metamock, meta, "wrong meta value");
+                        A.areEqual('mock', data.bar, "wrong data value");
+                        A.areEqual('mock', metamock.assets.foo, "wrong meta value");
                     }, _notify: function() {}
                 },
                 c = new Y.mojito.addons.ac.composite(command, adapter, ac),
@@ -115,6 +115,45 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
             });
 
             A.isTrue(exeCbCalled, "execute callback never called");
+
+        },
+
+        'test templateData (new API)': function() {
+
+            var command = {
+                    instance: {
+                        config: {
+                            children: {
+                                kid_a: { id: 'kid_a', type: 'kida' },
+                                kid_b: { id: 'kid_b', type: 'kidb' }
+                            }
+                        }
+                    }
+                },
+                adapter = Y.Mock(),
+                ac = {
+                    done: function(data, meta) {
+                        doneCalled = true;
+                        A.isString(data.foo);
+                        A.areSame('fooval', data.foo, "template data didn't transfer");
+                        A.areSame('kid_a__data', data.kid_a, "Missing core child data");
+                        A.areSame('kid_b__data', data.kid_b, "Missing core child data");
+                    },
+                    _dispatch: function(command, adapter) {
+                        var id = command.instance.id;
+                        var meta = {};
+                        meta[id] = id + '__meta';
+                        adapter.done(id + '__data', meta);
+                    }, _notify: function() {}
+                },
+                c = new Y.mojito.addons.ac.composite(command, adapter, ac),
+                doneCalled = false;
+
+            c.done({
+                foo: 'fooval'
+            });
+
+            A.isTrue(doneCalled, "ac done function never called");
 
         },
 
@@ -298,6 +337,62 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
             });
 
             A.isTrue(exeCbCalled, "execute callback never called");
+        },
+
+        'test parentMeta (new API)': function() {
+
+            var command = {
+                    instance: {
+                        config: {
+                            children: {
+                                kid_a: { id: 'kid_a', type: 'kida' },
+                                kid_b: { id: 'kid_b', type: 'kidb' }
+                            }
+                        }
+                    }
+                },
+                adapter = Y.Mock(),
+                ac = {
+                    done: function(data, meta) {
+                        doneCalled = true;
+                        A.isString(meta.view.name);
+                        A.areSame('fooFromParent', meta.view.name, "child meta should not overrule parent meta");
+                        A.areSame(3, meta.assets.top.js.length, "assets from parent and childs should be merged");
+                        A.isUndefined(meta.view.binder, "meta.view should be preserved from parent without deep merge");
+                    },
+                    _dispatch: function(command, adapter) {
+                        var id = command.instance.id;
+                        var meta = {
+                            view: {
+                                name: 'barFromChild',
+                                binder: 'barFromChildOnly'
+                            },
+                            assets: {
+                                top: {
+                                    js: [id]
+                                }
+                            }
+                        };
+                        meta[id] = id + '__meta';
+                        adapter.done(id + '__data', meta);
+                    },
+                    _notify: function() {}
+                },
+                c = new Y.mojito.addons.ac.composite(command, adapter, ac),
+                doneCalled = false;
+
+            c.done({}, {
+                view: {
+                    name: "fooFromParent"
+                },
+                assets: {
+                    top: {
+                        js: ["one"]
+                    }
+                }
+            });
+
+            A.isTrue(doneCalled, "ac done function never called");
         }
 
     }));

--- a/tests/unit/lib/app/addons/ac/test-composite.common.js
+++ b/tests/unit/lib/app/addons/ac/test-composite.common.js
@@ -355,10 +355,11 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                 ac = {
                     done: function(data, meta) {
                         doneCalled = true;
-                        A.isString(meta.view.name);
+                        A.isString(meta.view.name, 'view.name should come from parentMeta');
                         A.areSame('fooFromParent', meta.view.name, "child meta should not overrule parent meta");
                         A.areSame(3, meta.assets.top.js.length, "assets from parent and childs should be merged");
                         A.isUndefined(meta.view.binder, "meta.view should be preserved from parent without deep merge");
+                        A.areEqual(123, meta.binders.mojitid, "meta.binders map should be preserved from children");
                     },
                     _dispatch: function(command, adapter) {
                         var id = command.instance.id;
@@ -371,6 +372,9 @@ YUI().use('mojito-composite-addon', 'test', function(Y) {
                                 top: {
                                     js: [id]
                                 }
+                            },
+                            binders: {
+                                mojitid: 123
                             }
                         };
                         meta[id] = id + '__meta';


### PR DESCRIPTION
This PR tries to match the api of ac.done() and ac.composite.done() now that we don't accept passing params and other data into all children.

The new API will work like this:

```
ac.composite.done({
    "title" : "something"
}, {
    "view": {
        "name": "detail"
    },
    "assets": {
        "top": {
            "js": ["something.js"]
        }
    }
});
```

The old API is still supported, in which case this will also work:

```
ac.composite.done({
    "template:" {
        "title" : "something"
    }
});
```

but a warning will be issued to announce the deprecation.

TODO: 
- Update examples
- Update documentation
