### PR TITLE
write results in dir out side of working folder as arrow0.0.73 changes

### DIFF
--- a/tests/run.js
+++ b/tests/run.js
@@ -176,7 +176,7 @@ function runFuncAppTests(cmd, callback){
         descriptors.push(cmd.funcPath + '/' + descriptor);
     }
     
-    var arrowReportDir = cmd.funcPath + '/artifacts/arrowreport/';
+    var arrowReportDir = cmd.funcPath + '/../../artifacts/arrowreport/';
     try {
         wrench.rmdirSyncRecursive(arrowReportDir);
     } catch (e) {}


### PR DESCRIPTION
When switch arrow from 0.0.71 to 0.0.73, our CI report dir only has the last app tests report filed left. All reports from other apps got deleted. As arrow team suggested, if result dir is outside of working folder, all results will be saved. So I am making this change.
