### PR TITLE
post-install check to post `npm i -g mojito` deprecation message

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     },
     "bugs": "https://github.com/yahoo/mojito/issues",
     "scripts": {
+        "postinstall": "./postinstall.sh",
         "test": "./tests/runall.sh"
     },
     "yahoo": {

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+npm=$(which npm ynpm | grep ^/ | head -1)
+global_prefix=$($npm prefix -g)
+global_mojitolib=$global_lib/lib/node_modules/mojito
+current_prefix=$($npm prefix)
+
+if [[ $global_prefix = $current_prefix && -d $global_mojitolib ]]
+then
+    cat <<FOO >&2
+mojito: You have installed mojito globally (i.e. "npm install --global mojito").
+mojito: Installing mojito globally is deprecated. Instead you should install
+mojito: the package "mojito-cli" (i.e. "npm install --global mojito-cli").
+mojito: Note that usage of the "mojito" command from the command line should be
+mojito: unchanged.
+
+FOO
+
+fi


### PR DESCRIPTION
when `npm i -g mojito` is performed, this post install script outputs a deprecation message instructing user to `npm i -g mojito-cli` instead.
