### PR TITLE
routes sent to the client should honor the client context

### DIFF
--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -117,7 +117,7 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
                 clientConfig.pathToRoot = pathToRoot;
             }
 
-            clientConfig.routes = this.ac.url.getRouteMaker().getComputedRoutes();
+            clientConfig.routes = store.getRoutes(contextClient);
 
             // Unicode escape the various strings in the config data to help
             // fight against possible script injection attacks.
@@ -130,6 +130,11 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
                     yuiConfig.groups.app.comboSep) {
                 yuiConfigEscaped.groups.app.comboSep = yuiConfig.groups.app.comboSep;
             }
+
+            // some cleanup before serializing all the data
+            clientConfig.appConfig.routesFiles = undefined;
+            clientConfig.appConfig.mojitsDirs = undefined;
+            clientConfig.appConfig.appPort = undefined;
 
             yuiConfigStr = JSON.stringify(yuiConfigEscaped);
             clientConfigEscaped = Y.mojito.util.cleanse(clientConfig);
@@ -155,6 +160,5 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
 
 }, '0.1.0', {requires: [
     'mojito-util',
-    'mojito-http-addon',
-    'mojito-url-addon'
+    'mojito-http-addon'
 ]});

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -341,6 +341,9 @@ YUI.add('mojito-client', function(Y, NAME) {
 
             this.page.staticAppConfig = appConfig;
 
+            // compiling routes that are used by store-client
+            config.routes = (new Y.mojito.RouteMaker(config.routes)).getComputedRoutes();
+
             fireLifecycle('pre-init', forwardConfig);
             // if we didn't originaly have hooks enabled, copy back from config object.
             // This is the case where an add-on module wants to turn on hooks and

--- a/tests/unit/lib/app/addons/ac/test-deploy.server.js
+++ b/tests/unit/lib/app/addons/ac/test-deploy.server.js
@@ -25,16 +25,7 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                         return null;
                     }
                 },
-                context: {},
-                url: {
-                    getRouteMaker: function() {
-                        return {
-                            getComputedRoutes: function() {
-                                return ['routes'];
-                            }
-                        };
-                    }
-                }
+                context: {}
             };
         },
 
@@ -66,6 +57,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
             addon.setStore({
                 getAppConfig: function() {
                     return {};
+                },
+                getRoutes: function() {
+                    return ['routes'];
                 },
                 yui: {
                     getYUIConfig: function() {
@@ -120,6 +114,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 getAppConfig: function() {
                     return {yui: {config: {discarded: true}}};
                 },
+                getRoutes: function() {
+                    return ['routes'];
+                },
                 yui: {
                     getYUIConfig: function() {
                         return {
@@ -159,6 +156,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
             addon.setStore({
                 getAppConfig: function() {
                     return {};
+                },
+                getRoutes: function() {
+                    return ['routes'];
                 },
                 yui: {
                     getYUIConfig: function() {
@@ -211,6 +211,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
             addon.setStore({
                 getAppConfig: function() {
                     return {};
+                },
+                getRoutes: function() {
+                    return ['routes'];
                 },
                 yui: {
                     getYUIConfig: function() {


### PR DESCRIPTION
- server was using the server context to produce the routes to be expose to the client.
- server was also compiling those routes before sending them, which is something we can perfectly do in the client side.
- other small clean up in the data we serialized for client.
