### PR TITLE
making mojito to work on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
-  - "0.6"
 env:
   - "testtype=unit"
   - "testtype=func"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,10 @@ Deprecations, Removals
 Features
 --------
 
+* PR [#1103] Bringing `windows` to the front row by adding *partial* support for mojito on windows. We plan to consolidate this
+going forward, but until `tracisci` supports `windows` as part of the build process to do sanity check, we
+cannot guarantee that everything will work on `windows`.
+
 Bug Fixes
 ---------
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,8 +11,7 @@ Features
 --------
 
 * PR [#1103] Bringing `windows` to the front row by adding *partial* support for mojito on windows. We plan to consolidate this
-going forward, but until `tracisci` supports `windows` as part of the build process to do sanity check, we
-cannot guarantee that everything will work on `windows`.
+going forward, but until after [travis-ci.org](http://travis-ci.org/) supports `windows` [environment](http://about.travis-ci.org/docs/user/ci-environment/) as part of the build process to do sanity check, we cannot guarantee that everything will work on `windows`.
 
 Bug Fixes
 ---------

--- a/lib/app/addons/rs/url.js
+++ b/lib/app/addons/rs/url.js
@@ -23,6 +23,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
     var libfs   = require('fs'),
         liburl  = require('url'),
         libpath = require('path'),
+        libutil = require('../../../util.js'),
         existsSync = libfs.existsSync || libpath.existsSync,
         URL_PARTS = ['frameworkName', 'appName', 'prefix'],
         // TODO:  needs a more future-proof way to do this
@@ -152,7 +153,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
             var env = evt.args.env,
                 mojitRes = evt.args.mojitRes,
                 details = evt.mojitDetails;
-            details.assetsRoot = mojitRes.url + '/assets';
+            details.assetsRoot = libutil.webpath(mojitRes.url, 'assets');
         },
 
 
@@ -182,7 +183,7 @@ YUI.add('addon-rs-url', function(Y, NAME) {
                 // in conjuntion with "base", "comboBase" and "root"
                 // from application.json->yui->config
                 urlParts.push(res.yui.name + '.js');
-                res.url = urlParts.join('/');
+                res.url = libutil.webpath(urlParts);
                 return;
             }
 
@@ -212,13 +213,13 @@ YUI.add('addon-rs-url', function(Y, NAME) {
 
             if ('mojit' === res.type) {
                 if ('shared' !== res.name) {
-                    res.url = urlParts.join('/');
+                    res.url = libutil.webpath(urlParts);
                 }
                 return;
             }
 
             urlParts.push(relativePath);
-            res.url = urlParts.join('/');
+            res.url = libutil.webpath(urlParts);
         }
 
 

--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -26,6 +26,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
         libvm   = require('vm'),
         libmime = require('mime'),
         liburl  = require('url'),
+        libutil = require('../../../util.js'),
 
         WARN_SERVER_MODULES = /\b(dom-[\w\-]+|node-[\w\-]+|io-upload-iframe)/ig,
         MODULE_SUBDIRS = {
@@ -130,7 +131,6 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 '},"",{requires:["loader-base"]});'
         };
 
-
     function RSAddonYUI() {
         RSAddonYUI.superclass.constructor.apply(this, arguments);
     }
@@ -163,7 +163,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
 
             this.staticAppConfig = config.host.getStaticAppConfig() || {};
             this.staticHandling = this.staticAppConfig.staticHandling || {};
-            this.staticPrefix = libpath.join('/', (this.staticHandling.prefix || 'static'), "/");
+            this.staticPrefix = libutil.webpath('/', (this.staticHandling.prefix || 'static'), "/");
             this.yuiConfig = (this.staticAppConfig.yui && this.staticAppConfig.yui.config) || {};
             this.langs = {};            // keys are list of languages in the app, values are simply "true"
             this.resContents = {};      // res.id: contents
@@ -253,7 +253,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
          */
         getYUIConfig: function(ctx) {
             var version = Y.version,
-                yuiPrefix = libpath.join(this.staticPrefix, 'yui/'),
+                yuiPrefix = libutil.webpath(this.staticPrefix, 'yui/'),
                 appConfig = this.get('host').getAppConfig(ctx),
                 yuiConfig;
 
@@ -779,7 +779,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                     modules[name] = store.makeStaticHandlerDetails({
                         type: 'yui-module',
                         name: name,
-                        url: libpath.join(this.staticPrefix, 'yui', modules[name].path),
+                        url: libutil.webpath(this.staticPrefix, 'yui', modules[name].path),
                         path: modules[name].path,
                         source: {
                             fs: {

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -102,7 +102,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             'model': 'server',
             'spec': 'common',
             'view': 'common'
-        };
+        },
+        PATH_SEP = require('path').sep;
 
     libs.fs = require('fs');
     libs.glob = require('glob');
@@ -792,9 +793,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             for (p = 0; p < routesFiles.length; p += 1) {
                 path = routesFiles[p];
                 // relative paths are relative to the application
-                if ('/' !== path.charAt(1)) {
-                    path = this._libs.path.join(this._config.root, path);
-                }
+                path = this._libs.path.resolve(this._config.root, path);
                 routes = this.config.readConfigYCB(path, ctx);
                 Y.mix(out, routes, true);
             }
@@ -1035,7 +1034,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 rootDir: dir,
                 rootType: dirType,
                 subDir: subdir,
-                subDirArray: subdir.split('/'),
+                subDirArray: subdir.split(PATH_SEP),
                 isFile: isFile,
                 ext: this._libs.path.extname(file)
             };
@@ -1344,7 +1343,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 // special case
                 if ('addon' === type && ADDON_SUBTYPES_APPLEVEL[res.subtype]) {
@@ -1370,7 +1369,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return res;
             }
@@ -1414,7 +1413,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid view filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join('/'), baseParts.join('.'));
+                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 // for performance reasons, we might want to preload all
                 // views in memory.
@@ -1779,11 +1778,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 children,
                 childName,
                 childPath;
-
-            if ('/' !== dir.charAt(0)) {
-                dir = this._libs.path.join(this._config.root, dir);
-            }
-
+            dir = this._libs.path.resolve(this._config.root, dir);
             if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
             }
@@ -1817,10 +1812,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 ress,
                 r,
                 res;
-
-            if ('/' !== dir.charAt(0)) {
-                dir = this._libs.path.join(this._config.root, dir);
-            }
+            dir = this._libs.path.resolve(this._config.root, dir);
 
             if (!(this._libs.fs.existsSync || this._libs.path.existsSync)(dir)) {
                 return;
@@ -1981,7 +1973,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if ('object' === typeof ret) {
                     if (ret.skipSubdirParts) {
                         source.fs.subDirArray = source.fs.subDirArray.slice(ret.skipSubdirParts);
-                        source.fs.subDir = source.fs.subDirArray.join('/') || '.';
+                        source.fs.subDir = source.fs.subDirArray.join(PATH_SEP) || '.';
                     }
                     res = me.parseResourceVersion(source, ret.type, ret.subtype, mojitType);
                     if ('object' === typeof res) {
@@ -2095,9 +2087,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 glob;
             for (i = 0; i < list.length; i += 1) {
                 glob = list[i];
-                if ('/' !== glob.charAt(0)) {
-                    glob = this._libs.path.join(prefix, glob);
-                }
+                glob = this._libs.path.resolve(prefix, glob);
                 found = found.concat(this._libs.glob.sync(glob, {}));
             }
             return found;

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -110,7 +110,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
     libs.path = require('path');
     libs.semver = require('semver');
     libs.walker = require('./package-walker.server');
-
+    libs.util = require('../../util.js');
 
     // The Affinity object is to manage the use of the affinity string in
     // filenames.  Some files have affinities that have multiple parts
@@ -705,7 +705,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 if (res.type === 'view') {
                     template = {
                         'content-path': (env === 'client' ?
-                                this._libs.path.join(this._appConfigStatic.pathToRoot || '', res.url) :
+                                this._libs.util.webpath(this._appConfigStatic.pathToRoot || '', res.url) :
                                 res.source.fs.fullPath),
                         'content': res.content,
                         'engine': res.view.engine
@@ -1343,7 +1343,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
+                res.name = this._libs.util.webpath(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 // special case
                 if ('addon' === type && ADDON_SUBTYPES_APPLEVEL[res.subtype]) {
@@ -1369,7 +1369,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid ' + type + ' filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
+                res.name = this._libs.util.webpath(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return res;
             }
@@ -1387,7 +1387,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid spec filename. skipping ' + source.fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(source.fs.subDir, baseParts.join('.'));
+                res.name = this._libs.util.webpath(source.fs.subDir, baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return res;
             }
@@ -1413,7 +1413,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     Y.log('invalid view filename. skipping ' + fs.fullPath, 'warn', NAME);
                     return;
                 }
-                res.name = this._libs.path.join(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
+                res.name = this._libs.util.webpath(fs.subDirArray.join(PATH_SEP), baseParts.join('.'));
                 res.id = [res.type, res.subtype, res.name].join('-');
                 // for performance reasons, we might want to preload all
                 // views in memory.

--- a/lib/app/middleware/mojito-handler-static.js
+++ b/lib/app/middleware/mojito-handler-static.js
@@ -28,6 +28,7 @@
  */
 var liburl   = require('url'),
     libpath  = require('path'),
+    libutil  = require('../../util.js'),
 
     NAME = 'StaticHandler';
 
@@ -177,7 +178,7 @@ function staticProvider(store, logger, Y) {
         options = appConfig.staticHandling || {},
         cache   = options.cache,
         maxAge  = options.maxAge,
-        staticPath = liburl.resolve('/', (options.prefix || 'static') + '/'),
+        staticPath = libutil.webpath(liburl.resolve('/', (options.prefix || 'static') + '/')),
         comboPath = '/combo~';
 
     if (cache && !maxAge) {

--- a/lib/app/middleware/mojito-handler-tunnel-parser.js
+++ b/lib/app/middleware/mojito-handler-tunnel-parser.js
@@ -17,6 +17,7 @@ var RE_TRAILING_SLASHES = /\/+$/;
 module.exports = function (config) {
     var liburl      = require('url'),
         libpath     = require('path'),
+        libutil     = require('../../util.js'),
         appConfig   = config.store.getAppConfig({}) || {},
         staticPrefix,
         tunnelPrefix;
@@ -34,8 +35,9 @@ module.exports = function (config) {
         tunnelPrefix = libpath.normalize('/' + tunnelPrefix);
     }
 
-    staticPrefix = staticPrefix || '/static';
-    tunnelPrefix = tunnelPrefix || '/tunnel';
+    // normalizing the prefixes (this helps with windows runtime)
+    staticPrefix = libutil.webpath(staticPrefix || '/static');
+    tunnelPrefix = libutil.webpath(tunnelPrefix || '/tunnel');
 
     return function (req, res, next) {
         var hasTunnelPrefix = req.url.indexOf(tunnelPrefix) === 0,

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*jslint node:true, nomen: true */
+
+'use strict';
+
+var libpath = require('path');
+
+/**
+Produces a normalized web path by joining all the parts and normalizing the
+filesystem-like path into web compatible url. This is useful when you have to
+generate urls based on filesystem path where unix uses `/` and windows uses `\\`.
+Node is pretty smart and it will do the heavy lifting, we just need to adjust
+the separtor so it uses the `/`. This method also support relative and absolute
+paths.
+
+    util.webpath('foo/bar' ,'baz');
+    // => foo/bar/baz
+    util.webpath('foo\\bar', 'baz/');
+    // => foo/bar/baz/
+    util.webpath('./foo/bar', './baz');
+    // => foo/bar/baz
+    util.webpath(['foo', 'bar', 'baz']);
+    // => foo/bar/baz
+
+@method webpath
+@param {Array|String*} url the list of parts to be joined and normalized
+@return {String} The joined and normalized url
+**/
+exports.webpath = function (url) {
+    var args = [].concat.apply([], arguments),
+        parts = libpath.join.apply(libpath, args).split(libpath.sep);
+    return parts.join('/');
+};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "mojito": "bin/mojito"
     },
     "engines": {
-        "node": ">0.4",
+        "node": ">0.6",
         "npm": ">1.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "phantomjs": ">=1.8.0"
     },
     "scripts": {
-        "test": "cd tests && ./run.js test --browser phantomjs"
+        "test": "cd tests && node run.js test --browser phantomjs"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/tests/unit/lib/app/autoload/test-store.server.js
+++ b/tests/unit/lib/app/autoload/test-store.server.js
@@ -216,14 +216,14 @@ YUI().use(
             'server mojit view index.hb.html is loaded correctly': function() {
                 var instance = {type:'TestMojit3'};
                 store.expandInstance(instance, {}, function(err, instance){
-                    A.areSame('index.hb.html', instance.views.index['content-path'].split('/').pop());
+                    A.areSame('index.hb.html', instance.views.index['content-path'].split(libpath.sep).pop());
                 });
             },
 
             'server mojit view index.iphone.hb.html is loaded correctly': function(){
                 var instance = {type:'TestMojit3'};
                 store.expandInstance(instance, {device:'iphone'}, function(err, instance){
-                    A.areSame('index.iphone.hb.html', instance.views.index['content-path'].split('/').pop());
+                    A.areSame('index.iphone.hb.html', instance.views.index['content-path'].split(libpath.sep).pop());
                 });
             },
 

--- a/tests/unit/lib/app/commands/test-gv.js
+++ b/tests/unit/lib/app/commands/test-gv.js
@@ -113,15 +113,16 @@ YUI().use('mojito-test-extra', 'test', 'json-parse', 'json-stringify', function(
                 callbackCalled = true;
             });
             A.areSame(3, mockFs._log.length);
-            Y.TEST_CMP(['mkdirSync', fixtures + '/artifacts', 511], mockFs._log[0]);
-            Y.TEST_CMP(['mkdirSync', fixtures + '/artifacts/gv', 511], mockFs._log[1]);
+            Y.TEST_CMP(['mkdirSync', libpath.join(fixtures, '/artifacts'), 511], mockFs._log[0]);
+            Y.TEST_CMP(['mkdirSync', libpath.join(fixtures + '/artifacts/gv'), 511], mockFs._log[1]);
             Y.TEST_CMP('writeFileSync', mockFs._log[2][0]);
-            Y.TEST_CMP(fixtures + '/artifacts/gv/yui.server.dot', mockFs._log[2][1]);
+            Y.TEST_CMP(libpath.join(fixtures + '/artifacts/gv/yui.server.dot'), mockFs._log[2][1]);
 
             A.isTrue(callbackCalled, 'callback called');
             A.areSame(2, mockConsole._log.length, 'right number of log messages');
             A.areSame('Dotfile generated. To turn it into a graph, run the following:', mockConsole._log[0]);
-            A.areSame('$ dot -Tgif artifacts/gv/yui.server.dot > artifacts/gv/yui.server.gif', mockConsole._log[1]);
+            A.areSame('$ dot -Tgif ' + libpath.join('artifacts/gv/yui.server.dot') + ' > ' +
+                libpath.join('artifacts/gv/yui.server.gif'), mockConsole._log[1]);
 
             var graph = gvcmd.test.graph;
             var want = [

--- a/tests/unit/lib/app/commands/test-version.js
+++ b/tests/unit/lib/app/commands/test-version.js
@@ -57,7 +57,8 @@ YUI().use('test', function(Y) {
                 args: [Y.Mock.Value.Any],
                 run: function (err) {
                     A.isTrue(/no such file or directory/.test(err));
-                    A.isTrue(/mojits\/package.json/.test(err));
+                    A.isTrue(/mojits/.test(err));
+                    A.isTrue(/package.json/.test(err));
                 }
             });
             libutils.test.setConsole(mockConsole);


### PR DESCRIPTION
## Goal
- To support windows "partially" (which means, all unit tests and basic features tested, but not functional tests)
- To drop support for `nodejs@0.6` because that version does not support windows
  ## Steps to verify

With this commit very first commit, we get a dummy app working on windows, yay!

```
npm i mojito -g
mojito create app foo
cd foo
mojito create mojit bar
mojito start
```

then navigate to `http://localhost:8666/@bar/index`
## TODO
- [x] Test simple server side app
- [x] Test simple app with `HTMLFrameMojit` deployed to the client
- [x] Test `mojito test app .` in a simple app
- [x] Test rpc calls thru the tunnel (common example)
- [x] Unit tests to pass
