### PR TITLE
use ycb-based tokens like $$lib$$ instead of repeating subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "rimraf": ">2",
         "semver": "1.0.14",
         "wrench": "~1.3.9",
-        "ycb": "~1.0.0",
+        "ycb": "~1.0.5",
         "yui": "~3.9.1",
         "yuidocjs": "~0.3.14",
         "yuitest": "~0.7.4",
@@ -53,7 +53,7 @@
         "commander": "1.0.1",
         "mockery": "~1.4.0",
         "node-static": ">0.6.8",
-        "yahoo-arrow": ">=0.0.75"
+        "yahoo-arrow": "~0.0.76"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
+++ b/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider": {
             "analytics.common": {
                 "params": {

--- a/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
+++ b/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider": {
             "config.server": {
                 "params": {
@@ -18,7 +18,7 @@
             },
             "dispatch-helper.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.js,../../../../../../lib/app/addons/rs/config.js,../../../../../../lib/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/yui.js,../../../../../../lib/app/autoload/store.server.js,../../../../../../lib/app/addons/rs/url.js",
+                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/yui.js,$$config.lib$$/app/autoload/store.server.js,$$config.lib$$/app/addons/rs/url.js",
                     "test": "./test-dispatch-helper.js",
                     "driver": "nodejs"
                 },
@@ -34,7 +34,7 @@
             },
             "selector.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/config.js",
+                    "lib": "$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/config.js",
                     "test": "./test-selector.js",
                     "driver": "nodejs"
                 },
@@ -50,7 +50,7 @@
             },
             "yui.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/yui.js,../../../../../../lib/app/addons/rs/config.js,../../../../../../lib/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/url.js,../../../../../../lib/app/autoload/store.server.js",
+                    "lib": "$$config.lib$$/app/addons/rs/yui.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/url.js,$$config.lib$$/app/autoload/store.server.js",
                     "test": "./test-yui.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
+++ b/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "hb.client" : {
                 "params" : {
@@ -18,7 +18,7 @@
             },
             "hb.server" : {
                 "params" : {
-                    "lib": "./../../../../../../lib/app/addons/view-engines/hb.server.js",
+                    "lib": "$$config.lib$$/app/addons/view-engines/hb.server.js",
                     "test" : "./test-hb.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/autoload/autoload_test_descriptor.json
+++ b/tests/unit/lib/app/autoload/autoload_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../lib",
             "base": "../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "action-context.common": {
                 "params": {
@@ -19,7 +19,7 @@
             "dispatch.server": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",
-                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.server.js",
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,$$config.lib$$/app/autoload/dispatch.server.js",
                     "test": "./test-dispatch.server.js"
                 },
                 "group": "fw,unit,server"
@@ -27,7 +27,7 @@
             "dispatch.client": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",
-                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.client.js",
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,$$config.lib$$/app/autoload/dispatch.client.js",
                     "test": "./test-dispatch.client.js"
                 },
                 "group": "fw,unit,client"
@@ -105,7 +105,7 @@
             },
             "store.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/autoload/store.server.js,./../../../../../lib/app/addons/rs/config.js,./../../../../../lib/app/addons/rs/selector.js,./../../../../../lib/app/addons/rs/url.js,./../../../../../lib/app/addons/rs/yui.js",
+                    "lib": "$$config.lib$$/app/autoload/store.server.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/url.js,$$config.lib$$/app/addons/rs/yui.js",
                     "test": "./test-store.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/middleware/middleware_test_descriptor.json
+++ b/tests/unit/lib/app/middleware/middleware_test_descriptor.json
@@ -66,7 +66,7 @@
             },
             "router": {
                 "params": {
-                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,../../../../../lib/app/autoload/route-maker.common.js,../../../../../lib/app/autoload/util.common.js",
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,$$config.lib$$/app/autoload/route-maker.common.js,$$config.lib$$/app/autoload/util.common.js",
                     "test": "./test-router.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/mojits/mojits_test_descriptor.json
+++ b/tests/unit/lib/app/mojits/mojits_test_descriptor.json
@@ -10,7 +10,7 @@
         "dataprovider" : {
             "htmlframemojit-controller": {
                 "params": {
-                    "lib": "$$config.lib$$/app/mojits/HTMLFrameMojit/controller.server.js,./../../../../../lib/app/autoload/util.common.js",
+                    "lib": "$$config.lib$$/app/mojits/HTMLFrameMojit/controller.server.js,./$$config.lib$$/app/autoload/util.common.js",
                     "test": "./test-htmlframemojit-controller.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/lib_test_descriptor.json
+++ b/tests/unit/lib/lib_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../lib",
             "base": "../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "mojito": {
                 "params": {


### PR DESCRIPTION
requires ycb@1.0.5; previously only the first token would be replaced.

the tests pass locally, forcing mojito and arrow to use ycb@1.0.5. Travis/CI won't pass until deps specify ycb@1.0.5 (currently tagged "beta" not "latest").
