### PR TITLE
Revert commit 3a5822a

### DIFF
--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -1940,7 +1940,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if (versions.hasOwnProperty(resid)) {
                     highest = Math.max.apply(Math, Object.keys(versions[resid]));
                     //console.log('--DEBUG-- highest=' + highest + ' -- ' + resid);
-                    chosen = versions[resid][highest];
+                    chosen = Y.mojito.util.copy(versions[resid][highest]);
                     out.push(chosen);
                 }
             }


### PR DESCRIPTION
"Reduced memory consumption at server start by removing an apparently unnecessary meta-data copy operation..."

This reverts commit 3a5822aaf119dc2bbeb2e5e15d742205034d3116.
