### PR TITLE
(minor) reword start msg. fixes #1043

### DIFF
--- a/lib/app/commands/start.js
+++ b/lib/app/commands/start.js
@@ -99,6 +99,6 @@ exports.run = function(params, opts, callback) {
         console.log('\n');
         utils.success('\tMojito(v' + mojitoVersion + ') started' +
             (pack.name ? ' \'' + pack.name + '\'' : '') +
-            ' on http://127.0.0.1:' + options.port + '/\n');
+            ' on port ' + options.port + '\n');
     });
 };


### PR DESCRIPTION
mojito's underlying express/connect/node http server is started without specifying a host, and ends up listening to "connections directed to any IPv4 address (INADDR_ANY)." http://y.ahoo.it/XO3S2 see also http://y.ahoo.it/dIdNP
