### PR TITLE
fix issue #1026 path.join throws on null param in node 0.9+

### DIFF
--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -709,7 +709,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if (res.type === 'view') {
                     template = {
                         'content-path': (env === 'client' ?
-                                this._libs.path.join(this._appConfigStatic.pathToRoot || '', res.url) :
+                                this._libs.path.join(this._appConfigStatic.pathToRoot || '', res.url || '') :
                                 res.source.fs.fullPath),
                         'content': res.content,
                         'engine': res.view.engine


### PR DESCRIPTION
quick patch to prevent exception on mojito start in node 0.9, 0.10

addresses change where, in latest node versions, path.join throws if given a null value, instead of coercing it to ""
