### PR TITLE
use page object to store/use staticAppConfig

### DIFF
--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -308,7 +308,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         this._adapter = opts.adapter;
 
         // pathToRoot, viewEngine, amoung others will be available through this.
-        this.staticAppConfig = store.getStaticAppConfig();
+        this.staticAppConfig = (this._adapter.page && this._adapter.page.staticAppConfig) || store.getStaticAppConfig();
 
         // Create a function which will properly delegate to the dispatcher to
         // perform the actual processing.

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -338,6 +338,9 @@ YUI.add('mojito-client', function(Y, NAME) {
                     // pass globalHookhandler to addons that may want to use hooks
                     globalHookHandler: globalHookHandler
                 };
+
+            this.page.staticAppConfig = config.appConfig;
+
             fireLifecycle('pre-init', forwardConfig);
             // if we didn't originaly have hooks enabled, copy back from config object.
             // This is the case where an add-on module wants to turn on hooks and

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -339,7 +339,7 @@ YUI.add('mojito-client', function(Y, NAME) {
                     globalHookHandler: globalHookHandler
                 };
 
-            this.page.staticAppConfig = config.appConfig;
+            this.page.staticAppConfig = appConfig;
 
             fireLifecycle('pre-init', forwardConfig);
             // if we didn't originaly have hooks enabled, copy back from config object.

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -340,6 +340,8 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
             log: Y.log
         });
 
+        outputHandler.page.staticAppConfig = store.getStaticAppConfig();
+
         // HookSystem::StartBlock
         // enabling perf group
         if (appConfig.perf) {

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -65,7 +65,19 @@ YUI.add('mojito-hb', function(Y, NAME) {});
 
 /* AUTOLOAD */
 YUI.add('mojito-action-context', function(Y, NAME) {});
-YUI.add('mojito-dispatcher', function(Y, NAME) {});
+YUI.add('mojito-dispatcher', function(Y, NAME) {
+    // We need to grab the output handler while testing lib/mojito.js.
+    var mock = {
+        init: function(store) {
+            return {
+                dispatch: function(command, outputHandler) {
+                    mock.outputHandler = outputHandler;
+                }
+            };
+        }
+    };
+    Y.namespace('mojito').Dispatcher = mock;
+});
 YUI.add('mojito-mojit-proxy', function(Y, NAME) {});
 YUI.add('mojito-output-handler', function(Y, NAME) {});
 YUI.add('mojito-perf', function(Y, NAME) {});

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-YUI().use('mojito-action-context', 'test', function (Y) {
+YUI().use('mojito-action-context', 'mojito-tests', 'test', function (Y) {
 
     var suite = new Y.Test.Suite('mojito-action-context tests'),
         acStash = {},
@@ -197,7 +197,11 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: {
+                    page: {
+                        staticAppConfig: {foo: 'bar'}
+                    }
+                },
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -206,6 +210,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             A.areSame('Type', ac.type, 'bad type');
             A.areSame('index', ac.action, 'bad action');
             A.areSame('context', ac.context, 'bad context');
+            Y.TEST_CMP({foo: 'bar'}, ac.staticAppConfig, 'bad staticAppConfig');
 
             A.areSame('the dispatcher', ac.dispatcher,
                 "dispatcher wasn't stashed.");

--- a/tests/unit/lib/test-mojito.js
+++ b/tests/unit/lib/test-mojito.js
@@ -336,7 +336,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                     _options: {verbose: false}
                 };
 
-            cb = function(/*err, app*/) {};
+            cb = function(err, app) {};
 
             Y.Mock.expect(app, {
                 method: 'listen',
@@ -615,14 +615,24 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
         name: '_configureAppInstance suite',
 
         'test configureAppInstance': function () {
-            var appwtf = {
+            var dispatcher,
+                madeY,      // the Y instance made in mojito.js
+                appwtf = {
                     store: {
+                        getAllURLDetails: function () {
+                            return {};
+                        },
                         getAppConfig: function () {
                             A.isTrue(true);
                             return {
                                 debugMemory: true,
-                                middleware: ['mojito-router'],
-                                perf: {}
+                                middleware: ['mojito-handler-dispatcher']
+                            };
+                        },
+                        getStaticAppConfig: function () {
+                            return {
+                                debugMemory: true,
+                                middleware: ['mojito-handler-dispatcher']
                             };
                         },
                         getStaticContext: function () {
@@ -632,21 +642,36 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                             getConfigShared: function () {
                                 return {};
                             },
+                            getModulesConfig: function () {
+                                return {
+                                    modules: {
+                                        'mojito-hooks': {
+                                            fullpath: __dirname + '/../../base/mojito-test.js'
+                                        },
+                                        'mojito-dispatcher': {
+                                            fullpath: __dirname + '/../../base/mojito-test.js'
+                                        }
+                                    }
+                                };
+                            },
+                            getYUIURLDetails: function () {
+                                return {};
+                            }
                         }
                     },
-                    use: function () {}
+                    use: function (x) {
+                        dispatcher = x;
+                    }
                 };
 
-            Y.namespace('mojito.Dispatcher').init = function(store) {
-                Y.isObject(store);
-                return {
-                    dispatch: function (cmd, outputHandler) {}
-                };
+            Mojito.Server.prototype._configureLogger = function(y) {
+                madeY = y;
             };
-
-            try {
-                Mojito.Server.prototype._configureAppInstance(appwtf);
-            } catch (err) {}
+            Mojito.Server.prototype._configureAppInstance(appwtf);
+            dispatcher({command: {}}, {}, function() {});
+            A.isObject(madeY.mojito.Dispatcher.outputHandler);
+            A.isObject(madeY.mojito.Dispatcher.outputHandler.page);
+            A.isObject(madeY.mojito.Dispatcher.outputHandler.page.staticAppConfig);
         }
 
     }));


### PR DESCRIPTION
Reworking of PR #1051 to hang staticAppConfig off of "page" object (instead of dispatcher).
