### PR TITLE
App fails to boot in nodejitsu

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -489,18 +489,22 @@ MojitoServer.prototype.getHttpServer = function() {
  * Begin listening for inbound connections.
  * @param {Number} port The port number. Defaults to the server's value for
  *     options.port (which defaults to process.env.PORT followed by 8666).
- * @param {String} host The hostname or IP address in string form.
+ * @param {String} host Optional hostname or IP address in string form.
+ * @param {Function} callback Optional callback to get notified when the
+ * server is ready to server traffic.
  */
-MojitoServer.prototype.listen = function(port, host, cb) {
+MojitoServer.prototype.listen = function(port, host, callback) {
 
     var logger,
         app = this._app,
         p = port || this._options.port,
         h = host || this._options.host,
-        callback = cb || Mojito.NOOP,
         handler = function(err) {
-            callback(err, app);
-        };
+            if (callback) {
+                callback(err, app);
+            }
+        },
+        listenArgs = [p];
 
     // Track startup time and use it to ensure we don't try to listen() twice.
     if (this._startupTime) {
@@ -515,14 +519,17 @@ MojitoServer.prototype.listen = function(port, host, cb) {
         libutils.warn('Starting Mojito Application');
     }
 
+    if (h) {
+        listenArgs.push(h);
+    }
+    if (callback) {
+        listenArgs.push(handler);
+    }
+
     try {
-        if (h) {
-            app.listen(p, h, handler);
-        } else {
-            app.listen(p, handler);
-        }
+        app.listen.apply(app, listenArgs);
     } catch (err) {
-        callback(err);
+        handler(err);
     }
 };
 


### PR DESCRIPTION
App fails to boot in nodejitsu due to a callback wrapper that is synthetically created when calling `app.listen(8080);` in server.js. Apparently this callback interrupts the control, and make the app to hang. To solve the problem, we are removing the wrapper in favor of the original callback or nothing, in other words callback argument for app.listen() is optional now.
