### PR TITLE
reusing the same staticAppConfig for the request instead of for the mojit

### DIFF
--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -308,7 +308,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         this._adapter = opts.adapter;
 
         // pathToRoot, viewEngine, amoung others will be available through this.
-        this.staticAppConfig = store.getStaticAppConfig();
+        this.staticAppConfig = opts.staticAppConfig || store.getStaticAppConfig();
 
         // Create a function which will properly delegate to the dispatcher to
         // perform the actual processing.

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -40,6 +40,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             // reference.
             this.store = resourceStore;
             this.tunnel = rpcTunnel;
+            this.staticAppConfig = resourceStore.getStaticAppConfig();
 
             Y.log('Dispatcher created', 'debug', NAME);
 
@@ -69,7 +70,8 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                     controller: Y.mojito.util.heir(controller),
                     dispatcher: this,         // NOTE passing dispatcher.
                     adapter: adapter,
-                    store: this.store
+                    store: this.store,
+                    staticAppConfig: this.staticAppConfig
                 });
             } catch (e) {
                 Y.log('Error from dispatch on instance \'' +


### PR DESCRIPTION
Hi,

would that something mojito team might consider? it could live behind a staticAppConfig and be disable by default. When dealing with expressive amount of config and tens of mojits this change can save more than 10% on performance.

The change intends to use a copy of staticAppConfig per request instead of per mojit dispatch. Tests with our application looked OK.

Please comment.
