### PR TITLE
Fix for client side hooks, bug fix in template hooks.

### DIFF
--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -70,6 +70,10 @@ YUI.add('mojito-hb', function (Y, NAME) {
                 partial,
                 partials;
 
+            // HookSystem::StartBlock
+            Y.mojito.hooks.hook('hb', adapter.hook, 'start', template);
+            // HookSystem::EndBlock
+
             // support for legacy url instead of a view object
             if (Y.Lang.isString(template)) {
                 Y.log('[view] argument in [render] method should be an object', 'warn', NAME);
@@ -84,10 +88,6 @@ YUI.add('mojito-hb', function (Y, NAME) {
                 handler(null, cache[cacheKey]);
                 return;
             }
-
-            // HookSystem::StartBlock
-            Y.mojito.hooks.hook('hb', adapter.hook, 'start', template);
-            // HookSystem::EndBlock
 
             stack = new Y.Parallel();
             partials = {};

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -332,9 +332,13 @@ YUI.add('mojito-client', function(Y, NAME) {
         init: function(config) {
             var forwardConfig = {
                 config: config,
+                // pass globalHookhandler to addons that may want to use hooks
                 globalHookHandler: globalHookHandler
             };
             fireLifecycle('pre-init', forwardConfig);
+            // if we didn't originaly have hooks enabled, copy back from config object.
+            // This is the case where an add-on module wants to turn on hooks and
+            // created an instance of the globalHookHandler.
             if (!globalHookHandler) {
                 globalHookHandler = forwardConfig.globalHookHandler;
             }

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -330,11 +330,13 @@ YUI.add('mojito-client', function(Y, NAME) {
     MojitoClient.prototype = {
 
         init: function(config) {
-            var forwardConfig = {
-                config: config,
-                // pass globalHookhandler to addons that may want to use hooks
-                globalHookHandler: globalHookHandler
-            };
+            var that = this,
+                appConfig = config.appConfig,
+                forwardConfig = {
+                    config: config,
+                    // pass globalHookhandler to addons that may want to use hooks
+                    globalHookHandler: globalHookHandler
+                };
             fireLifecycle('pre-init', forwardConfig);
             // if we didn't originaly have hooks enabled, copy back from config object.
             // This is the case where an add-on module wants to turn on hooks and
@@ -345,8 +347,6 @@ YUI.add('mojito-client', function(Y, NAME) {
             // HookSystem::StartBlock
             Y.mojito.hooks.hook('mojitoClient', globalHookHandler, 'start', this);
             // HookSystem::EndBlock
-            var that = this,
-                appConfig = config.appConfig;
 
             // YUI Console
             if (appConfig && appConfig.yui &&

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -330,7 +330,14 @@ YUI.add('mojito-client', function(Y, NAME) {
     MojitoClient.prototype = {
 
         init: function(config) {
-            fireLifecycle('pre-init', {config: config});
+            var forwardConfig = {
+                config: config,
+                globalHookHandler: globalHookHandler
+            };
+            fireLifecycle('pre-init', forwardConfig);
+            if (!globalHookHandler) {
+                globalHookHandler = forwardConfig.globalHookHandler;
+            }
             // HookSystem::StartBlock
             Y.mojito.hooks.hook('mojitoClient', globalHookHandler, 'start', this);
             // HookSystem::EndBlock


### PR DESCRIPTION
To use hooks on the client side, the globalHookHandler has to be available for addons. Send pass it around using life cycle events in mojito client.

Fixed bug introduced by Caridy in hb.server.js. Hooks start call has to be called before cache code.
