### PR TITLE
[bz5800733] Handlebars Template Helpers (second attempt after #922)

### DIFF
--- a/lib/app/addons/ac/helpers.common.js
+++ b/lib/app/addons/ac/helpers.common.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*jslint nomen:true*/
+/*global YUI*/
+
+/**
+ * @module ActionContextAddon
+ */
+YUI.add('mojito-helpers-addon', function (Y, NAME) {
+
+    'use strict';
+
+    /**
+     * <strong>Access point:</strong> <em>ac.helpers.*</em>
+     * Addon that provides helpers functionalities
+     * @class Helpers.common
+     */
+    function Addon(command, adapter) {
+        this._page = adapter.page;
+        // exposing instance helpers for render engine can use it,
+        // also, mixing in any previously exposed helper.
+        this._helpers = command.instance.helpers = Y.merge({},
+            (this._page.helpers || {}));
+    }
+
+    Addon.prototype = {
+
+        namespace: 'helpers',
+
+        /**
+         * Gets one specific helper if the name is specified,
+         * otherwise returns all available helpers.
+         * @method get
+         * @param {string} helperName The optional helper name
+         * @return {function|object} a helper function or all available helpers
+         */
+        get: function (helperName) {
+            return helperName ? this._helpers[helperName] : this._helpers;
+        },
+
+        /**
+         * set a helper function at the mojit instance.
+         * @method set
+         * @param {string} helperName The helper name.
+         * @param {function} helper The helper function.
+         */
+        set: function (helperName, helper) {
+            if (!helperName || !helper) {
+                Y.log('Invalid helper name or helper function ' +
+                    'when calling `ac.helpers.set()`: ' + helperName, 'error', NAME);
+                return;
+            }
+            if (this._helpers[helperName]) {
+                Y.log('Overiding an existing helper function with name: ' +
+                    helperName, 'warn', NAME);
+            }
+            this._helpers[helperName] = helper;
+        },
+
+        /**
+         * Expose a helper function as global. On the server side
+         * this means any mojit instance under a particular request
+         * can use the helper. On the client, any
+         * mojit instance on the page can use the helper.
+         * @method expose
+         * @param {string} helperName The helper name.
+         * @param {function} helper Optional helper function, if not
+         * present, the helper will be lookup by name.
+         */
+        expose: function (helperName, helper) {
+            this._page.helpers = this._page.helpers || {};
+            // you might want to expose an existing local helper
+            helper = helper || this._helpers[helperName];
+            // exposing thru global page object
+            this._page.helpers[helperName] = helper;
+            // exposing at the instance level
+            this._helpers[helperName] = helper;
+            Y.log('Exposing a global helper: ' + helperName, 'info', NAME);
+        }
+
+    };
+
+    Y.namespace('mojito.addons.ac').helpers = Addon;
+
+}, '0.1.0', {requires: [
+    'mojito',
+    'mojito-util'
+]});

--- a/lib/app/addons/ac/models.common.js
+++ b/lib/app/addons/ac/models.common.js
@@ -14,26 +14,14 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
 
     'use strict';
 
-    // global model cache when on the client to store
-    // models at the page level, while running on the
-    // server we store them on adapter.req object per
-    // request.
-    var _clientCache = {};
-
-    // TODO:
-    // - update tests
-    // - update fixtures
-    // - update documentation
-    // - update examples
-
     /**
-     * <strong>Access point:</strong> <em>ac.models.get()</em>
+     * <strong>Access point:</strong> <em>ac.models.*</em>
      * Addon that provides access to the models collection
      * @class Models.common
      */
     function Addon(command, adapter) {
         this._models = {};
-        this._adapter = adapter;
+        this._page = adapter.page;
         this._instance = command.instance;
     }
 
@@ -49,9 +37,8 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
          */
         get: function (modelName) {
 
-            var model = this._models[modelName] || _clientCache[modelName] ||
-                        (this._adapter.req && this._adapter.req.models &&
-                         this._adapter.req.models[modelName]);
+            var cache = this._page.models || {},
+                model = this._models[modelName] || cache[modelName];
 
             // instantanting the model once during the lifetime of
             // the ac object, this acts like an internal cache.
@@ -76,33 +63,47 @@ YUI.add('mojito-models-addon', function (Y, NAME) {
         },
 
         /**
-         * Set a model instance as global. On the server side
+         * set a model instance at the mojit instance.
+         * @method set
+         * @param {string} modelName The model name.
+         * @param {object} model The model instance.
+         */
+        set: function (modelName, model) {
+            if (!modelName || !model) {
+                Y.log('Invalid model name or model instance ' +
+                    'when calling `ac.models.set()`: ' + modelName, 'error', NAME);
+                return;
+            }
+            if (this._models[modelName]) {
+                Y.log('Overiding an existing model instance with name: ' +
+                    modelName, 'warn', NAME);
+            }
+            this._models[modelName] = model;
+        },
+
+        /**
+         * Expose a model instance as global. On the server side
          * this means any mojit instance under a particular request
          * will have access to the model. On the client, any
          * mojit instance on the page will have access to
          * the model as well.
-         * @method get
-         * @param {string} name The model name.
-         * @param {object} model The model instance
+         * @method expose
+         * @param {string} modelName The model name.
+         * @param {object} model Optional model instance, if not
+         * present, the instance will be lookup by modelName.
          */
-        registerGlobal: function (name, model) {
-            if (this._adapter.req) {
-                // server side routine to store on the request
-                // to avoid leaks.
-                // NOTE: models on req object will be destroyed
-                //       with the request lifecycle.
-                this._adapter.req.models = this._adapter.req.models || {};
-                this._adapter.req.models[name] = model;
-                Y.log('Storing a global model on the server: ' + name, 'info', NAME);
-            } else {
-                // client side routine to store on a global
-                // cache structure.
-                // NOTE: there is no way to destroy this model at
-                //       the moment, it is now tied to the page
-                //       life cycle.
-                _clientCache[name] = model;
-                Y.log('Storing a global model on the client: ' + name, 'info', NAME);
-            }
+        expose: function (modelName, model) {
+            this._page.models = this._page.models || {};
+            // you might want to expose an existing local model
+            model = model || this.get(modelName);
+
+            // NOTE: models on the server will be destroyed
+            //       with the request lifecycle.
+            // NOTE: for models on the client, there is no way
+            //       to destroy them at the moment, it is tied
+            //       to the page life cycle.
+            this._page.models[modelName] = model;
+            Y.log('Exposing a global model: ' + modelName, 'info', NAME);
         }
 
     };

--- a/lib/app/addons/view-engines/hb.client.js
+++ b/lib/app/addons/view-engines/hb.client.js
@@ -41,15 +41,24 @@ YUI.add('mojito-hb', function(Y, NAME) {
         render: function (data, instance, template, adapter, meta, more) {
             var cacheTemplates = (this.options.cacheTemplates === false ? false : true),
                 handler = function (err, obj) {
-                    var output;
+                    var output,
+                        helpers = HB.helpers;
 
                     if (err) {
                         adapter.error(err);
                         return;
                     }
 
+                    // making sure we preserve the original helpers
+                    // from Y.Handlebars.helpers but letting the custom
+                    // helpers per mojit instance to override any of them.
+                    if (instance && instance.helpers) {
+                        helpers = Y.merge(HB.helpers, instance.helpers);
+                    }
+
                     output = obj.compiled(data, {
-                        partials: obj.partials
+                        partials: obj.partials,
+                        helpers: helpers
                     });
 
                     if (more) {

--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -43,15 +43,24 @@ YUI.add('mojito-hb', function (Y, NAME) {
         render: function (data, instance, template, adapter, meta, more) {
             var cacheTemplates = (this.options.cacheTemplates === false ? false : true),
                 handler = function (err, obj) {
-                    var output;
+                    var output,
+                        helpers = HB.helpers;
 
                     if (err) {
                         adapter.error(err);
                         return;
                     }
 
+                    // making sure we preserve the original helpers
+                    // from Y.Handlebars.helpers but letting the custom
+                    // helpers per mojit instance to override any of them.
+                    if (instance && instance.helpers) {
+                        helpers = Y.merge(HB.helpers, instance.helpers);
+                    }
+
                     output = obj.compiled(data, {
-                        partials: obj.partials
+                        partials: obj.partials,
+                        helpers: helpers
                     });
 
                     // HookSystem::StartBlock

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -218,6 +218,7 @@ YUI.add('mojito-client', function(Y, NAME) {
      *     server to start up mojito.
      */
     function MojitoClient(config) {
+        this.page = {};
         this.timeLogStack = [];
         this.yuiConsole = null;
         this._pauseQueue = [];

--- a/lib/app/autoload/output-handler.client.js
+++ b/lib/app/autoload/output-handler.client.js
@@ -139,6 +139,7 @@ YUI.add('mojito-output-handler', function(Y, NAME) {
         this.callback = cb;
         this.buffer = '';
         this.mojitoClient = mojitoClient;
+        this.page = mojitoClient.page;
     }
 
 

--- a/lib/output-handler.server.js
+++ b/lib/output-handler.server.js
@@ -30,6 +30,7 @@ var NAME = 'OutputHandler.server',
         this.res = res;
         this.next = next;
         this.headers = {};
+        this.page = {};
     };
 
 

--- a/tests/unit/lib/app/addons/ac/test-models.common.js
+++ b/tests/unit/lib/app/addons/ac/test-models.common.js
@@ -13,7 +13,9 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
         name: 'model tests',
 
         'invalid model name': function () {
-            var adapter = {};
+            var adapter = {
+                page: {}
+            };
 
             var addon = new Y.mojito.addons.ac.models({
                 instance: {}
@@ -25,7 +27,9 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
         },
 
         'valid model name': function () {
-            var adapter = {};
+            var adapter = {
+                page: {}
+            };
 
             var addon = new Y.mojito.addons.ac.models({
                 instance: {
@@ -43,7 +47,9 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
         },
 
         'test instances of a model': function () {
-            var adapter = {};
+            var adapter = {
+                page: {}
+            };
 
             var addon = new Y.mojito.addons.ac.models({
                 instance: {}
@@ -68,9 +74,9 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
 
         name: 'global model tests',
 
-        'register global model in server with req object': function() {
-            var serverAdapter = {
-                req: {}
+        'test register global model': function() {
+            var adapter = {
+                page: {}
             };
             var bar = {
                 init: function () {
@@ -81,13 +87,13 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
             // creating first addon instance
             var addon1 = new Y.mojito.addons.ac.models({
                 instance: {}
-            }, serverAdapter);
-            addon1.registerGlobal('bar', bar);
+            }, adapter);
+            addon1.expose('bar', bar);
 
             // creating second addon instance
             var addon2 = new Y.mojito.addons.ac.models({
                 instance: {}
-            }, serverAdapter);
+            }, adapter);
 
             // testing models
             var model1 = addon1.get('bar');
@@ -98,36 +104,10 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
             A.areSame(bar, model2, 'should return the registered model');
         },
 
-        'register global model in client without req object': function() {
-            var clientAdapter = {};
-            var baz = {
-                init: function () {
-                    A.fail('init of a global model should never be called, it is an instance already');
-                }
-            };
-
-            // creating first addon instance
-            var addon1 = new Y.mojito.addons.ac.models({
-                instance: {}
-            }, clientAdapter);
-            addon1.registerGlobal('baz', baz);
-
-            // creating second addon instance
-            var addon2 = new Y.mojito.addons.ac.models({
-                instance: {}
-            }, clientAdapter);
-
-            // testing models
-            var model1 = addon1.get('baz');
-            var model2 = addon2.get('baz');
-            A.isObject(model1, 'registered global model should return an instance');
-            A.areSame(baz, model1, 'should return the registered model');
-            A.isObject(model2, 'registered global model by other mojit should return an instance');
-            A.areSame(baz, model2, 'should return the registered model');
-        },
-
         'test global vs local': function() {
-            var adapter = {};
+            var adapter = {
+                page: {}
+            };
 
             var addon = new Y.mojito.addons.ac.models({
                 instance: {}
@@ -141,11 +121,50 @@ YUI().use('mojito-models-addon', 'test', function(Y) {
             };
 
             Y.mojito.models.cuba = localModel;
-            addon.registerGlobal('cuba', globalModel);
+            addon.expose('cuba', globalModel);
 
             model = addon.get('cuba');
             A.isObject(model, 'registered model should return an instance');
             A.areSame(globalModel, model, 'global registered should have priority over local models');
+        },
+
+        'test expose': function() {
+            var adapter = {
+                page: {}
+            };
+            var baz = {
+                init: function () {
+                    A.fail('init of a global model should never be called, it is an instance already');
+                }
+            };
+            // creating first addon instance
+            var addon = new Y.mojito.addons.ac.models({
+                instance: {}
+            }, adapter);
+            addon.expose('baz', baz);
+
+            // testing models
+            A.areSame(baz, adapter.page.models.baz, 'models should be exposed thru adapter.page.models.*');
+        },
+
+        'test expose by name': function() {
+            var adapter = {
+                page: {}
+            };
+            var baz = {
+                init: function () {
+                    A.fail('init of a global model should never be called, it is an instance already');
+                }
+            };
+            // creating first addon instance
+            var addon = new Y.mojito.addons.ac.models({
+                instance: {}
+            }, adapter);
+            addon.set('baz', baz);
+            addon.expose('baz');
+
+            // testing models
+            A.areSame(baz, adapter.page.models.baz, 'models should be exposed thru adapter.page.models.*');
         }
 
     }));


### PR DESCRIPTION
This PR introduces the concept of helpers thru an addon called `mojito-helpers-addon`. Any mojito requiring this addon will be able to:
- register a helper function at the instance level
- register a helper function and expose it at the request level (when in the server)
- register a helper function and expose it at the page level (when in the client)
- expose an already registered helper function
## API
- `ac.helpers.set(name, func)` to set a local helper
- `ac.helpers.get(name)` in case you want to get a handler on a global or even local that was registered somewhere
- `ac.helpers.expose(name, func)` to make it available locally but also exposing it globally
- `ac.helpers.expose(name)` in case you want to expose an existing helper.
## How does it work?

Under the hood, any helper function, locally set using `ac.helpers.set()` or globally exposed by any of the parent mojits using `ac.helpers.expose()` will be passed into the handlebars render engine, so you can use them in your templates/views.
## Limitations and things to keep in mind
- You will be able to override any default helper provided by Y.Handlebars since the custom helper functions will have priority. This also mean you can break the default handlebar helpers, so be careful.
- You will not be able to use helpers when using `mojitProxy.render()` or `mojitProxy.refreshView()`, only thru `mojitProxy.invoke()`.
- You will not be able to use helpers when using `mojitProxy.invoke()` if the helper is supposed to be defined by another mojit that was not instantiated prior to the invoke.
## Examples

https://github.com/caridy/mojito-demos/tree/master/mojito-helpers
