### PR TITLE
backport bugfix for build cmd: spec in mapSpecUris referred to key not value

### DIFF
--- a/lib/app/commands/build/shared.js
+++ b/lib/app/commands/build/shared.js
@@ -41,7 +41,8 @@ function mapSpecUris(buildmap, conf, name, store) {
     var opts = {type: 'spec', mojit: name},
         specs = store.getResourceVersions(opts);
 
-    Object.keys(specs).forEach(function (spec) {
+    Object.keys(specs).forEach(function (key) {
+        var spec = specs[key];
         if (spec.hasOwnProperty('url')) { // see mapDefxUris [urls] comment
             buildmap[conf.tunnelpf + spec.url + conf.contextqs] = spec.url;
         }

--- a/tests/unit/lib/app/commands/build/test-shared.js
+++ b/tests/unit/lib/app/commands/build/test-shared.js
@@ -155,7 +155,10 @@ YUI().use('mojito-test-extra', 'test', function(Y) {
                     getResourceVersions: function(filter) {return mojits;}
                 },
                 buildmap = {},
-                expected = {'/tunnel/yahoo.application.test50/top_frame/definition.json?device=iphone': '/yahoo.application.test50/top_frame/definition.json'};
+                expected = {
+                    '/tunnel/yahoo.application.test50/top_frame/definition.json?device=iphone': '/yahoo.application.test50/top_frame/definition.json',
+                    '/tunnel/yahoo.application.test50/top_frame?device=iphone': '/yahoo.application.test50/top_frame'
+                };
 
             A.areSame(0, count);
             shared.mapDefxUris(buildmap, getConf(), store);


### PR DESCRIPTION
see isao/mojito-build@c11c48100828397e3f70dd3e20477a40fbf809f6

This is low impact, the affected code supports an undocumented legacy edge-case from the Livestand days.
