### PR TITLE
added doT templates view engine

### DIFF
--- a/lib/app/addons/view-engines/doT-base.common.js
+++ b/lib/app/addons/view-engines/doT-base.common.js
@@ -1,0 +1,128 @@
+// doT.js
+// 2011, Laura Doktorova, https://github.com/olado/doT
+// Licensed under the MIT license.
+// 'Ported' to YUI by Jesse Foltz
+
+YUI.add("doT", function(Y) {
+    "use strict";
+
+    var doT = Y.doT = {
+		version: '1.0.0',
+		templateSettings: {
+			evaluate:    /\{\{([\s\S]+?\}?)\}\}/g,
+			interpolate: /\{\{=([\s\S]+?)\}\}/g,
+			encode:      /\{\{!([\s\S]+?)\}\}/g,
+			use:         /\{\{#([\s\S]+?)\}\}/g,
+			useParams:   /(^|[^\w$])def(?:\.|\[[\'\"])([\w$\.]+)(?:[\'\"]\])?\s*\:\s*([\w$\.]+|\"[^\"]+\"|\'[^\']+\'|\{[^\}]+\})/g,
+			define:      /\{\{##\s*([\w\.$]+)\s*(\:|=)([\s\S]+?)#\}\}/g,
+			defineParams:/^\s*([\w$]+):([\s\S]+)/,
+			conditional: /\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}/g,
+			iterate:     /\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})/g,
+			varname:	'it',
+			strip:		true,
+			append:		true,
+			selfcontained: false
+		},
+		template: undefined, //fn, compile template
+		compile:  undefined  //fn, for express
+	};
+
+	function encodeHTMLSource() {
+		var encodeHTMLRules = { "&": "&#38;", "<": "&#60;", ">": "&#62;", '"': '&#34;', "'": '&#39;', "/": '&#47;' },
+			matchHTML = /&(?!#?\w+;)|<|>|"|'|\//g;
+		return function() {
+			return this ? this.replace(matchHTML, function(m) {return encodeHTMLRules[m] || m;}) : this;
+		};
+	}
+	String.prototype.encodeHTML = encodeHTMLSource();
+
+	var startend = {
+		append: { start: "'+(",      end: ")+'",      endencode: "||'').toString().encodeHTML()+'" },
+		split:  { start: "';out+=(", end: ");out+='", endencode: "||'').toString().encodeHTML();out+='"}
+	}, skip = /$^/;
+
+	function resolveDefs(c, block, def) {
+		return ((typeof block === 'string') ? block : block.toString())
+		.replace(c.define || skip, function(m, code, assign, value) {
+			if (code.indexOf('def.') === 0) {
+				code = code.substring(4);
+			}
+			if (!(code in def)) {
+				if (assign === ':') {
+					if (c.defineParams) value.replace(c.defineParams, function(m, param, v) {
+						def[code] = {arg: param, text: v};
+					});
+					if (!(code in def)) def[code]= value;
+				} else {
+					new Function("def", "def['"+code+"']=" + value)(def);
+				}
+			}
+			return '';
+		})
+		.replace(c.use || skip, function(m, code) {
+			if (c.useParams) code = code.replace(c.useParams, function(m, s, d, param) {
+				if (def[d] && def[d].arg && param) {
+					var rw = (d+":"+param).replace(/'|\\/g, '_');
+					def.__exp = def.__exp || {};
+					def.__exp[rw] = def[d].text.replace(new RegExp("(^|[^\\w$])" + def[d].arg + "([^\\w$])", "g"), "$1" + param + "$2");
+					return s + "def.__exp['"+rw+"']";
+				}
+			});
+			var v = new Function("def", "return " + code)(def);
+			return v ? resolveDefs(c, v, def) : v;
+		});
+	}
+
+	function unescape(code) {
+		return code.replace(/\\('|\\)/g, "$1").replace(/[\r\t\n]/g, ' ');
+	}
+
+	doT.template = function(tmpl, c, def) {
+		c = c || doT.templateSettings;
+		var cse = c.append ? startend.append : startend.split, needhtmlencode, sid = 0, indv,
+			str  = (c.use || c.define) ? resolveDefs(c, tmpl, def || {}) : tmpl;
+
+		str = ("var out='" + (c.strip ? str.replace(/(^|\r|\n)\t* +| +\t*(\r|\n|$)/g,' ')
+					.replace(/\r|\n|\t|\/\*[\s\S]*?\*\//g,''): str)
+			.replace(/'|\\/g, '\\$&')
+			.replace(c.interpolate || skip, function(m, code) {
+				return cse.start + unescape(code) + cse.end;
+			})
+			.replace(c.encode || skip, function(m, code) {
+				needhtmlencode = true;
+				return cse.start + unescape(code) + cse.endencode;
+			})
+			.replace(c.conditional || skip, function(m, elsecase, code) {
+				return elsecase ?
+					(code ? "';}else if(" + unescape(code) + "){out+='" : "';}else{out+='") :
+					(code ? "';if(" + unescape(code) + "){out+='" : "';}out+='");
+			})
+			.replace(c.iterate || skip, function(m, iterate, vname, iname) {
+				if (!iterate) return "';} } out+='";
+				sid+=1; indv=iname || "i"+sid; iterate=unescape(iterate);
+				return "';var arr"+sid+"="+iterate+";if(arr"+sid+"){var "+vname+","+indv+"=-1,l"+sid+"=arr"+sid+".length-1;while("+indv+"<l"+sid+"){"
+					+vname+"=arr"+sid+"["+indv+"+=1];out+='";
+			})
+			.replace(c.evaluate || skip, function(m, code) {
+				return "';" + unescape(code) + "out+='";
+			})
+			+ "';return out;")
+			.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/\r/g, '\\r')
+			.replace(/(\s|;|\}|^|\{)out\+='';/g, '$1').replace(/\+''/g, '')
+			.replace(/(\s|;|\}|^|\{)out\+=''\+/g,'$1out+=');
+
+		if (needhtmlencode && c.selfcontained) {
+			str = "String.prototype.encodeHTML=(" + encodeHTMLSource.toString() + "());" + str;
+		}
+		try {
+			return new Function(c.varname, str);
+		} catch (e) {
+			if (typeof console !== 'undefined') console.log("Could not create a template function: " + str);
+			throw e;
+		}
+	};
+
+	doT.compile = function(tmpl, def) {
+		return doT.template(tmpl, null, def);
+	};    
+},"0.0.1");

--- a/lib/app/addons/view-engines/doT.client.js
+++ b/lib/app/addons/view-engines/doT.client.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+/*jslint anon:true, sloppy:true, nomen:true*/
+/*global YUI*/
+
+YUI.add('mojito-doT', function(Y, NAME) {
+
+    'use strict';
+
+    var doT = Y.doT,
+        cache = Y.namespace('Env.Mojito.Handlebars');
+
+    /**
+     * doT Adapter for the client runtime.
+     * @class doTAdapterClient
+     * @constructor
+     * @param {object} options View engine configuration.
+     * @private
+     */
+    function doTAdapter(options) {
+        this.options = options || {};
+    }
+
+    doTAdapter.prototype = {
+
+        /**
+         * Renders the doT template using the data provided.
+         * @param {object} data The data to render.
+         * @param {object} instance The expanded mojit instance.
+         * @param {object} template The view object from RS to render with format:
+         * {'content-path': 'path to view', content: 'cached string'}.
+         * @param {object} adapter The output adapter to use.
+         * @param {object} meta Optional metadata.
+         * @param {boolean} more Whether there is more to be rendered
+         */
+        render: function (data, instance, template, adapter, meta, more) {
+            var cacheTemplates = (this.options.cacheTemplates === false ? false : true),
+                handler = function (err, obj) {
+                    var output;
+
+                    if (err) {
+                        adapter.error(err);
+                        return;
+                    }
+                    
+                    try{
+                        output = doT.compile(obj.raw, obj.partials)(data);
+                    }catch(e){
+                        output = e;
+                    }
+
+                    if (more) {
+                        adapter.flush(output, meta);
+                    } else {
+                        adapter.done(output, meta);
+                    }
+                },
+                stack,
+                cacheKey,
+                fn,
+                partial,
+                partials;
+
+            // support for legacy url instead of a view object
+            if (Y.Lang.isString(template)) {
+                Y.log('[view] argument in [render] method should be an object', 'warn', NAME);
+                template = {
+                    'content-path': template
+                };
+            }
+
+            cacheKey = template['content-path'];
+
+            if (cacheTemplates && cache[cacheKey]) {
+                handler(null, cache[cacheKey]);
+                return;
+            }
+
+            stack = new Y.Parallel();
+            partials = {};
+
+            // first item in the asyc queue is the actual view
+            this._getTemplateObj(template, stack.add(function (err, obj) {
+                if (err) {
+                    Y.log('Error trying to compile view ' + cacheKey, 'error', NAME);
+                    Y.log(err, 'error', NAME);
+                    return;
+                }
+                cache[cacheKey] = obj;
+            }));
+
+            // after the first item, we just add any partial
+            if (instance && instance.partials && Y.Object.keys(instance.partials).length > 0) {
+                fn = function (partial, err, obj) {
+                    if (err) {
+                        Y.log('Error trying to compile partial [' + partial + '] on view ' +
+                            cacheKey, 'error', NAME);
+                        Y.log(err, 'error', NAME);
+                        return;
+                    }
+                    partials[partial] = obj.raw;
+                };
+                for (partial in instance.partials) {
+                    if (instance.partials.hasOwnProperty(partial)) {
+                        this._getTemplateObj(instance.partials[partial],
+                            stack.add(Y.bind(fn, this, partial)));
+                    }
+                }
+            }
+
+            // finally, let's just put the compiled view and partials together
+            stack.done(function () {
+                if (!cache[cacheKey]) {
+                    handler(new Error("Error trying to render view " + cacheKey));
+                    return;
+                }
+                cache[cacheKey].partials = partials;
+                handler(null, cache[cacheKey]);
+            });
+
+        },
+
+        /**
+         * Build a compiled handlebar template, plus
+         * a raw string representation of the template.
+         * @private
+         * @param {object} template The view object from RS to render with format:
+         * {'content-path': 'path to view', content: 'cached string'}.
+         * @param {function} callback The function that is called with the compiled template
+         * @return {object} literal object with the "raw" and "template" references.
+         */
+        _getTemplateObj: function (template, callback) {
+            var fn = function (err, str) {
+                    if (err) {
+                        callback(err);
+                        return;
+                    }
+                    callback(null, {
+                        raw: str
+                    });
+                };
+            if (template.content) {
+                fn(null, template.content);
+            } else {
+                this._loadTemplate(template['content-path'], fn);
+            }
+        },
+
+        /**
+         * Loads a template from a remote location
+         * @param tmpl The location of the template
+         * @param cb The callback to call with the template response
+         * @private
+         */
+        _loadTemplate: function (tmpl, cb) {
+            Y.io(tmpl, {
+                on: {
+                    success: function (id, resp) {
+                        cb(null, resp.responseText);
+                    },
+                    failure: function (id, resp) {
+                        cb({
+                            code: resp.status,
+                            message: resp.statusText
+                        });
+                    }
+                }
+            });
+        }
+    };
+
+    Y.namespace('mojito.addons.viewEngines').doT = doTAdapter;
+
+}, '0.1.0', {requires: [
+    'io-base',
+    'parallel',
+    'doT'
+]});

--- a/lib/app/addons/view-engines/doT.server.js
+++ b/lib/app/addons/view-engines/doT.server.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, sloppy:true, nomen:true, node:true*/
+/*global YUI*/
+
+YUI.add('mojito-doT', function (Y, NAME) {
+
+    'use strict';
+
+    var fs = require('fs'),
+        doT = Y.doT,
+        cache = YUI.namespace('Env.Mojito.Handlebars');
+
+    /**
+     * doT Adapter for the server runtime.
+     * @class doTAdapterServer
+     * @constructor
+     * @param {object} options View engine configuration.
+     * @private
+     */
+    function doTAdapter(options) {
+        this.options = options || {};
+    }
+
+    doTAdapter.prototype = {
+
+        /**
+         * Renders the doT template using the data provided.
+         * @param {object} data The data to render.
+         * @param {object} instance The expanded mojit instance.
+         * @param {object} template The view object from RS to render with format:
+         * {'content-path': 'path to view', content: 'cached string'}.
+         * @param {object} adapter The output adapter to use.
+         * @param {object} meta Optional metadata.
+         * @param {boolean} more Whether there is more to be rendered
+         */
+        render: function (data, instance, template, adapter, meta, more) {
+            var cacheTemplates = (this.options.cacheTemplates === false ? false : true),
+                handler = function (err, obj) {
+                    var output;
+
+                    if (err) {
+                        adapter.error(err);
+                        return;
+                    }
+
+                    try{
+                        template = doT.compile(obj.raw, obj.partials);
+                        output = template(data);
+                    }catch(e){
+                        output = e;
+                    }
+
+                    // HookSystem::StartBlock
+                    Y.mojito.hooks.hook('doT', adapter.hook, 'end', template);
+                    // HookSystem::EndBlock
+
+                    if (more) {
+                        adapter.flush(output, meta);
+                    } else {
+                        adapter.done(output, meta);
+                    }
+                },
+                stack,
+                cacheKey,
+                fn,
+                partial,
+                partials;
+
+            // HookSystem::StartBlock
+            Y.mojito.hooks.hook('doT', adapter.hook, 'start', template);
+            // HookSystem::EndBlock
+
+            // support for legacy url instead of a view object
+            if (Y.Lang.isString(template)) {
+                Y.log('[view] argument in [render] method should be an object', 'warn', NAME);
+                template = {
+                    'content-path': template
+                };
+            }
+
+            cacheKey = template['content-path'];
+
+            if (cacheTemplates && cache[cacheKey]) {
+                handler(null, cache[cacheKey]);
+                return;
+            }
+
+            stack = new Y.Parallel();
+            partials = {};
+
+            // first item in the asyc queue is the actual view
+            this._getTemplateObj(template, stack.add(function (err, obj) {
+                if (err) {
+                    Y.log('Error trying to compile view ' + cacheKey, 'error', NAME);
+                    Y.log(err, 'error', NAME);
+                    return;
+                }
+                cache[cacheKey] = obj;
+            }));
+
+            // after the first item, we just add any partial
+            if (instance && instance.partials && Y.Object.keys(instance.partials).length > 0) {
+                fn = function (partial, err, obj) {
+                    if (err) {
+                        Y.log('Error trying to compile partial [' + partial + '] on view ' +
+                            cacheKey, 'error', NAME);
+                        Y.log(err, 'error', NAME);
+                        return;
+                    }
+                    partials[partial] = obj.raw;
+                };
+                for (partial in instance.partials) {
+                    if (instance.partials.hasOwnProperty(partial)) {
+                        this._getTemplateObj(instance.partials[partial],
+                            stack.add(Y.bind(fn, this, partial)));
+                    }
+                }
+            }
+
+            // finally, let's just put the compiled view and partials together
+            stack.done(function () {
+                if (!cache[cacheKey]) {
+                    handler(new Error("Error trying to render view " + cacheKey));
+                    return;
+                }
+                cache[cacheKey].partials = partials;
+                handler(null, cache[cacheKey]);
+            });
+
+        },
+
+        /**
+         * Stringify the doT template.
+         * @param {string} tmpl The name of the template to render.
+         * @return {string} the string representation of the template
+         * that can be sent to the client side.
+         */
+        compiler: function (tmpl, callback) {
+            this._getTemplateObj(tmpl, function (err, obj) {
+                callback(err, JSON.stringify(obj.raw));
+            });
+        },
+        
+        precompile: function (tmpl, callback) {
+            Y.log("Precomile");
+        },
+
+        /**
+         * Build a compiled doT template, plus
+         * a raw string representation of the template.
+         * @private
+         * @param {object|string} template The view object from RS to render with format:
+         * {'content-path': 'path to view', content: 'cached string'} or a string with the
+         * fullpath of the template to be loaded.
+         * @param {function} callback The function that is called with the compiled template
+         */
+        _getTemplateObj: function (template, callback) {
+            var fn = function (err, str) {
+                    if (err) {
+                        callback(err);
+                        return;
+                    }
+                    callback(null, {
+                        raw: str
+                    });
+                };
+            if (template.content) {
+                fn(null, template.content);
+            } else {
+                this._loadTemplate((typeof template === 'string' ? template : template['content-path']), fn);
+            }
+        },
+
+        /**
+         * Loads a template from the file system
+         * @param {string} tmpl The location of the template file
+         * @param {function} callback The callback to call with the template contents
+         * @private
+         */
+        _loadTemplate: function (tmpl, callback) {
+            fs.readFile(tmpl, 'utf8', function (err, data) {
+                callback(err, data);
+            });
+        }
+    };
+
+    Y.namespace('mojito.addons.viewEngines').doT = doTAdapter;
+
+}, '0.1.0', {requires: [
+    'mojito',
+    'parallel',
+    'mojito-hooks',
+    'doT'
+]});


### PR DESCRIPTION
I've added doT templates as an alternative view engine. It's MIT license, dead simple, SUPER fast, flexible, and in this implementation more fault tolerant than HB. This implementation has support for partials. I haven't made helpers work because they aren't in doT. It would be easy to add a helpers object to the data object going into the compiler that are just references to functions to be used in the template.

I've been using it on one major project and would really like to have dot available on other smaller projects as part of the core mojito lib.

More on doT.
http://olado.github.io/doT/index.html

Benchmarks:

doT is ~46x faster

Chrome 26.0.1386
Handlebars.js:
63,263 ops/sec

Chrome 26.0.1386 (2)
doT.js:
2,943,894 ops/sec
