### PR TITLE
enable per-request tunnel url configuration

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,10 @@ version @VERSION@
 
 Notes
 ------------
+* A middleware called `mojito-handler-error` has been added to handle
+  middleware errors. If you have redefined the middleware stack and do not have
+  your own error handler, then it is your responsibility to add it so that
+  errors can be handled appropriately.
 
 Deprecations
 ------------
@@ -10,6 +14,14 @@ Deprecations
 Features
 ------------
 * Upgraded to YUI 3.9.0
+* [issue #979](/yahoo/mojito/issues/979):
+  * The `mojito-handler-tunnel` middleware was refactored into a middleware
+    substack that more loosens the coupling between the parsing and handling
+    phases of a tunnel request. This means that applications will have an
+    easier time overriding and customizing tunnel behavior.
+  * The URL is now customizable per request using the `tunnelUrl` option for
+    `mojitProxy.invoke()`, but is still subject to the `tunnelPrefix`
+    restriction.
 
 Bug Fixes
 ------------

--- a/lib/app/autoload/mojit-proxy.client.js
+++ b/lib/app/autoload/mojit-proxy.client.js
@@ -196,6 +196,10 @@ YUI.add('mojito-mojit-proxy', function(Y, NAME) {
                 rpc: options.rpc || false
             };
 
+            if (options.tunnelUrl) {
+                command._tunnelUrl = options.tunnelUrl;
+            }
+
             this._client.executeAction(command, this.getId(), callback);
         },
 

--- a/lib/app/autoload/tunnel-client.common.js
+++ b/lib/app/autoload/tunnel-client.common.js
@@ -25,6 +25,11 @@ YUI.add('mojito-tunnel-client', function(Y, NAME) {
 
             url = this._appConfig.tunnelPrefix;
 
+            if (command._tunnelUrl) {
+                url = command._tunnelUrl;
+                command._tunnelUrl = undefined;
+            }
+
             cfg = {
                 method: 'POST',
                 data: Y.JSON.stringify(command),

--- a/lib/app/middleware/mojito-handler-tunnel-parser.js
+++ b/lib/app/middleware/mojito-handler-tunnel-parser.js
@@ -74,14 +74,14 @@ module.exports = function (config) {
         path = path.replace(staticPrefix, '')
                    .replace(tunnelPrefix, '');
 
+        parts = path.split('/');
+
         req._tunnel = {};
 
-        if (path) {
+        // If there was a '/' in the path.
+        if (parts.length > 1) {
             // Get the basename without the .json extension.
             name = libpath.basename(path, '.json');
-
-            // Time to get dirty.
-            parts = path.split('/');
 
             // Get the mojit type.
             type = parts[1];
@@ -101,7 +101,7 @@ module.exports = function (config) {
             }
         }
         // "RPC" tunnel request
-        else if (req.url === tunnelPrefix && req.method === 'POST') {
+        else if (hasTunnelPrefix && req.method === 'POST') {
             req._tunnel.rpcReq = {};
         }
 

--- a/tests/unit/lib/app/autoload/test-mojit-proxy.client.js
+++ b/tests/unit/lib/app/autoload/test-mojit-proxy.client.js
@@ -164,6 +164,34 @@ YUI({useBrowserConsole: true}).use(
                 Y.Mock.verify(mojitProxy._client);
             },
 
+            "test invoke with tunnelUrl option": function () {
+                var mojitProxy = this.mojitProxy,
+                    mojitProxyConfig = this.mojitProxyConfig,
+                    tunnelUrl = '/tunnel;_ylt=A0oGdV8GMC1RcBgAQNhXNyoA';
+
+                mojitProxy._client = Y.Mock();
+                mojitProxy.query = {}; // Avoid window calls
+
+                Y.Mock.expect(mojitProxy._client, {
+                    method: 'executeAction',
+                    args: [Y.Mock.Value.Object, Y.Mock.Value.String, Y.Mock.Value.Function],
+                    run: function (command, id, cb) {
+                        Y.Assert.areSame(tunnelUrl, command._tunnelUrl);
+                    }
+                });
+
+                mojitProxy.invoke('index', {
+                    params: {
+                        body: {
+                            testKey: 'testVal'
+                        }
+                    },
+                    tunnelUrl: tunnelUrl,
+                    rpc: true
+                });
+                Y.Mock.verify(mojitProxy._client);
+            },
+
             "test refreshView": function () {
                 var mojitProxy = this.mojitProxy;
                 mojitProxy._client = Y.Mock();

--- a/tests/unit/lib/app/autoload/test-tunnel.common.js
+++ b/tests/unit/lib/app/autoload/test-tunnel.common.js
@@ -35,6 +35,22 @@ YUI({useBrowserConsole: true}).use(
                 Y.Assert.areEqual(this.appConfig, tunnelClient._appConfig);
             },
 
+            "test tunnelUrl override": function () {
+                var appConfig = this.appConfig,
+                    tunnelClient = this.tunnelClient,
+                    tunnelUrl = '/tunnel;_ylt=A0oGdV8GMC1RcBgAQNhXNyoA',
+                    command = {
+                        _tunnelUrl: tunnelUrl
+                    };
+
+                tunnelClient._makeRequest = function (url) {
+                    Y.Assert.isString(url);
+                    Y.Assert.areEqual(tunnelUrl, url);
+                };
+
+                tunnelClient.rpc(command);
+            },
+
             "test rpc success": function () {
                 var appConfig = this.appConfig,
                     tunnelClient = this.tunnelClient,

--- a/tests/unit/lib/app/middleware/test-handler-tunnel-parser.js
+++ b/tests/unit/lib/app/middleware/test-handler-tunnel-parser.js
@@ -170,6 +170,20 @@ YUI().use('mojito-test-extra', 'test', function (Y) {
             A.areSame('MojitY', req._tunnel.typeReq.type, 'should have parsed out the mojit type correctly');
         },
 
+        'test compatibility with tunnelUrl option': function () {
+            req.url = '/tunnel;_ylt=A0oGdV8GMC1RcBgAQNhXNyoA;_ylu=X3oDMTE5aWhtbjdhBHNlYwNvdi10b3AEY29sbwNzazEEdnRpZANTTUUwNDFfMTU0BHBvcwMx';
+            req.headers['x-mojito-header'] = 'huggies';
+
+            middleware = factory(config);
+            middleware(req, null, function () {
+                nextCallCount += 1;
+            });
+
+            A.areSame(1, nextCallCount, 'next() handler should have been called');
+            A.isObject(req._tunnel.rpcReq, 'should have been identified as an rpc request');
+        },
+
+
         'test tunnel rpc request is correctly parsed': function () {
             middleware = factory(config);
             middleware(req, null, function () {


### PR DESCRIPTION
Configured `tunnelUrl` must still be prefixed with `tunnelPrefix`.
