### PR TITLE
supporting applicationConfigFiles definition in a setting other than master

### DIFF
--- a/lib/app/addons/rs/config.js
+++ b/lib/app/addons/rs/config.js
@@ -351,7 +351,13 @@ YUI.add('addon-rs-config', function(Y, NAME) {
             // since application.json is optional, we should be careful
             // in any case there is a low-level cache mechanism going on here.
             if (Y.Lang.isArray(this.readConfigSimple(rootAppJSON))) {
-                ycb = this.readConfigYCB(rootAppJSON, {});
+                // ensuring the context runtime:server to read applicationConfigFiles,
+                // it does not matter if runtime is not a dimension, it works just fine
+                // since the purpose of this block is to read applicationConfigFiles
+                // from /application.json, and the rest is part of this.createMultipartYCB
+                ycb = this.readConfigYCB(rootAppJSON, {
+                    runtime: 'server'
+                });
                 // adding the master application.json as the top level
                 paths.push(rootAppJSON);
                 // optional applicationConfigFiles to mix in more configs

--- a/tests/fixtures/app-jsons/application.json
+++ b/tests/fixtures/app-jsons/application.json
@@ -1,10 +1,13 @@
 [
     {
-        "settings": [ "master" ],
+        "settings": [ "runtime:common" ],
         "applicationConfigFiles": [
             "node_modules/devices/application.json",
             "node_modules/runtimes/application.json"
-        ],
+        ]
+    },
+    {
+        "settings": [ "master" ],
         "testKey1": "testVal1",
         "testKey2": "testVal2",
         "testKey3": "testVal3"


### PR DESCRIPTION
specifically supporting runtime:common or runtime:server, e.g.: 

```
[
    {
        "settings": [ "runtime:common" ],
        "applicationConfigFiles": [
            "another/application.json",
            "master-setting.json"
        ]
    },
    {
        "settings": [ "master" ],
        "testKey1": "testVal1",
        "testKey2": "testVal2",
        "testKey3": "testVal3"
    }
]
```

So, you can get a master setting that is shared between apps, and include it as part of the root application.json
