### PR TITLE
prefer store.getStaticAppConfig()

### DIFF
--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -292,7 +292,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         Y.mojito.hooks.hook('actionContext', opts.adapter.hook, 'start', my, opts);
         // HookSystem::EndBlock
 
-        staticAppConfig = store.getAppConfig(store.getStaticContext());
+        staticAppConfig = store.getStaticAppConfig();
 
         // It's possible to setup a route that calls "foo.", which means that
         // the default action in the instance should be used instead.

--- a/lib/app/autoload/store.client.js
+++ b/lib/app/autoload/store.client.js
@@ -236,6 +236,16 @@ YUI.add('mojito-client-store', function(Y, NAME) {
 
 
         /**
+         * Returns the static (non-runtime-sensitive) version of the application.json.
+         * @method getStaticAppConfig
+         * @return {object} the configuration from applications.json
+         */
+        getStaticAppConfig: function(ctx) {
+            return this.appConfig;
+        },
+
+
+        /**
          * Returns the routes configured in the application.
          * @method getRoutes
          * @param {object} ctx the context

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -275,7 +275,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         options.context = {};
     }
 
-    appConfig = store.getAppConfig(store.getStaticContext());
+    appConfig = store.getStaticAppConfig();
     yuiConfig = (appConfig.yui && appConfig.yui.config) || {};
 
     // redefining "combine" and/or "base" in the server side have side effects

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -13,6 +13,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             getAppConfig: function() {
                 return 'app config';
             },
+            getStaticAppConfig: function() {
+                return 'static app config';
+            },
             getStaticContext: function() {
                 return 'static context';
             },
@@ -596,6 +599,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         actionTimeout: 1
                     };
                 },
+                getStaticAppConfig: function() {
+                    return 'static app config';
+                },
                 getStaticContext: function() {
                     return 'static context';
                 },
@@ -650,6 +656,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         actionTimeout: 1000
                     };
                 },
+                getStaticAppConfig: function() {
+                    return 'static app config';
+                },
                 getStaticContext: function() {
                     return 'static context';
                 },
@@ -701,6 +710,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     return {
                         actionTimeout: 1000
                     };
+                },
+                getStaticAppConfig: function() {
+                    return 'static app config';
                 },
                 getStaticContext: function() {
                     return 'static context';
@@ -835,6 +847,9 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             var store = {
                 getAppConfig: function() {
                     return {};
+                },
+                getStaticAppConfig: function() {
+                    return 'static app config';
                 },
                 getStaticContext: function() {
                     return {};
@@ -977,6 +992,11 @@ YUI().use('mojito-action-context', 'test', function (Y) {
         'test pathToRoot for views': function() {
             var store = {
                     getAppConfig: function() {
+                        return {
+                            pathToRoot: '/path/to/root/'
+                        };
+                    },
+                    getStaticAppConfig: function() {
                         return {
                             pathToRoot: '/path/to/root/'
                         };


### PR DESCRIPTION
... over store.getAppConfig(store.getStaticContext())
