### PR TITLE
fix bz6160815: port argument must be an integer

### DIFF
--- a/lib/app/commands/start.js
+++ b/lib/app/commands/start.js
@@ -76,7 +76,9 @@ exports.run = function(params, opts, callback) {
 
     pack = store.config.readConfigJSON(path.join(root, 'package.json'));
 
-    options.port = params[0] || appConfig.appPort || process.env.PORT || 8666;
+    options.port = parseInt(params[0], 10) || appConfig.appPort;
+    options.port = options.port || process.env.PORT || 8666;
+
     if (inputOptions.context) {
         options.context = inputOptions.context;
     }

--- a/tests/unit/lib/app/commands/test-start.js
+++ b/tests/unit/lib/app/commands/test-start.js
@@ -84,6 +84,34 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function(Y) {
             A.areSame(8667, port);
         },
 
+        'test run start string port': function() {
+            A.areSame(0, listenCalls);
+            start.run(['8888'], null, function() {});
+            A.areSame(1, listenCalls);
+            A.areSame(8888, port);
+        },
+
+        'test run start funny string port': function() {
+            A.areSame(0, listenCalls);
+            start.run(['07777a.bc'], null, function() {});
+            A.areSame(1, listenCalls);
+            A.areSame(7777, port);
+        },
+
+        'test run start port is "foo"': function() {
+            A.areSame(0, listenCalls);
+            start.run(['foo'], null, function() {});
+            A.areSame(1, listenCalls);
+            A.areSame(8666, port);
+        },
+
+        'test run start with args ["app", "."]': function() {
+            A.areSame(0, listenCalls);
+            start.run(["app", "."], null, function() {});
+            A.areSame(1, listenCalls);
+            A.areSame(8666, port);
+        },
+
         'test run start context': function() {
             var options = {
                 context: "environment:production"


### PR DESCRIPTION
sanitize command line argument for mojito start's port
