### PR TITLE
refactor tunnel middleware into two phases

### DIFF
--- a/lib/app/middleware/mojito-handler-error.js
+++ b/lib/app/middleware/mojito-handler-error.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global require, module*/
+/*jslint sloppy:true, nomen:true*/
+
+/**
+ * Export a middleware error handler.
+ * @param {Object} The configuration.
+ * @return {Object} The handler.
+ */
+module.exports = function (config) {
+    return function (err, req, res, next) {
+        var statusCode = res.statusCode || 500;
+        res.send(statusCode, {
+            code: statusCode,
+            error: err.message
+        });
+    };
+};

--- a/lib/app/middleware/mojito-handler-tunnel-demux.js
+++ b/lib/app/middleware/mojito-handler-tunnel-demux.js
@@ -11,15 +11,6 @@
 var liburl  = require('url'),
     libpath = require('path');
 
-function trimSlash(str) {
-    if (str.charAt(0) === '/') {
-        str = str.substring(1, str.length);
-    }
-    if (str.charAt(str.length - 1) === '/') {
-        str = str.substring(0, str.length - 1);
-    }
-    return str;
-}
 
 
 /**
@@ -36,14 +27,15 @@ module.exports = function (config) {
     tunnelPrefix = appConfig.tunnelPrefix;
 
     if (staticPrefix) {
-        staticPrefix = '/' + trimSlash(staticPrefix);
+        staticPrefix = '/' + staticPrefix;
     }
     if (tunnelPrefix) {
-        tunnelPrefix = '/' + trimSlash(tunnelPrefix);
+        tunnelPrefix = '/' + tunnelPrefix;
     }
 
-    staticPrefix = staticPrefix || '/static';
-    tunnelPrefix = tunnelPrefix || '/tunnel';
+    // normalize() will squash multiple slashes into one slash.
+    staticPrefix = libpath.normalize(staticPrefix) || '/static';
+    tunnelPrefix = libpath.normalize(tunnelPrefix) || '/tunnel';
 
     return function (req, res, next) {
         var hasTunnelPrefix = req.url.indexOf(tunnelPrefix) === 0,
@@ -79,19 +71,17 @@ module.exports = function (config) {
 
         path = liburl.parse(req.url).pathname;
 
-        // Replace multiple slashes with a single one.
-        path = libpath.resolve(path);
-
         // Normalization step to handle `/{tunnelPrefix}`, `/{staticPrefix}`,
         // and `/{tunnelPrefix}/{staticPrefix}` URLs.
         path = path.replace(staticPrefix, '')
                    .replace(tunnelPrefix, '');
 
-        parts = path.split('/');
-
-        if (parts.length) {
+        if (path) {
             // Get the basename without the .json extension.
             name = libpath.basename(path, '.json');
+
+            // Time to get dirty.
+            parts = path.split('/');
 
             // Get the mojit type.
             type = parts[1];

--- a/lib/app/middleware/mojito-handler-tunnel-demux.js
+++ b/lib/app/middleware/mojito-handler-tunnel-demux.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global require, module*/
+/*jslint sloppy:true, nomen:true*/
+
+
+var liburl = require('url'),
+    RE_REPEATING_SLASH = /\/{2,}/g;
+
+function trimSlash(str) {
+    if (str.charAt(0) === '/') {
+        str = str.substring(1, str.length);
+    }
+    if (str.charAt(str.length - 1) === '/') {
+        str = str.substring(0, str.length - 1);
+    }
+    return str;
+}
+
+
+/**
+ * Export a function which can create the handler.
+ * @param {Object} config Data to configure the handler.
+ * @return {Object} The newly constructed handler.
+ */
+module.exports = function (config) {
+    var that      = this,
+        appConfig = config.store.getAppConfig({}) || {},
+        staticPrefix,
+        tunnelPrefix;
+
+    staticPrefix = appConfig.staticHandling && appConfig.staticHandling.prefix;
+    tunnelPrefix = appConfig.tunnelPrefix;
+
+    if (staticPrefix) {
+        staticPrefix = '/' + trimSlash(staticPrefix);
+    }
+    if (tunnelPrefix) {
+        tunnelPrefix = '/' + trimSlash(tunnelPrefix);
+    }
+
+    this.staticPrefix = staticPrefix || '/static';
+    this.tunnelPrefix = tunnelPrefix || '/tunnel';
+
+    return function (req, res, next) {
+        var hasTunnelPrefix = req.url.indexOf(that.tunnelPrefix) === 0,
+            hasTunnelHeader = req.headers['x-mojito-header'] === 'tunnel',
+            name,
+            type,
+            url,
+            parts;
+
+        // If we are not tunneling get out of here fast!
+        if (!hasTunnelPrefix && !hasTunnelHeader) {
+            return next();
+        }
+
+        req._tunnel = {};
+
+        /**
+        Tunnel examples
+
+        RPC tunnel:
+        /tunnel (or it could just have the tunnel header)
+
+        Type tunnel:
+        /static/{type}/definition.json
+        /{tunnelPrefix}/{type}/definition.json // custom prefix
+        /tunnel/static/{type}/definition.json  // according to a UT
+
+        Spec tunnel:
+        /static/{type}/specs/default.json
+        /{staticPrefix}/{type}/specs/default.json  // custom prefix
+        /tunnel/static/{type}/specs/default.json   // according to a UT
+        **/
+
+        url = req.url.split('?')[0];
+
+        // Normalization step to handle `/{tunnelPrefix}`, `/{staticPrefix}`,
+        // and `/{tunnelPrefix}/{staticPrefix}` URLs.
+        url = url.replace(that.staticPrefix, '')
+                 .replace(that.tunnelPrefix, '')
+                 .replace(RE_REPEATING_SLASH, '/');
+
+        parts = url.split('/');
+
+        if (parts.length) {
+            name = parts[parts.length - 1];
+            type = parts[1];
+
+            // Spec tunnel
+            if (parts[parts.length - 2] === 'specs') {
+                req._tunnel.specsReq = {
+                    type: type,
+                    name: name
+                };
+                return next();
+            }
+            // Type tunnel
+            if (name === 'definition.json') {
+                req._tunnel.typeReq = {
+                    type: type
+                };
+                return next();
+            }
+        }
+
+        // RPC tunnel
+        if (req.url === that.tunnelPrefix && req.method === 'POST') {
+            req._tunnel.rpcReq = {};
+            return next();
+        }
+
+        return next();
+    };
+};

--- a/lib/app/middleware/mojito-handler-tunnel-demux.js
+++ b/lib/app/middleware/mojito-handler-tunnel-demux.js
@@ -8,8 +8,8 @@
 /*jslint sloppy:true, nomen:true*/
 
 
-var liburl = require('url'),
-    RE_REPEATING_SLASH = /\/{2,}/g;
+var liburl  = require('url'),
+    libpath = require('path');
 
 function trimSlash(str) {
     if (str.charAt(0) === '/') {
@@ -28,8 +28,7 @@ function trimSlash(str) {
  * @return {Object} The newly constructed handler.
  */
 module.exports = function (config) {
-    var that      = this,
-        appConfig = config.store.getAppConfig({}) || {},
+    var appConfig = config.store.getAppConfig({}) || {},
         staticPrefix,
         tunnelPrefix;
 
@@ -43,15 +42,15 @@ module.exports = function (config) {
         tunnelPrefix = '/' + trimSlash(tunnelPrefix);
     }
 
-    this.staticPrefix = staticPrefix || '/static';
-    this.tunnelPrefix = tunnelPrefix || '/tunnel';
+    staticPrefix = staticPrefix || '/static';
+    tunnelPrefix = tunnelPrefix || '/tunnel';
 
     return function (req, res, next) {
-        var hasTunnelPrefix = req.url.indexOf(that.tunnelPrefix) === 0,
+        var hasTunnelPrefix = req.url.indexOf(tunnelPrefix) === 0,
             hasTunnelHeader = req.headers['x-mojito-header'] === 'tunnel',
             name,
             type,
-            url,
+            path,
             parts;
 
         // If we are not tunneling get out of here fast!
@@ -78,18 +77,23 @@ module.exports = function (config) {
         /tunnel/static/{type}/specs/default.json   // according to a UT
         **/
 
-        url = req.url.split('?')[0];
+        path = liburl.parse(req.url).pathname;
+
+        // Replace multiple slashes with a single one.
+        path = libpath.resolve(path);
 
         // Normalization step to handle `/{tunnelPrefix}`, `/{staticPrefix}`,
         // and `/{tunnelPrefix}/{staticPrefix}` URLs.
-        url = url.replace(that.staticPrefix, '')
-                 .replace(that.tunnelPrefix, '')
-                 .replace(RE_REPEATING_SLASH, '/');
+        path = path.replace(staticPrefix, '')
+                   .replace(tunnelPrefix, '');
 
-        parts = url.split('/');
+        parts = path.split('/');
 
         if (parts.length) {
-            name = parts[parts.length - 1];
+            // Get the basename without the .json extension.
+            name = libpath.basename(path, '.json');
+
+            // Get the mojit type.
             type = parts[1];
 
             // Spec tunnel
@@ -101,7 +105,7 @@ module.exports = function (config) {
                 return next();
             }
             // Type tunnel
-            if (name === 'definition.json') {
+            if (name === 'definition') {
                 req._tunnel.typeReq = {
                     type: type
                 };
@@ -110,7 +114,7 @@ module.exports = function (config) {
         }
 
         // RPC tunnel
-        if (req.url === that.tunnelPrefix && req.method === 'POST') {
+        if (req.url === tunnelPrefix && req.method === 'POST') {
             req._tunnel.rpcReq = {};
             return next();
         }

--- a/lib/app/middleware/mojito-handler-tunnel-parser.js
+++ b/lib/app/middleware/mojito-handler-tunnel-parser.js
@@ -74,6 +74,8 @@ module.exports = function (config) {
         path = path.replace(staticPrefix, '')
                    .replace(tunnelPrefix, '');
 
+        req._tunnel = {};
+
         if (path) {
             // Get the basename without the .json extension.
             name = libpath.basename(path, '.json');

--- a/lib/app/middleware/mojito-handler-tunnel-parser.js
+++ b/lib/app/middleware/mojito-handler-tunnel-parser.js
@@ -5,21 +5,19 @@
  */
 
 /*global require, module*/
-/*jslint sloppy:true, nomen:true*/
+/*jslint sloppy:true, nomen:true, white:true*/
 
-
-var liburl  = require('url'),
-    libpath = require('path');
-
-
+var RE_TRAILING_SLASHES = /\/+$/;
 
 /**
- * Export a function which can create the handler.
- * @param {Object} config Data to configure the handler.
- * @return {Object} The newly constructed handler.
+ * Export a function which can parse tunnel requests.
+ * @param {Object} config The configuration.
+ * @return {Object} The parser.
  */
 module.exports = function (config) {
-    var appConfig = config.store.getAppConfig({}) || {},
+    var liburl      = require('url'),
+        libpath     = require('path'),
+        appConfig   = config.store.getAppConfig({}) || {},
         staticPrefix,
         tunnelPrefix;
 
@@ -27,9 +25,11 @@ module.exports = function (config) {
     tunnelPrefix = appConfig.tunnelPrefix;
 
     if (staticPrefix) {
+        staticPrefix = staticPrefix.replace(RE_TRAILING_SLASHES, '');
         staticPrefix = '/' + staticPrefix;
     }
     if (tunnelPrefix) {
+        tunnelPrefix = tunnelPrefix.replace(RE_TRAILING_SLASHES, '');
         tunnelPrefix = '/' + tunnelPrefix;
     }
 
@@ -49,8 +49,6 @@ module.exports = function (config) {
         if (!hasTunnelPrefix && !hasTunnelHeader) {
             return next();
         }
-
-        req._tunnel = {};
 
         /**
         Tunnel examples
@@ -86,27 +84,23 @@ module.exports = function (config) {
             // Get the mojit type.
             type = parts[1];
 
-            // Spec tunnel
+            // "Spec" tunnel request
             if (parts[parts.length - 2] === 'specs') {
                 req._tunnel.specsReq = {
                     type: type,
                     name: name
                 };
-                return next();
             }
-            // Type tunnel
-            if (name === 'definition') {
+            // "Type" tunnel request
+            else if (name === 'definition') {
                 req._tunnel.typeReq = {
                     type: type
                 };
-                return next();
             }
         }
-
-        // RPC tunnel
-        if (req.url === tunnelPrefix && req.method === 'POST') {
+        // "RPC" tunnel request
+        else if (req.url === tunnelPrefix && req.method === 'POST') {
             req._tunnel.rpcReq = {};
-            return next();
         }
 
         return next();

--- a/lib/app/middleware/mojito-handler-tunnel-parser.js
+++ b/lib/app/middleware/mojito-handler-tunnel-parser.js
@@ -24,18 +24,18 @@ module.exports = function (config) {
     staticPrefix = appConfig.staticHandling && appConfig.staticHandling.prefix;
     tunnelPrefix = appConfig.tunnelPrefix;
 
+    // normalize() will squash multiple slashes into one slash.
     if (staticPrefix) {
         staticPrefix = staticPrefix.replace(RE_TRAILING_SLASHES, '');
-        staticPrefix = '/' + staticPrefix;
+        staticPrefix = libpath.normalize('/' + staticPrefix);
     }
     if (tunnelPrefix) {
         tunnelPrefix = tunnelPrefix.replace(RE_TRAILING_SLASHES, '');
-        tunnelPrefix = '/' + tunnelPrefix;
+        tunnelPrefix = libpath.normalize('/' + tunnelPrefix);
     }
 
-    // normalize() will squash multiple slashes into one slash.
-    staticPrefix = libpath.normalize(staticPrefix) || '/static';
-    tunnelPrefix = libpath.normalize(tunnelPrefix) || '/tunnel';
+    staticPrefix = staticPrefix || '/static';
+    tunnelPrefix = tunnelPrefix || '/tunnel';
 
     return function (req, res, next) {
         var hasTunnelPrefix = req.url.indexOf(tunnelPrefix) === 0,

--- a/lib/app/middleware/mojito-handler-tunnel-rpc.js
+++ b/lib/app/middleware/mojito-handler-tunnel-rpc.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global exports, module*/
+/*jslint sloppy:true, nomen:true*/
+
+
+function sendData(res, data, code) {
+    res.writeHead((code || 200), {
+        'content-type': 'application/json; charset="utf-8"'
+    });
+    res.end(JSON.stringify(data, null, 4));
+}
+
+function sendError(res, msg, code) {
+    sendData(res, {error: msg}, (code || 500));
+}
+
+
+/**
+ * Exports a middleware factory that can handle RPC tunnel requests.
+ *
+ * @param {Object} config The configuration.
+ * @return {Function} The handler.
+ */
+module.exports = function (config) {
+    return function (req, res, next) {
+        var command  = req.body,
+            instance = command.instance;
+
+        command.context = command.context || {};
+
+        if (!req._tunnel || !req._tunnel.rpcReq) {
+            return next();
+        }
+
+        // When switching from the client context to the server context, we
+        // have to override the runtime.
+        command.context.runtime = 'server';
+
+        // All we need to do is expand the instance given within the RPC call
+        // and attach it within a "tunnelCommand", which will be handled by
+        // Mojito instead of looking up a route for it.
+        config.store.expandInstance(instance, command.context, function (err, instance) {
+            // Replace with the expanded instance.
+            command.instance = instance;
+            req.command = {
+                action: command.action,
+                instance: {
+                    // Magic here to delegate to tunnelProxy.
+                    base: 'tunnelProxy'
+                },
+                params: {
+                    body: {
+                        proxyCommand: command
+                    }
+                },
+                context: command.context
+            };
+            return next();
+        });
+    };
+};

--- a/lib/app/middleware/mojito-handler-tunnel-rpc.js
+++ b/lib/app/middleware/mojito-handler-tunnel-rpc.js
@@ -7,19 +7,6 @@
 /*global exports, module*/
 /*jslint sloppy:true, nomen:true*/
 
-
-function sendData(res, data, code) {
-    res.writeHead((code || 200), {
-        'content-type': 'application/json; charset="utf-8"'
-    });
-    res.end(JSON.stringify(data, null, 4));
-}
-
-function sendError(res, msg, code) {
-    sendData(res, {error: msg}, (code || 500));
-}
-
-
 /**
  * Exports a middleware factory that can handle RPC tunnel requests.
  *
@@ -29,8 +16,7 @@ function sendError(res, msg, code) {
 module.exports = function (config) {
     return function (req, res, next) {
         var rpcReq = req._tunnel && req._tunnel.rpcReq,
-            command,
-            instance;
+            command;
 
         if (!rpcReq) {
             return next();

--- a/lib/app/middleware/mojito-handler-tunnel-rpc.js
+++ b/lib/app/middleware/mojito-handler-tunnel-rpc.js
@@ -37,7 +37,6 @@ module.exports = function (config) {
         }
 
         command         = req.body;
-        instance        = command.instance;
         command.context = command.context || {};
 
         // When switching from the client context to the server context, we
@@ -48,7 +47,7 @@ module.exports = function (config) {
         // and attach it within a "tunnelCommand", which will be handled by
         // Mojito instead of looking up a route for it.
         config.store.expandInstance(
-            instance,
+            command.instance,
             command.context,
             function (err, instance) {
                 // Replace with the expanded instance.

--- a/lib/app/middleware/mojito-handler-tunnel-rpc.js
+++ b/lib/app/middleware/mojito-handler-tunnel-rpc.js
@@ -28,14 +28,17 @@ function sendError(res, msg, code) {
  */
 module.exports = function (config) {
     return function (req, res, next) {
-        var command  = req.body,
-            instance = command.instance;
+        var rpcReq = req._tunnel && req._tunnel.rpcReq,
+            command,
+            instance;
 
-        command.context = command.context || {};
-
-        if (!req._tunnel || !req._tunnel.rpcReq) {
+        if (!rpcReq) {
             return next();
         }
+
+        command         = req.body;
+        instance        = command.instance;
+        command.context = command.context || {};
 
         // When switching from the client context to the server context, we
         // have to override the runtime.
@@ -44,23 +47,27 @@ module.exports = function (config) {
         // All we need to do is expand the instance given within the RPC call
         // and attach it within a "tunnelCommand", which will be handled by
         // Mojito instead of looking up a route for it.
-        config.store.expandInstance(instance, command.context, function (err, instance) {
-            // Replace with the expanded instance.
-            command.instance = instance;
-            req.command = {
-                action: command.action,
-                instance: {
-                    // Magic here to delegate to tunnelProxy.
-                    base: 'tunnelProxy'
-                },
-                params: {
-                    body: {
-                        proxyCommand: command
-                    }
-                },
-                context: command.context
-            };
-            return next();
-        });
+        config.store.expandInstance(
+            instance,
+            command.context,
+            function (err, instance) {
+                // Replace with the expanded instance.
+                command.instance = instance;
+                req.command = {
+                    action: command.action,
+                    instance: {
+                        // Magic here to delegate to tunnelProxy.
+                        base: 'tunnelProxy'
+                    },
+                    params: {
+                        body: {
+                            proxyCommand: command
+                        }
+                    },
+                    context: command.context
+                };
+                return next();
+            }
+        );
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel-rpc.js
+++ b/lib/app/middleware/mojito-handler-tunnel-rpc.js
@@ -36,8 +36,13 @@ module.exports = function (config) {
             command.instance,
             command.context,
             function (err, instance) {
+                if (err) {
+                    next(err);
+                }
+
                 // Replace with the expanded instance.
                 command.instance = instance;
+
                 req.command = {
                     action: command.action,
                     instance: {
@@ -51,6 +56,7 @@ module.exports = function (config) {
                     },
                     context: command.context
                 };
+
                 return next();
             }
         );

--- a/lib/app/middleware/mojito-handler-tunnel-specs.js
+++ b/lib/app/middleware/mojito-handler-tunnel-specs.js
@@ -7,19 +7,6 @@
 /*global module*/
 /*jslint sloppy:true, nomen:true*/
 
-
-function sendData(res, data, code) {
-    res.writeHead((code || 200), {
-        'content-type': 'application/json; charset="utf-8"'
-    });
-    res.end(JSON.stringify(data, null, 4));
-}
-
-function sendError(res, msg, code) {
-    sendData(res, {error: msg}, (code || 500));
-}
-
-
 /**
  * Exports a middleware factory that can handle spec tunnel requests.
  *
@@ -29,6 +16,7 @@ function sendError(res, msg, code) {
 module.exports = function (config) {
     return function (req, res, next) {
         var specsReq = req._tunnel && req._tunnel.specsReq,
+            instance,
             type,
             name;
 
@@ -40,20 +28,31 @@ module.exports = function (config) {
         name = specsReq.name;
 
         if (!type || !name) {
-            return sendError(res, 'Not found: ' + req.url, 404);
+            return req._tunnel.sendError(res, 'Not found: ' + req.url, 404);
         }
 
-        config.store.expandInstanceForEnv('client', {
-            base: (name === 'default') ? type : type + ':' + name
-        }, req.context, function (err, data) {
-            if (err) {
-                return sendError(
-                    res,
-                    'Error opening: ' + req.url + '\n' + err,
-                    500
-                );
+        instance = {
+            base: type
+        };
+
+        if (name !== 'default') {
+            instance.base += ':' + name;
+        }
+
+        config.store.expandInstanceForEnv(
+            'client',
+            instance,
+            req.context,
+            function (err, data) {
+                if (err) {
+                    return req._tunnel.sendError(
+                        res,
+                        'Error opening: ' + req.url + '\n' + err,
+                        500
+                    );
+                }
+                return req._tunnel.sendData(res, data);
             }
-            return sendData(res, data);
-        });
+        );
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel-specs.js
+++ b/lib/app/middleware/mojito-handler-tunnel-specs.js
@@ -28,7 +28,8 @@ module.exports = function (config) {
         name = specsReq.name;
 
         if (!type || !name) {
-            return req._tunnel.sendError(res, 'Not found: ' + req.url, 404);
+            res.statusCode = 404;
+            return next(new Error('Not found: ' + req.url));
         }
 
         instance = {
@@ -45,13 +46,17 @@ module.exports = function (config) {
             req.context,
             function (err, data) {
                 if (err) {
-                    return req._tunnel.sendError(
-                        res,
-                        'Error opening: ' + req.url + '\n' + err,
-                        500
+                    res.statusCode = 500;
+                    return next(
+                        new Error('Error opening: ' + req.url + '\n' + err)
                     );
                 }
-                return req._tunnel.sendData(res, data);
+                // TODO: Use the express sugar method res.json([status],
+                // [body]) after we rewrite the existing tests.
+                res.writeHead(res.statusCode || 200, {
+                    'content-type': 'application/json; charset="utf-8"'
+                });
+                res.end(JSON.stringify(data, null, 4));
             }
         );
     };

--- a/lib/app/middleware/mojito-handler-tunnel-specs.js
+++ b/lib/app/middleware/mojito-handler-tunnel-specs.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global module*/
+/*jslint sloppy:true, nomen:true*/
+
+
+function sendData(res, data, code) {
+    res.writeHead((code || 200), {
+        'content-type': 'application/json; charset="utf-8"'
+    });
+    res.end(JSON.stringify(data, null, 4));
+}
+
+function sendError(res, msg, code) {
+    sendData(res, {error: msg}, (code || 500));
+}
+
+
+/**
+ * Exports a middleware factory that can handle spec tunnel requests.
+ *
+ * @param {Object} config The configuration.
+ * @return {Function} The handler.
+ */
+module.exports = function (config) {
+    return function (req, res, next) {
+        var specsReq = req._tunnel && req._tunnel.specsReq,
+            instance = {},
+            type,
+            name;
+
+        if (!specsReq) {
+            return next();
+        }
+
+        type = specsReq.type;
+        name = specsReq.name;
+        name = name && name.split('.').slice(0, -1).join('.');
+
+        if (!type || !name) {
+            return sendError(res, 'Not found: ' + req.url, 500);
+        }
+
+        instance.base = type;
+
+        if (name !== 'default') {
+            instance.base += ':' + name;
+        }
+
+        config.store.expandInstanceForEnv('client', instance, req.context,
+            function (err, data) {
+                if (err) {
+                    return sendError(
+                        res,
+                        'Error opening: ' + req.url + '\n' + err,
+                        500
+                    );
+                }
+                return sendData(res, data);
+            });
+    };
+};

--- a/lib/app/middleware/mojito-handler-tunnel-specs.js
+++ b/lib/app/middleware/mojito-handler-tunnel-specs.js
@@ -29,7 +29,6 @@ function sendError(res, msg, code) {
 module.exports = function (config) {
     return function (req, res, next) {
         var specsReq = req._tunnel && req._tunnel.specsReq,
-            instance = {},
             type,
             name;
 
@@ -39,28 +38,22 @@ module.exports = function (config) {
 
         type = specsReq.type;
         name = specsReq.name;
-        name = name && name.split('.').slice(0, -1).join('.');
 
         if (!type || !name) {
-            return sendError(res, 'Not found: ' + req.url, 500);
+            return sendError(res, 'Not found: ' + req.url, 404);
         }
 
-        instance.base = type;
-
-        if (name !== 'default') {
-            instance.base += ':' + name;
-        }
-
-        config.store.expandInstanceForEnv('client', instance, req.context,
-            function (err, data) {
-                if (err) {
-                    return sendError(
-                        res,
-                        'Error opening: ' + req.url + '\n' + err,
-                        500
-                    );
-                }
-                return sendData(res, data);
-            });
+        config.store.expandInstanceForEnv('client', {
+            base: (name === 'default') ? type : type + ':' + name
+        }, req.context, function (err, data) {
+            if (err) {
+                return sendError(
+                    res,
+                    'Error opening: ' + req.url + '\n' + err,
+                    500
+                );
+            }
+            return sendData(res, data);
+        });
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel-specs.js
+++ b/lib/app/middleware/mojito-handler-tunnel-specs.js
@@ -51,12 +51,7 @@ module.exports = function (config) {
                         new Error('Error opening: ' + req.url + '\n' + err)
                     );
                 }
-                // TODO: Use the express sugar method res.json([status],
-                // [body]) after we rewrite the existing tests.
-                res.writeHead(res.statusCode || 200, {
-                    'content-type': 'application/json; charset="utf-8"'
-                });
-                res.end(JSON.stringify(data, null, 4));
+                res.send(200, data);
             }
         );
     };

--- a/lib/app/middleware/mojito-handler-tunnel-type.js
+++ b/lib/app/middleware/mojito-handler-tunnel-type.js
@@ -42,12 +42,7 @@ module.exports = function (config) {
                         new Error('Error opening: ' + req.url + '\n' + err)
                     );
                 }
-                // TODO: Use the express sugar method res.json([status],
-                // [body]) after we rewrite the existing tests.
-                res.writeHead(res.statusCode || 200, {
-                    'content-type': 'application/json; charset="utf-8"'
-                });
-                res.end(JSON.stringify(data, null, 4));
+                res.send(200, data);
             }
         );
     };

--- a/lib/app/middleware/mojito-handler-tunnel-type.js
+++ b/lib/app/middleware/mojito-handler-tunnel-type.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global module*/
+/*jslint sloppy:true, nomen:true*/
+
+
+function sendData(res, data, code) {
+    res.writeHead((code || 200), {
+        'content-type': 'application/json; charset="utf-8"'
+    });
+    res.end(JSON.stringify(data, null, 4));
+}
+
+function sendError(res, msg, code) {
+    sendData(res, {error: msg}, (code || 500));
+}
+
+
+/**
+ * Exports a middleware factory that can handle type tunnel requests.
+ *
+ * @param {Object} config The configuration.
+ * @return {Function} The handler.
+ */
+module.exports = function (config) {
+    return function (req, res, next) {
+        var typeReq  = req._tunnel && req._tunnel.typeReq,
+            instance = {};
+
+        if (!typeReq) {
+            return next();
+        }
+
+        if (!typeReq.type) {
+            return sendError(res, 'Not found: ' + req.url, 500);
+        }
+
+        instance.type = typeReq.type;
+
+        config.store.expandInstanceForEnv('client', instance, req.context,
+            function (err, data) {
+                if (err) {
+                    return sendError(
+                        res,
+                        'Error opening: ' + req.url + '\n' + err,
+                        500
+                    );
+                }
+                return sendData(res, data);
+            });
+    };
+};

--- a/lib/app/middleware/mojito-handler-tunnel-type.js
+++ b/lib/app/middleware/mojito-handler-tunnel-type.js
@@ -7,19 +7,6 @@
 /*global module*/
 /*jslint sloppy:true, nomen:true*/
 
-
-function sendData(res, data, code) {
-    res.writeHead((code || 200), {
-        'content-type': 'application/json; charset="utf-8"'
-    });
-    res.end(JSON.stringify(data, null, 4));
-}
-
-function sendError(res, msg, code) {
-    sendData(res, {error: msg}, (code || 500));
-}
-
-
 /**
  * Exports a middleware factory that can handle type tunnel requests.
  *
@@ -28,27 +15,35 @@ function sendError(res, msg, code) {
  */
 module.exports = function (config) {
     return function (req, res, next) {
-        var typeReq = req._tunnel && req._tunnel.typeReq;
+        var typeReq = req._tunnel && req._tunnel.typeReq,
+            instance;
 
         if (!typeReq) {
             return next();
         }
 
         if (!typeReq.type) {
-            return sendError(res, 'Not found: ' + req.url, 404);
+            return req._tunnel.sendError(res, 'Not found: ' + req.url, 404);
         }
 
-        config.store.expandInstanceForEnv('client', {
+        instance = {
             type: typeReq.type
-        }, req.context, function (err, data) {
-            if (err) {
-                return sendError(
-                    res,
-                    'Error opening: ' + req.url + '\n' + err,
-                    500
-                );
+        };
+
+        config.store.expandInstanceForEnv(
+            'client',
+            instance,
+            req.context,
+            function (err, data) {
+                if (err) {
+                    return req._tunnel.sendError(
+                        res,
+                        'Error opening: ' + req.url + '\n' + err,
+                        500
+                    );
+                }
+                return req._tunnel.sendData(res, data);
             }
-            return sendData(res, data);
-        });
+        );
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel-type.js
+++ b/lib/app/middleware/mojito-handler-tunnel-type.js
@@ -28,29 +28,27 @@ function sendError(res, msg, code) {
  */
 module.exports = function (config) {
     return function (req, res, next) {
-        var typeReq  = req._tunnel && req._tunnel.typeReq,
-            instance = {};
+        var typeReq = req._tunnel && req._tunnel.typeReq;
 
         if (!typeReq) {
             return next();
         }
 
         if (!typeReq.type) {
-            return sendError(res, 'Not found: ' + req.url, 500);
+            return sendError(res, 'Not found: ' + req.url, 404);
         }
 
-        instance.type = typeReq.type;
-
-        config.store.expandInstanceForEnv('client', instance, req.context,
-            function (err, data) {
-                if (err) {
-                    return sendError(
-                        res,
-                        'Error opening: ' + req.url + '\n' + err,
-                        500
-                    );
-                }
-                return sendData(res, data);
-            });
+        config.store.expandInstanceForEnv('client', {
+            type: typeReq.type
+        }, req.context, function (err, data) {
+            if (err) {
+                return sendError(
+                    res,
+                    'Error opening: ' + req.url + '\n' + err,
+                    500
+                );
+            }
+            return sendData(res, data);
+        });
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel-type.js
+++ b/lib/app/middleware/mojito-handler-tunnel-type.js
@@ -23,7 +23,8 @@ module.exports = function (config) {
         }
 
         if (!typeReq.type) {
-            return req._tunnel.sendError(res, 'Not found: ' + req.url, 404);
+            res.statusCode = 404;
+            return next(new Error('Not found: ' + req.url));
         }
 
         instance = {
@@ -36,13 +37,17 @@ module.exports = function (config) {
             req.context,
             function (err, data) {
                 if (err) {
-                    return req._tunnel.sendError(
-                        res,
-                        'Error opening: ' + req.url + '\n' + err,
-                        500
+                    res.statusCode = 500;
+                    return next(
+                        new Error('Error opening: ' + req.url + '\n' + err)
                     );
                 }
-                return req._tunnel.sendData(res, data);
+                // TODO: Use the express sugar method res.json([status],
+                // [body]) after we rewrite the existing tests.
+                res.writeHead(res.statusCode || 200, {
+                    'content-type': 'application/json; charset="utf-8"'
+                });
+                res.end(JSON.stringify(data, null, 4));
             }
         );
     };

--- a/lib/app/middleware/mojito-handler-tunnel.js
+++ b/lib/app/middleware/mojito-handler-tunnel.js
@@ -13,50 +13,48 @@
  * @return {Object} The handler.
  */
 module.exports = function (config) {
-    var tunnelSubstack = [
-        require('./mojito-handler-tunnel-parser')(config),
-        require('./mojito-handler-tunnel-rpc')(config),
-        require('./mojito-handler-tunnel-specs')(config),
-        require('./mojito-handler-tunnel-type')(config)
-    ];
+    var parser = require('./mojito-handler-tunnel-parser')(config),
+        rpc    = require('./mojito-handler-tunnel-rpc')(config),
+        specs  = require('./mojito-handler-tunnel-specs')(config),
+        type   = require('./mojito-handler-tunnel-type')(config);
 
     return function (req, res, next) {
-        var len,
-            i;
+        var middleware = [
+            parser,
+            rpc,
+            specs,
+            type
+        ];
 
-        // Connects the tunnel middleware substack.
-        function connect(err) {
-            // Exit the substack on error.
-            if (err) {
-                next(err);
-            }
-        }
-
+        // Helper methods.
         req._tunnel = {
             sendData: function (res, data, code) {
                 res.writeHead((code || 200), {
                     'content-type': 'application/json; charset="utf-8"'
                 });
                 res.end(JSON.stringify(data, null, 4));
-
-                // Flag the end of this request.
-                req._tunnel.done = true;
             },
             sendError: function (res, msg, code) {
                 this.sendData(res, {error: msg}, (code || 500));
             }
         };
 
-        // Iterate over the tunnel middleware substack.
-        for (i = 0, len = tunnelSubstack.length; i < len; i += 1) {
-            tunnelSubstack[i](req, res, connect);
+        function run() {
+            var m = middleware.shift();
 
-            // End this request if we've provided an end-point in the stack.
-            if (req._tunnel.done) {
-                return;
+            if (!m) {
+                req._tunnel = null;
+                return next();
             }
+
+            m(req, res, function (err) {
+                if (err) {
+                    return next(err);
+                }
+                run();
+            });
         }
 
-        next();
+        run();
     };
 };

--- a/lib/app/middleware/mojito-handler-tunnel.js
+++ b/lib/app/middleware/mojito-handler-tunnel.js
@@ -4,202 +4,59 @@
  * See the accompanying LICENSE file for terms.
  */
 
-
-/*jslint anon:true, sloppy:true, nomen:true*/
-
-
-var liburl = require('url'),
-    logger,
-    RX_MULTI_SLASH_ALL = /\/+/g;
-
-
-function trimSlash(str) {
-    if ('/' === str.charAt(str.length - 1)) {
-        return str.substring(0, str.length - 1);
-    }
-    return str;
-}
-
-
-function TunnelServer() {}
-
-/*
-* store.client.js expandInstance() makes an RPC call to the TunnelServer.
-* The header 'x-mojito-header' (read here and set in
-* store.client.js) tells the server not to try to route the URL, it gets handled
-* by this critter. The targeted URL _might actually exist_ but we need to make
-* sure that it _does not_ if the mojito header is set to 'tunnel'.
-*/
-TunnelServer.prototype = {
-
-    handle: function(store, globalLogger) {
-        var self = this,
-            config;
-        logger = globalLogger;
-        //console.log('creating handle');
-        this._store = store;
-        config = store.getAppConfig({});
-        this.tunnelPrefix = (config && config.tunnelPrefix) ?
-                config.tunnelPrefix :
-                '/tunnel';
-        this.staticPrefix = '/static';
-        if (config && config.staticHandling &&
-                config.staticHandling.hasOwnProperty('prefix')) {
-            this.staticPrefix = (config.staticHandling.prefix ?
-                    '/' + config.staticHandling.prefix :
-                    '');
-        }
-        this.tunnelPrefix = trimSlash(this.tunnelPrefix);
-        this.staticPrefix = trimSlash(this.staticPrefix);
-        if (!this.tunnelPrefix) {
-            // this makes the logic below a bit simpler
-            this.tunnelPrefix = '/';
-        }
-
-        return function(req, res, next) {
-            var url, parts;
-
-            // If we are not in a tunnel get out of here fast
-            if (req.url.indexOf(self.tunnelPrefix) !== 0 &&
-                    req.headers['x-mojito-header'] !== 'tunnel') {
-                return next();
-            }
-
-            url = req.url.replace(self.tunnelPrefix, '').replace(
-                self.staticPrefix,
-                ''
-            );
-            url = url.replace(RX_MULTI_SLASH_ALL, '/');
-            url = url.split('?')[0];
-            parts = url.split('/');
-
-            if (parts.length === 4 && parts[2] === 'specs') {
-                return self._handleSpec(req, res, next, parts[1], parts[3]);
-            }
-            if (parts.length === 3 && parts[2] === 'definition.json') {
-                return self._handleType(req, res, next, parts[1]);
-            }
-            if (req.url === self.tunnelPrefix && 'POST' === req.method) {
-                return self._handleRpc(req, res, next);
-            }
-            next();
-        };
-    },
-
-
-    _handleSpec: function(req, res, next, type, basename) {
-        var name,
-            instance = {},
-            my = this;
-
-        name = basename.split('.').slice(0, -1).join('.') || null;
-
-        if (!type || !name) {
-            my._sendError(res, 'Not found: ' + req.url, 500);
-            return;
-        }
-
-        instance.base = type;
-
-        if (name !== 'default') {
-            instance.base += ':' + name;
-        }
-
-        this._store.expandInstanceForEnv('client', instance, req.context,
-            function(err, data) {
-                if (err) {
-                    my._sendError(res, 'Error opening: ' + req.url + '\n' +
-                        err,
-                        500
-                        );
-                    return;
-                }
-                my._sendData(res, data);
-            });
-    },
-
-
-    _handleType: function(req, res, next, type) {
-        var instance = {},
-            my = this;
-
-        if (!type) {
-            my._sendError(res, 'Not found: ' + req.url, 500);
-            return;
-        }
-
-        instance.type = type;
-
-        this._store.expandInstanceForEnv('client', instance, req.context,
-            function(err, data) {
-                if (err) {
-                    my._sendError(res, 'Error opening: ' + req.url + '\n' +
-                        err,
-                        'debug',
-                        'Tunnel:specs'
-                        );
-                    return;
-                }
-                my._sendData(res, data);
-            });
-    },
-
-
-    _handleRpc: function(req, res, next) {
-        var data = req.body,
-            command = data;
-
-
-        // when taking in the client context on the server side, we have to
-        // override the runtime, because the runtime switches from client to server
-        if (!command.context) {
-            command.context = {};
-        }
-        command.context.runtime = 'server';
-
-        // all we need to do is expand the instance given within the RPC call
-        // and attach it within a "tunnelCommand", which will be handled by
-        // Mojito instead of looking up a route for it.
-        this._store.expandInstance(command.instance, command.context,
-            function(err, inst) {
-                // replace with the expanded instance
-                command.instance = inst;
-                req.command = {
-                    action: command.action,
-                    instance: {
-                        // Magic here to delegate to tunnelProxy.
-                        base: 'tunnelProxy'
-                    },
-                    params: {
-                        body: {
-                            proxyCommand: command
-                        }
-                    },
-                    context: data.context
-                };
-                next();
-            });
-    },
-
-    _sendError: function(res, msg, code) {
-        this._sendData(res, {error: msg}, (code || 500));
-    },
-
-    _sendData: function(res, data, code) {
-        res.writeHead((code || 200), {
-            'content-type': 'application/json; charset="utf-8"'
-        });
-        res.end(JSON.stringify(data, null, 4));
-    }
-};
-
+/*global require, module*/
+/*jslint sloppy:true, nomen:true*/
 
 /**
- * Export a function which can create the handler.
- * @param {Object} config Data to configure the handler.
- * @return {Object} The newly constructed handler.
+ * Export a middleware aggregate.
+ * @param {Object} The configuration.
+ * @return {Object} The handler.
  */
-module.exports = function(config) {
-    var tunnel = new TunnelServer();
-    return tunnel.handle(config.store, config.logger);
+module.exports = function (config) {
+    var tunnelSubstack = [
+        require('./mojito-handler-tunnel-parser')(config),
+        require('./mojito-handler-tunnel-rpc')(config),
+        require('./mojito-handler-tunnel-specs')(config),
+        require('./mojito-handler-tunnel-type')(config)
+    ];
+
+    return function (req, res, next) {
+        var len,
+            i;
+
+        // Connects the tunnel middleware substack.
+        function connect(err) {
+            // Exit the substack on error.
+            if (err) {
+                next(err);
+            }
+        }
+
+        req._tunnel = {
+            sendData: function (res, data, code) {
+                res.writeHead((code || 200), {
+                    'content-type': 'application/json; charset="utf-8"'
+                });
+                res.end(JSON.stringify(data, null, 4));
+
+                // Flag the end of this request.
+                req._tunnel.done = true;
+            },
+            sendError: function (res, msg, code) {
+                this.sendData(res, {error: msg}, (code || 500));
+            }
+        };
+
+        // Iterate over the tunnel middleware substack.
+        for (i = 0, len = tunnelSubstack.length; i < len; i += 1) {
+            tunnelSubstack[i](req, res, connect);
+
+            // End this request if we've provided an end-point in the stack.
+            if (req._tunnel.done) {
+                return;
+            }
+        }
+
+        next();
+    };
 };

--- a/lib/app/middleware/mojito-handler-tunnel.js
+++ b/lib/app/middleware/mojito-handler-tunnel.js
@@ -26,19 +26,6 @@ module.exports = function (config) {
             type
         ];
 
-        // Helper methods.
-        req._tunnel = {
-            sendData: function (res, data, code) {
-                res.writeHead((code || 200), {
-                    'content-type': 'application/json; charset="utf-8"'
-                });
-                res.end(JSON.stringify(data, null, 4));
-            },
-            sendError: function (res, msg, code) {
-                this.sendData(res, {error: msg}, (code || 500));
-            }
-        };
-
         function run() {
             var m = middleware.shift();
 

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -90,7 +90,10 @@ MojitoServer.MOJITO_MIDDLEWARE = [
     'mojito-parser-body',
     'mojito-parser-cookies',
     'mojito-contextualizer',
-    'mojito-handler-tunnel',
+    'mojito-handler-tunnel-demux',
+    'mojito-handler-tunnel-rpc',
+    'mojito-handler-tunnel-specs',
+    'mojito-handler-tunnel-type',
     'mojito-router',
     'mojito-handler-dispatcher'
 ];

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -92,7 +92,8 @@ MojitoServer.MOJITO_MIDDLEWARE = [
     'mojito-contextualizer',
     'mojito-handler-tunnel',
     'mojito-router',
-    'mojito-handler-dispatcher'
+    'mojito-handler-dispatcher',
+    'mojito-handler-error'
 ];
 
 
@@ -357,9 +358,6 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
 
     // attach middleware pieces
     this._useMiddleware(app, dispatcher, options.dir, midConfig, middleware);
-
-    // TODO: [Issue 82] The last middleware in the stack should be an
-    // error handler
 
     Y.log('Mojito HTTP Server initialized in ' +
             ((new Date().getTime()) - Mojito.MOJITO_INIT) + 'ms.');

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -90,10 +90,7 @@ MojitoServer.MOJITO_MIDDLEWARE = [
     'mojito-parser-body',
     'mojito-parser-cookies',
     'mojito-contextualizer',
-    'mojito-handler-tunnel-demux',
-    'mojito-handler-tunnel-rpc',
-    'mojito-handler-tunnel-specs',
-    'mojito-handler-tunnel-type',
+    'mojito-handler-tunnel',
     'mojito-router',
     'mojito-handler-dispatcher'
 ];

--- a/tests/unit/lib/app/middleware/middleware_test_descriptor.json
+++ b/tests/unit/lib/app/middleware/middleware_test_descriptor.json
@@ -32,6 +32,22 @@
                 },
                 "group": "fw,unit,server"
             },
+            "handler-tunnel-parser": {
+                "params": {
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel-parser.js",
+                    "test": "./test-handler-tunnel-parser.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,unit,server"
+            },
+            "handler-tunnel-rpc": {
+                "params": {
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel-rpc.js",
+                    "test": "./test-handler-tunnel-rpc.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,unit,server"
+            },
             "router": {
                 "params": {
                     "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,../../../../../lib/app/autoload/route-maker.common.js,../../../../../lib/app/autoload/util.common.js",

--- a/tests/unit/lib/app/middleware/middleware_test_descriptor.json
+++ b/tests/unit/lib/app/middleware/middleware_test_descriptor.json
@@ -48,6 +48,22 @@
                 },
                 "group": "fw,unit,server"
             },
+            "handler-tunnel-specs": {
+                "params": {
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel-specs.js",
+                    "test": "./test-handler-tunnel-specs.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,unit,server"
+            },
+            "handler-tunnel-type": {
+                "params": {
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel-type.js",
+                    "test": "./test-handler-tunnel-type.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,unit,server"
+            },
             "router": {
                 "params": {
                     "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,../../../../../lib/app/autoload/route-maker.common.js,../../../../../lib/app/autoload/util.common.js",

--- a/tests/unit/lib/app/middleware/test-handler-tunnel-parser.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel-parser.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI, require*/
+/*jslint nomen:true*/
+
+YUI().use('mojito-test-extra', 'test', function (Y) {
+    'use strict';
+
+    var A  = Y.Assert,
+        AA = Y.ArrayAssert,
+        OA = Y.ObjectAssert,
+
+        factory = require(Y.MOJITO_DIR + 'lib/app/middleware/mojito-handler-tunnel-parser'),
+        req,
+        nextCallCount,
+        middleware,
+        store,
+        config;
+
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'tunnel handler parser tests',
+
+        setUp: function () {
+            nextCallCount = 0;
+
+            store = {
+                getAppConfig: function () {
+                    return {};
+                }
+            };
+
+            config = {
+                store: store
+            };
+
+            req = {
+                url: '/tunnel',
+                headers: {
+                    'x-mojito-header': 'tunnel'
+                },
+                method: 'POST'
+            };
+        },
+
+        tearDown: function () {
+            store           = null;
+            config          = null;
+            nextCallCount   = null;
+            req             = null;
+        },
+
+        'test trailing slashes are removed from tunnel URIs': function () {
+            config.store.getAppConfig = function () {
+                return {
+                    tunnelPrefix: '/spinach/'
+                };
+            };
+            req.url = '/spinach';
+            req.headers['x-mojito-header'] = 'nottunnel';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.isObject(req._tunnel.rpcReq, 'request should have been identified as a tunnel request');
+            A.areSame(1, nextCallCount, 'next() should have been called');
+        },
+
+        'test multiple slashes are squashed into one': function () {
+            config.store.getAppConfig = function () {
+                return {
+                    staticHandling: {
+                        prefix: 'brusselsprouts//'
+                    }
+                };
+            };
+            req.url = '/brusselsprouts/MojitX/definition.json';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.isObject(req._tunnel.typeReq, 'request should have been identified as a tunnel request');
+            A.areSame('MojitX', req._tunnel.typeReq.type, 'should have gotten the correct mojit type');
+            A.areSame(1, nextCallCount, 'next() should have been called');
+        },
+
+        'test prefix defaults are used if custom prefixes are not declared': function () {
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.isObject(req._tunnel.rpcReq, 'request should have been identified as an rpc request');
+            A.areSame(1, nextCallCount, 'next() should have been called for the rpc request');
+
+            req.url = '/static/MojitX/definition.json';
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.isObject(req._tunnel.typeReq, 'request should have been identified as a type request');
+            A.areSame(2, nextCallCount, 'next() should have been called for the type request');
+        },
+
+        'test exit early if not tunnel request': function () {
+            req.url = '/spinach';
+            req.headers['x-mojito-header'] = 'brusselsprouts';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() should have been called');
+            A.isUndefined(req._tunnel, 'next() should have been called immediately');
+        },
+
+        'test tunnel request paths are normalized correctly': function () {
+            req.url = '/static/MojitX/specs/broccoli.json';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.specsReq, 'should have been identified as a specs request');
+
+            req.url = '/tunnel/static/MojitX/specs/broccoli.json';
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(2, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.specsReq, 'should have been identified as a specs request');
+        },
+
+        'test tunnel spec request is correctly parsed': function () {
+            req.url = '/static/MojitX/specs/broccoli.json';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.specsReq, 'should have been identified as a specs request');
+            A.areSame('MojitX', req._tunnel.specsReq.type, 'should have parsed out the mojit type correctly');
+            A.areSame('broccoli', req._tunnel.specsReq.name, 'should have parsed out the file name correctly');
+        },
+
+        'test tunnel type request is correctly parsed': function () {
+            req.url = '/static/MojitY/definition.json';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.typeReq, 'should have been identified as a type request');
+            A.areSame('MojitY', req._tunnel.typeReq.type, 'should have parsed out the mojit type correctly');
+        },
+
+        'test tunnel rpc request is correctly parsed': function () {
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.rpcReq, 'should have been identified as an rpc request');
+
+            // Although 'wipes' is not a tunnel header, we should identify this
+            // request as a tunnel request because the tunnelPrefix matches.
+            req.headers['x-mojito-header'] = 'wipes';
+            req.url = '/diapers';
+            config.store.getAppConfig = function () {
+                return {
+                    tunnelPrefix: '/diapers'
+                };
+            };
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(2, nextCallCount, 'next() should have been called');
+            A.isObject(req._tunnel.rpcReq, 'should have been identified as an rpc request');
+        }
+    }));
+});

--- a/tests/unit/lib/app/middleware/test-handler-tunnel-rpc.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel-rpc.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI, require*/
+/*jslint nomen:true*/
+
+YUI().use('mojito-test-extra', 'test', function (Y) {
+    'use strict';
+
+    var A  = Y.Assert,
+        AA = Y.ArrayAssert,
+        OA = Y.ObjectAssert,
+
+        factory = require(Y.MOJITO_DIR + 'lib/app/middleware/mojito-handler-tunnel-rpc'),
+        expandedContext = null,
+        req,
+        nextCallCount,
+        middleware,
+        store,
+        config;
+
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'tunnel handler rpc tests',
+
+        setUp: function () {
+            nextCallCount = 0;
+
+            store = {
+                expandInstance: function (instance, context, callback) {
+                    expandedContext = context;
+                    callback(null, instance);
+                }
+            };
+
+            config = {
+                store: store
+            };
+
+            req = {
+                _tunnel: {
+                    rpcReq: {}
+                },
+                action: 'eatallyourspinach',
+                body: {
+                    instance: {},
+                    context: {
+                        runtime: 'client'
+                    }
+                }
+            };
+        },
+
+        tearDown: function () {
+            store           = null;
+            config          = null;
+            nextCallCount   = null;
+            req             = null;
+            expandedContext = null;
+        },
+
+        'handler should exit early if not an rpc request': function () {
+            req._tunnel.rpcReq = null;
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isNull(expandedContext, 'instance should not have been expanded');
+        },
+
+        'handler should override execution context to "server"': function () {
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.areSame(expandedContext.runtime, 'server', 'instance should have server context');
+        },
+
+        'handler should set execution context to "server"': function () {
+            req.body.context.runtime = null;
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.areSame(expandedContext.runtime, 'server', 'instance should have server context');
+        }
+    }));
+});

--- a/tests/unit/lib/app/middleware/test-handler-tunnel-specs.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel-specs.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI, require*/
+/*jslint nomen:true*/
+
+YUI().use('mojito-test-extra', 'test', function (Y) {
+    'use strict';
+
+    var A  = Y.Assert,
+        AA = Y.ArrayAssert,
+        OA = Y.ObjectAssert,
+
+        factory = require(Y.MOJITO_DIR + 'lib/app/middleware/mojito-handler-tunnel-specs'),
+        expandInstanceInvoked = false,
+        error,
+        req,
+        res,
+        sendData,
+        statusCode,
+        nextCallCount,
+        middleware,
+        store,
+        config;
+
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'tunnel handler specs tests',
+
+        setUp: function () {
+            nextCallCount = 0;
+
+            store = {
+                expandInstanceForEnv: function (env, instance, context, callback) {
+                    expandInstanceInvoked = true;
+                }
+            };
+
+            config = {
+                store: store
+            };
+
+            req = {
+                url: '/tunnel',
+                _tunnel: {
+                    specsReq: {
+                        type: 'MojitX',
+                        name: 'default'
+                    }
+                }
+            };
+
+            res = {
+                send: function (code, data) {
+                    sendData    = data;
+                    statusCode  = code;
+                }
+            };
+        },
+
+        tearDown: function () {
+            expandInstanceInvoked = false;
+
+            nextCallCount = 0;
+            sendData      = undefined;
+            statusCode    = undefined;
+            store         = null;
+            config        = null;
+            req           = null;
+            res           = null;
+            middleware    = null;
+            error         = undefined;
+        },
+
+        'handler should exit early if not specs request': function () {
+            req._tunnel.specsReq = null;
+            middleware = factory(config);
+            middleware(req, res, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isFalse(expandInstanceInvoked, 'should not have attempted to expand the instance');
+        },
+
+        'handler should error if "type" is missing': function () {
+            req._tunnel.specsReq.type = null;
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isNotUndefined(error, 'next() handler should have received an error');
+            A.areSame(404, res.statusCode, 'status code should have been set to 404');
+        },
+
+        'handler should error if "name" is missing': function () {
+            req._tunnel.specsReq.name = null;
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isNotUndefined(error, 'next() handler should have received an error');
+            A.areSame(404, res.statusCode, 'status code should have been set to 404');
+        },
+
+        'handler should error if expandInstanceForEnv errors': function () {
+            config.store.expandInstanceForEnv = function (env, instance, context, callback) {
+                callback(new Error('you have 10 seconds to eat that tomato'));
+            };
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.areSame(500, res.statusCode, 'status code should have been set to 500');
+            A.isNotUndefined(error, 'next() handler should have received an error');
+            A.isUndefined(sendData, 'data should not have been sent');
+        },
+
+        'test handler response for success': function () {
+            var data = 'good job, here is your dessert!';
+            config.store.expandInstanceForEnv = function (env, instance, context, callback) {
+                callback(null, data);
+            };
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(0, nextCallCount, 'next() handler should not have been called');
+            A.areSame(200, statusCode, 'status code should have been set to 200');
+            A.isUndefined(error, 'next() handler should have received an error');
+            A.areSame(data, sendData, 'data should have been sent');
+        }
+    }));
+});

--- a/tests/unit/lib/app/middleware/test-handler-tunnel-type.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel-type.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI, require*/
+/*jslint nomen:true*/
+
+YUI().use('mojito-test-extra', 'test', function (Y) {
+    'use strict';
+
+    var A  = Y.Assert,
+        AA = Y.ArrayAssert,
+        OA = Y.ObjectAssert,
+
+        factory = require(Y.MOJITO_DIR + 'lib/app/middleware/mojito-handler-tunnel-type'),
+        expandInstanceInvoked = false,
+        error,
+        req,
+        res,
+        sendData,
+        statusCode,
+        nextCallCount,
+        middleware,
+        store,
+        config;
+
+
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'tunnel handler type tests',
+
+        setUp: function () {
+            nextCallCount = 0;
+
+            store = {
+                expandInstanceForEnv: function (env, instance, context, callback) {
+                    expandInstanceInvoked = true;
+                }
+            };
+
+            config = {
+                store: store
+            };
+
+            req = {
+                url: '/tunnel',
+                _tunnel: {
+                    typeReq: {
+                        type: 'MojitX'
+                    }
+                }
+            };
+
+            res = {
+                send: function (code, data) {
+                    sendData    = data;
+                    statusCode  = code;
+                }
+            };
+        },
+
+        tearDown: function () {
+            expandInstanceInvoked = false;
+
+            nextCallCount = 0;
+            sendData      = undefined;
+            statusCode    = undefined;
+            store         = null;
+            config        = null;
+            req           = null;
+            res           = null;
+            middleware    = null;
+            error         = undefined;
+        },
+
+        'handler should exit early if not type request': function () {
+            req._tunnel.typeReq = null;
+            middleware = factory(config);
+            middleware(req, res, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isFalse(expandInstanceInvoked, 'should not have attempted to expand the instance');
+        },
+
+        'handler should error if "type" is missing': function () {
+            req._tunnel.typeReq.type = null;
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isNotUndefined(error, 'next() handler should have received an error');
+            A.areSame(404, res.statusCode, 'status code should have been set to 404');
+        },
+
+        'handler should error if expandInstanceForEnv errors': function () {
+            config.store.expandInstanceForEnv = function (env, instance, context, callback) {
+                callback(new Error('you have 10 seconds to eat that tomato'));
+            };
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.areSame(500, res.statusCode, 'status code should have been set to 500');
+            A.isNotUndefined(error, 'next() handler should have received an error');
+            A.isUndefined(sendData, 'data should not have been sent');
+        },
+
+        'test handler response for success': function () {
+            var data = 'good job, here is your dessert!';
+            config.store.expandInstanceForEnv = function (env, instance, context, callback) {
+                callback(null, data);
+            };
+            middleware = factory(config);
+            middleware(req, res, function (err) {
+                error = err;
+                nextCallCount += 1;
+            });
+
+            A.areSame(0, nextCallCount, 'next() handler should not have been called');
+            A.areSame(200, statusCode, 'status code should have been set to 200');
+            A.isUndefined(error, 'next() handler should have received an error');
+            A.areSame(data, sendData, 'data should have been sent');
+        }
+    }));
+});

--- a/tests/unit/lib/app/middleware/test-handler-tunnel.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel.js
@@ -123,14 +123,15 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
         'handler should override execution context to server (with /tunnel prefix)': function() {
             var nextCalls = 0, writeCalls = 0, endCalls = 0,
                 req = {
-                    'url': '/tunnel',
-                    'method': 'POST',
-                    'body': {
-                        'context': {
-                            'runtime': 'client',
-                            'myKey': 'myValue'
+                    url: '/tunnel',
+                    method: 'POST',
+                    body: {
+                        context: {
+                            runtime: 'client',
+                            myKey: 'myValue'
                         }
-                    }
+                    },
+                    headers: {}
                 },
                 res = {
                 };
@@ -151,13 +152,14 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
         'handler should set execution context to server (with /tunnel prefix)': function() {
             var nextCalls = 0, writeCalls = 0, endCalls = 0,
                 req = {
-                    'url': '/tunnel',
-                    'method': 'POST',
-                    'body': {
-                        'reqs': [{
-                            'data': {}
+                    url: '/tunnel',
+                    method: 'POST',
+                    body: {
+                        reqs: [{
+                            data: {}
                         }]
-                    }
+                    },
+                    headers: {}
                 },
                 res = {
                 };

--- a/tests/unit/lib/app/middleware/test-handler-tunnel.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel.js
@@ -3,307 +3,55 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-YUI().use('mojito-test-extra', 'test', function(Y) {
-    var A = Y.Assert,
+
+/*global YUI, require*/
+/*jslint nomen:true*/
+
+YUI().use('mojito-test-extra', 'test', function (Y) {
+    'use strict';
+
+    var A  = Y.Assert,
         AA = Y.ArrayAssert,
         OA = Y.ObjectAssert,
-        cases = {},
 
         factory = require(Y.MOJITO_DIR + 'lib/app/middleware/mojito-handler-tunnel'),
-        expandedContext;
+        req,
+        nextCallCount,
+        middleware,
+        store,
+        config;
 
-    cases = {
-        name: 'tunnel handler tests',
 
-        _handler: null,
+    Y.Test.Runner.add(new Y.Test.Case({
+        name: 'tunnel handler tunnel tests',
 
-        setUp: function() {
-            var store = {
-                    getAppConfig: function() { return { obj: 'appConfig' }; },
-                    getSpec: function(env, id, ctx, cb) {
-                        cb(null, {
-                            env: env,
-                            id: id,
-                            ctx: ctx
-                        });
-                    },
-                    getType: function(env, type, ctx, cb) {
-                        cb(null, {
-                            env: env,
-                            type: type,
-                            ctx: ctx
-                        });
-                    },
-                    expandInstance: function(instance, context, callback) {
-                        expandedContext = context;
-                        callback(null, instance);
-                    },
-                    expandInstanceForEnv: function(env, instance, context, callback) {
-                        expandedContext = context;
-                        callback(null, instance);
-                    }
-                },
-                globalLogger = null;
-
-            this._handler = factory({
-                context: {},
-                store:  store,
-                logger: globalLogger
-            });
-
-            expandedContext = null;
+        setUp: function () {
+            nextCallCount = 0;
+            config = {
+                store: {
+                    getAppConfig: function () {}
+                }
+            };
+            req = {
+                url: '/nodessertunlessyoueatallyourveggies',
+                headers: {}
+            };
         },
 
-        'handler calls next() when tunnel url or HTTP header not present': function() {
-            var callCount = 0,
-                req = {
-                    url: '/notunnel',
-                    headers: {}
-                };
-
-            this._handler(req, null, function() {
-                callCount++;
-            });
-
-            A.areEqual(1, callCount, 'next() handler should have been called');
+        tearDown: function () {
+            nextCallCount   = null;
+            config          = null;
+            req             = null;
         },
 
-        'test trailing slashes get removed from tunnels uris': function() {
-            var store = {
-                    getAppConfig: function() {
-                        return {
-                            obj: 'appConfig',
-                            tunnelPrefix: '/mytunnelprefix/'
-                        };
-                    },
-                    getSpec: function(env, id, ctx, cb) {
-                        cb(null, {
-                            env: env,
-                            id: id,
-                            ctx: ctx
-                        });
-                    },
-                    getType: function(env, type, ctx, cb) {
-                        cb(null, {
-                            env: env,
-                            type: type,
-                            ctx: ctx
-                        });
-                    },
-                    expandInstance: function(instance, context, callback) {
-                        expandedContext = context;
-                        callback(null, instance);
-                    },
-                    expandInstanceForEnv: function(env, instance, context, callback) {
-                        expandedContext = context;
-                        callback(null, instance);
-                    }
-                },
-                globalLogger = null,
-                callCount = 0,
-                req = {
-                    url: '/notunnel',
-                    headers: {}
-                };
-
-            this._handler = factory({
-                context: {},
-                store:  store,
-                logger: globalLogger
+        'handler should run all tunnel middleware if not a tunnel request': function () {
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
             });
 
-            this._handler(req, null, function() {
-                callCount++;
-            });
-
-            A.areEqual(1, callCount, 'next() handler should have been called');
-        },
-
-
-        'handler should override execution context to server (with /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0,
-                req = {
-                    url: '/tunnel',
-                    method: 'POST',
-                    body: {
-                        context: {
-                            runtime: 'client',
-                            myKey: 'myValue'
-                        }
-                    },
-                    headers: {}
-                },
-                res = {
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.isObject(expandedContext, 'Expanded context should be an object');
-            A.areEqual('myValue', expandedContext.myKey, 'custom context property should have been preserved');
-            A.areEqual('server', expandedContext.runtime, 'context.runtime should have been set to "server"');
-
-            A.areEqual(1, nextCalls, 'next() handler should have been called');
-            A.areEqual(0, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(0, endCalls, 'res.end() should have been called');
-        },
-
-        'handler should set execution context to server (with /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0,
-                req = {
-                    url: '/tunnel',
-                    method: 'POST',
-                    body: {
-                        reqs: [{
-                            data: {}
-                        }]
-                    },
-                    headers: {}
-                },
-                res = {
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.isObject(expandedContext, 'Expanded context should be an object');
-            A.areEqual('server', expandedContext.runtime, 'context.runtime should have been set to "server"');
-
-            A.areEqual(1, nextCalls, 'next() handler should have been called');
-            A.areEqual(0, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(0, endCalls, 'res.end() should have been called');
-        },
-
-        'handles specs (with /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0;
-                req = {
-                    url: '/tunnel/static/MojitA/specs/orange.json',
-                    headers: { 'x-mojito-header': 'tunnel' }
-                },
-                res = {
-                    writeHead: function(code, headers) {
-                        writeCalls++;
-                        A.areEqual('200', code, 'should have gotten 200');
-                        A.areEqual('application/json; charset="utf-8"', headers['content-type'], 'should have gotten application/json, utf-8');
-                    },
-                    end: function(data) {
-                        var expected = {
-                            "base": "MojitA:orange"
-                        };
-                        endCalls++;
-                        A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
-                    }
-
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.areEqual(0, nextCalls, 'next() handler should not have been called');
-            A.areEqual(1, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(1, endCalls, 'res.end() should have been called');
-        },
-
-        'handles specs (no /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0;
-                req = {
-                    url: '/static/MojitA/specs/orange.json',
-                    headers: { 'x-mojito-header': 'tunnel' }
-                },
-                res = {
-                    writeHead: function(code, headers) {
-                        writeCalls++;
-                        A.areEqual('200', code, 'should have gotten 200');
-                        A.areEqual('application/json; charset="utf-8"', headers['content-type'], 'should have gotten application/json, utf-8');
-                    },
-                    end: function(data) {
-                        var expected = {
-                            "base": "MojitA:orange"
-                        };
-                        endCalls++;
-                        A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
-                    }
-
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.areEqual(0, nextCalls, 'next() handler should not have been called');
-            A.areEqual(1, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(1, endCalls, 'res.end() should have been called');
-        },
-
-        'handles type (with /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0;
-                req = {
-                    url: '/tunnel/static/MojitA/definition.json?x=y',
-                    headers: { 'x-mojito-header': 'tunnel' }
-                },
-                res = {
-                    writeHead: function(code, headers) {
-                        writeCalls++;
-                        A.areEqual('200', code, 'should have gotten 200');
-                        A.areEqual('application/json; charset="utf-8"', headers['content-type'], 'should have gotten application/json, utf-8');
-                    },
-                    end: function(data) {
-                        var expected = {
-                            "type": "MojitA"
-                        };
-                        endCalls++;
-                        A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
-                    }
-
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.areEqual(0, nextCalls, 'next() handler should not have been called');
-            A.areEqual(1, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(1, endCalls, 'res.end() should have been called');
-        },
-
-        'handles type (no /tunnel prefix)': function() {
-            var nextCalls = 0, writeCalls = 0, endCalls = 0;
-                req = {
-                    url: '/static/MojitA/definition.json',
-                    headers: { 'x-mojito-header': 'tunnel' }
-                },
-                res = {
-                    writeHead: function(code, headers) {
-                        writeCalls++;
-                        A.areEqual('200', code, 'should have gotten 200');
-                        A.areEqual('application/json; charset="utf-8"', headers['content-type'], 'should have gotten application/json, utf-8');
-                    },
-                    end: function(data) {
-                        var expected = {
-                            "type": "MojitA"
-                        };
-                        endCalls++;
-                        A.areEqual(Y.JSON.stringify(expected,null,4), data, 'should have gotten spec');
-                    }
-
-                };
-
-            this._handler(req, res, function() {
-                nextCalls++;
-            });
-
-            A.areEqual(0, nextCalls, 'next() handler should not have been called');
-            A.areEqual(1, writeCalls, 'res.writeHead() should have been called');
-            A.areEqual(1, endCalls, 'res.end() should have been called');
-        },
-
-        'ignore:': function () {
-
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isNull(req._tunnel, 'should have cleaned up private variable');
         }
-    };
-
-    Y.Test.Runner.add(new Y.Test.Case(cases));
+    }));
 });


### PR DESCRIPTION
By splitting the tunnel logic into a detection phase and a handling phase,
applications are free to override the handling logic.

In order to maintain backwards-compatibility, instead of refactoring the
existing tunnel middleware, a tunnel-demux middleware to detect the type of
tunnel request, and tunnel-(rpc|specs|type) middleware to handle each type of
request have been added. Mojito itself will now use these new middleware in
place of the single tunnel middleware, which will remain for those applications
that are specifying it in their configuration.
