### PR TITLE
relying more on the adapter.page object to store appConfig and routes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,20 @@ version @VERSION@
 
 Notes
 -----
+* `ac.config.getAppConfig()` was reworked to improve performance by computing the app
+config once per request, and reuse across all the mojit instances in the same page using
+the `mojito-config-addon`. This means you have to be extra careful if you attempt to
+change that object, because it might affects other mojits in the same page.
+* `ac.config.getRoutes()` was reworked to improve performance by computing the app
+config once per request, and reuse across all the mojit instances in the same page using
+the `mojito-url-addon`. This means you have to be extra careful if you attempt to
+change that object, because it might affects other mojits in the same page.
 
 Deprecations, Removals
-------------
+----------------------
+* `ac.staticAppConfig` was a private api used by mojito to allocate static config for the app,
+and this is now removed. If you need access to the config, you can use `mojito-config-addon`
+to access `ac.config.getAppConfig()`.
 
 Features
 --------

--- a/lib/app/addons/ac/carrier.server.js
+++ b/lib/app/addons/ac/carrier.server.js
@@ -65,6 +65,5 @@ YUI.add('mojito-carrier-addon', function(Y, NAME) {
 
 }, '0.1.0', {requires: [
     'mojito',
-    'mojito-config-addon',
     'mojito-http-addon'
 ]});

--- a/lib/app/addons/ac/config.common.js
+++ b/lib/app/addons/ac/config.common.js
@@ -41,10 +41,9 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
      * @class Config.common
      */
     function Addon(command, adapter, ac) {
-        this._ctx = command.context;
         this._config = command.instance.config;
         this._def = command.instance.definition;
-        this._store = null;
+        this._page = adapter.page;
     }
 
 
@@ -86,7 +85,7 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
          * @return {object} the app config
          */
         getAppConfig: function() {
-            return this._store.getAppConfig(this._ctx);
+            return this._page.appConfig;
         },
 
 
@@ -96,19 +95,9 @@ YUI.add('mojito-config-addon', function(Y, NAME) {
          * @return {object} the routes
          */
         getRoutes: function() {
-            return this._store.getRoutes(this._ctx);
-        },
-
-
-        /**
-         * Internal method called by the Mojito framework.
-         * @method setStore
-         * @param {object} store the resource store
-         * @return {nothing}
-         */
-        setStore: function(store) {
-            this._store = store;
+            return this._page.routes;
         }
+
     };
 
     Y.namespace('mojito.addons.ac').config = Addon;

--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -58,9 +58,6 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
 
             var store = this.rs,
                 contextServer = this.ac.context,
-
-                appConfigServer = store.getAppConfig(contextServer),
-
                 contextClient,
                 appConfigClient,
                 yuiConfig = {},

--- a/lib/app/addons/ac/partial.common.js
+++ b/lib/app/addons/ac/partial.common.js
@@ -24,7 +24,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
         this.command = command;
         this.dispatch = ac._dispatch;
         this.ac = ac;
-        this.adapter = adapter;
+        this._page = adapter.page;
     }
 
 
@@ -55,7 +55,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
             mojitView = instance.views[view];
             data = data || {}; // default null data to empty view template
             renderer = new Y.mojito.ViewRenderer(mojitView.engine,
-                this.ac.staticAppConfig.viewEngine);
+                this._page.staticAppConfig.viewEngine);
 
             Y.log('Rendering "' + view + '" view for "' + (instance.id || '@' +
                 instance.type) + '"', 'debug', NAME);

--- a/lib/app/addons/ac/url.common.js
+++ b/lib/app/addons/ac/url.common.js
@@ -5,7 +5,7 @@
  */
 
 
-/*jslint anon:true, sloppy:true*/
+/*jslint anon:true, sloppy:true, nomen: true */
 /*global YUI*/
 
 
@@ -21,9 +21,8 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
      * @class Url.common
      */
     function UrlAcAddon(command, adapter, ac) {
-        this.context = command.context;
-        this.rs = null;
-        this.pathToRoot = ac.staticAppConfig.pathToRoot;
+        this._page = adapter.page;
+        this.pathToRoot = this._page.staticAppConfig.pathToRoot;
         this.maker =  null;
     }
 
@@ -110,20 +109,10 @@ YUI.add('mojito-url-addon', function(Y, NAME) {
         getRouteMaker: function() {
             if (!this.maker) {
                 this.maker = new Y.mojito.RouteMaker(
-                    this.rs.getRoutes(this.context)
+                    this._page.routes
                 );
             }
             return this.maker;
-        },
-
-        /**
-         * Storing a reference to the store.
-         * @method setStore
-         * @private
-         * @param {ResourceStore} rs The resource store instance.
-         */
-        setStore: function(rs) {
-            this.rs = rs;
         }
 
     };

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -307,9 +307,6 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         this.instance = command.instance;
         this._adapter = opts.adapter;
 
-        // pathToRoot, viewEngine, amoung others will be available through this.
-        this.staticAppConfig = (this._adapter.page && this._adapter.page.staticAppConfig) || store.getStaticAppConfig();
-
         // Create a function which will properly delegate to the dispatcher to
         // perform the actual processing.
         this._dispatch = function(command, adapter) {

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -335,7 +335,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
         // Reap the request/ac process within the timeout. If ac.done or
         // ac.error is invoked by user code prior to the time limit this
         // timer will be cleared.
-        if (this.staticAppConfig.actionTimeout) {
+        if (this._adapter.page.staticAppConfig.actionTimeout) {
             this._timer = setTimeout(function() {
                 var err,
                     msg = 'Killing potential zombie context for Mojit type: ' +
@@ -357,7 +357,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                     Y.log('ac.done() called after timeout. results lost', 'warn', NAME);
                 };
 
-            }, this.staticAppConfig.actionTimeout);
+            }, this._adapter.page.staticAppConfig.actionTimeout);
         }
 
         controller[actionFunction](this);
@@ -576,7 +576,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                 // TODO: we might want to use a view renderer factory
                 // that can provide caching capabilities for better performance
                 // instead of creating objects over and over again per mojit instance
-                renderer = new Y.mojito.ViewRenderer(mojitView.engine, this.staticAppConfig.viewEngine);
+                renderer = new Y.mojito.ViewRenderer(mojitView.engine, page.staticAppConfig.viewEngine);
                 renderer.render(data, instance, mojitView, adapter, meta, more);
 
             } else {

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -403,7 +403,6 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                 mojitView,
                 renderer = null,
                 contentType,
-                pageData,
                 instanceData;
 
             // TODO: optimize this. it is not needed if there is no binder

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -342,10 +342,11 @@ YUI.add('mojito-client', function(Y, NAME) {
                     globalHookHandler: globalHookHandler
                 };
 
-            this.page.staticAppConfig = appConfig;
+            // static app config and app config are equivalent in the client runtime
+            this.page.staticAppConfig = this.page.appConfig = appConfig;
 
-            // compiling routes that are used by store-client
-            config.routes = (new Y.mojito.RouteMaker(config.routes)).getComputedRoutes();
+            // compiling routes that are used by store-client or by any addon
+            this.page.routes = config.routes = (new Y.mojito.RouteMaker(config.routes)).getComputedRoutes();
 
             fireLifecycle('pre-init', forwardConfig);
             // if we didn't originaly have hooks enabled, copy back from config object.

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -326,7 +326,8 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
 
     function dispatcher(req, res, next) {
         var command = req.command,
-            outputHandler;
+            outputHandler,
+            context = req.context || {};
 
         if (!command) {
             next();
@@ -338,7 +339,11 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
             log: Y.log
         });
 
+        // storing the static app config as well as contextualized app config per request
         outputHandler.page.staticAppConfig = store.getStaticAppConfig();
+        outputHandler.page.appConfig = store.getAppConfig(context);
+        // compute routes once per request
+        outputHandler.page.routes = store.getRoutes(context);
 
         // HookSystem::StartBlock
         // enabling perf group

--- a/tests/unit/lib/app/addons/ac/test-assets.common.js
+++ b/tests/unit/lib/app/addons/ac/test-assets.common.js
@@ -13,7 +13,8 @@ YUI().use('mojito-assets-addon', 'test', 'array-extras', function(Y, NAME) {
     var suite = new Y.Test.Suite('mojito-assets-addon tests'),
         cases = {},
         A = Y.Assert,
-        AA = Y.ArrayAssert;
+        AA = Y.ArrayAssert,
+        addon;
 
     cases = {
         name: 'basics',

--- a/tests/unit/lib/app/addons/ac/test-config.common.js
+++ b/tests/unit/lib/app/addons/ac/test-config.common.js
@@ -25,6 +25,10 @@ YUI().use('mojito-config-addon', 'test', function(Y) {
                 config: configs,
                 definition: definitions
             }
+        }, {
+            page: {
+                appConfig: 'page app config'
+            }
         });
     }
 
@@ -110,6 +114,12 @@ YUI().use('mojito-config-addon', 'test', function(Y) {
             A.isNotUndefined(ac.getDefinition('d1'));
             A.isNotUndefined(ac.getDefinition('d2'));
             A.isNotUndefined(ac.getDefinition('d3'));
+        },
+
+        'test getAppConfig()': function() {
+            var ac = create();
+
+            A.areSame('page app config', ac.getAppConfig(), 'the app config should come from adapter.page.appConfig');
         }
 
     }));

--- a/tests/unit/lib/app/addons/ac/test-partial.common.js
+++ b/tests/unit/lib/app/addons/ac/test-partial.common.js
@@ -9,16 +9,20 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
         Assert = Y.Assert,
         ObjectAssert = Y.ObjectAssert,
         Mock = Y.Mock,
-        ac;
+        ac,
+        adapter;
 
     suite.add(new Y.Test.Case({
 
         name: 'render() tests',
 
         'setUp': function () {
-            ac = {
-                staticAppConfig: {
-                    viewEngine: {}
+            ac = {};
+            adapter = {
+                page: {
+                    staticAppConfig: {
+                        viewEngine: 'page static app config view engine'
+                    }
                 }
             };
         },
@@ -36,7 +40,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                 args: ['View "missingView" not found']
             });
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, ac);
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, ac);
             addon.render(null, 'missingView', mockCallback.callback);
 
             Mock.verify(mockCallback);
@@ -56,7 +60,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                     }
                 };
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, ac);
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, ac);
 
             var mockRenderer = Mock();
             Mock.expect(mockRenderer, {
@@ -71,7 +75,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
             var mockYMojito = Mock();
             Mock.expect(mockYMojito, {
                 method: 'ViewRenderer',
-                args: ['myViewEngine', ac.staticAppConfig.viewEngine],
+                args: ['myViewEngine', 'page static app config view engine'],
                 returns: mockRenderer
             });
 
@@ -109,7 +113,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                 };
             };
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, ac);
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, ac);
             addon.render(null, 'myView', mockCallback.callback);
 
             Y.mojito.ViewRenderer = yMojitoViewRenderer;
@@ -152,7 +156,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
             ac.context = 'myContext';
             ac._dispatch = mockDispatch.dispatch;
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, ac);
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, ac);
             addon.invoke('myAction', options, null);
 
             Mock.verify(mockDispatch);
@@ -181,7 +185,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                 })]
             });
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, { _dispatch: mockDispatch.dispatch });
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, { _dispatch: mockDispatch.dispatch });
             addon.invoke(null, { params: {} }, mockCallback.callback);
 
             Mock.verify(mockDispatch);
@@ -199,7 +203,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                 returns: {}
             });
 
-            var addon = new Y.mojito.addons.ac.partial(command, null, {
+            var addon = new Y.mojito.addons.ac.partial(command, adapter, {
                 _dispatch: function() {},
                 params: mockParams
             });

--- a/tests/unit/lib/app/addons/ac/test-url.common.js
+++ b/tests/unit/lib/app/addons/ac/test-url.common.js
@@ -11,7 +11,8 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
         AA = Y.ArrayAssert,
         OA = Y.ObjectAssert,
         RouteMaker,
-        acMock;
+        acMock,
+        adapterMock;
 
     cases = {
         name: 'make url tests',
@@ -19,9 +20,13 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
         setUp: function() {
             // Capture the real RouteMaker
             RouteMaker = Y.mojito.RouteMaker;
-            acMock = {
-                staticAppConfig: {}
+            adapterMock = {
+                page: {
+                    staticAppConfig: {},
+                    routes: 'routes'
+                }
             };
+            acMock = {};
         },
 
         tearDown: function() {
@@ -40,17 +45,15 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.find('myid.myaction?foo=bar', 'get');
             A.areSame('ohhai url', url);
         },
 
         'test find url (get) using real RouteMaker': function() {
-            var addon, url, routes = {
+            var addon, url;
+            adapterMock.page.routes = {
                 'aroute': {
                     'call': 'foo',
                     'path': '/a/b/c/',
@@ -61,10 +64,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
             //need to use real find() which needs real RouteMaker
             Y.mojito.RouteMaker = RouteMaker;
 
-            addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return routes; }
-            });
+            addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.find('/a/b/c/', 'get');
 
@@ -89,7 +89,8 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
         },
 
         'test find http://url?with=params (get) using real RouteMaker': function() {
-            var addon, url, routes = {
+            var addon, url;
+            adapterMock.page.routes = {
                 'aroute': {
                     'call': 'foo',
                     'path': '/a/b/c/',
@@ -100,10 +101,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
             //need to use real find() which needs real RouteMaker
             Y.mojito.RouteMaker = RouteMaker;
 
-            addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return routes; }
-            });
+            addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.find('http://xyz.com/a/b/c/?a=1&b=2', 'get');
             A.areSame('foo', url.call);
@@ -122,10 +120,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.find('myid.myaction', 'post');
             A.areSame('ohhai url', url);
@@ -143,10 +138,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', {foo: 'bar'}, 'get');
 
@@ -167,10 +159,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', {foo: 'bar'}, 'get', {a:1, b:2});
             A.areSame('ohhai url', url);
@@ -188,10 +177,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', {foo: 'bar' }, 'post');
             A.areSame('ohhai url', url);
@@ -208,10 +194,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction');
             A.areSame('ohhai url', url);
@@ -229,10 +212,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', {foo:'bar'}, 'get');
             A.areSame('ohhai url', url);
@@ -249,10 +229,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction');
             A.areSame('ohhai url', url);
@@ -270,10 +247,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', {foo: 'bar'}, 'get', {foo: 'baz'});
             A.areSame('ohhai url', url);
@@ -294,10 +268,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', 'foo=bar&bar=baz', 'get', 'a=1&b=2');
             A.areSame('ohhai url', url);
@@ -320,10 +291,7 @@ YUI().use('mojito-url-addon', 'test', 'querystring', function(Y) {
                     }
                 };
             };
-            var addon = new Y.mojito.addons.ac.url({}, null, acMock);
-            addon.setStore({
-                getRoutes: function() { return 'routes'; }
-            });
+            var addon = new Y.mojito.addons.ac.url({}, adapterMock, acMock);
 
             url = addon.make('myid', 'myaction', ['foo', 'bar'], 'get', ['a', 'b']);
             A.areSame('ohhai url', url);

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -9,14 +9,8 @@ YUI().use('mojito-action-context', 'test', function (Y) {
         acStash = {},
         A = Y.Assert,
         OA = Y.ObjectAssert,
-        store = {
-            getStaticAppConfig: function() {
-                return 'static app config';
-            },
-            getRoutes: function(ctx) {
-                return "routes";
-            }
-        };
+        adapter,
+        store;
 
     suite.add(new Y.Test.Case({
 
@@ -26,6 +20,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             Y.Object.each(Y.namespace('mojito.addons').ac, function(v, k) {
                 acStash[k] = v;
             });
+            store = {};
+            adapter = {
+                page: {
+                    staticAppConfig: 'static app config'
+                },
+                done: function(data, meta) {},
+                error: function(err) {}
+            };
         },
 
         tearDown: function() {
@@ -53,16 +55,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 models: {},
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                flush: function (data, meta) {
-                    A.areSame(data, 'test flush data', 'improper test data');
-                }
+            adapter.flush = function (data, meta) {
+                A.areSame(data, 'test flush data', 'improper test data');
             };
 
             ac.flush('test flush data');
@@ -85,16 +85,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 models: {},
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                done: function (data, meta) {
-                    A.areSame(data, 'test done data', 'improper test data');
-                }
+            adapter.done = function (data, meta) {
+                A.areSame(data, 'test done data', 'improper test data');
             };
 
             ac.done('test done data');
@@ -117,16 +115,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 models: {},
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                error: function (data, meta) {
-                    A.areSame(data, 'test error data', 'improper test data');
-                }
+            adapter.error = function (data, meta) {
+                A.areSame(data, 'test error data', 'improper test data');
             };
 
             ac.error('test error data');
@@ -148,7 +144,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 models: {},
                 controller: {index: function() {}},
                 dispatcher: 'the dispatcher',
@@ -173,7 +169,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         acAddons: ['custom']
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
@@ -197,11 +193,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: 'views'
                     }
                 },
-                adapter: {
-                    page: {
-                        staticAppConfig: {foo: 'bar'}
-                    }
-                },
+                adapter: adapter,
                 models: {},
                 controller: {index: function() {}},
                 store: store
@@ -210,8 +202,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             A.areSame('Type', ac.type, 'bad type');
             A.areSame('index', ac.action, 'bad action');
             A.areSame('context', ac.context, 'bad context');
-            A.areSame(1, Y.Object.keys(ac.staticAppConfig).length, 'bad staticAppConfig object');
-            A.areSame('bar', ac.staticAppConfig.foo, 'bad staticAppConfig.foo value');
 
             A.areSame('the dispatcher', ac.dispatcher,
                 "dispatcher wasn't stashed.");
@@ -259,7 +249,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         ]
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
@@ -273,6 +263,20 @@ YUI().use('mojito-action-context', 'test', function (Y) {
 
         name: 'general tests',
 
+        setUp: function() {
+            store = {};
+            adapter = {
+                page: {
+                    staticAppConfig: 'static app config'
+                },
+                done: function(data, meta) {},
+                error: function(err) {}
+            };
+        },
+
+        tearDown: function() {
+        },
+
         'test flush calls done with "more"': function() {
             var doneCalled;
             var ac = new Y.mojito.ActionContext({
@@ -285,7 +289,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         acAddons: []
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
@@ -315,19 +319,17 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                done: function(data, meta) {
-                    var ct = meta.http.headers['content-type'];
-                    doneCalled = true;
-                    A.areSame('hi',data, 'bad string to done');
-                    A.areSame(1, ct.length, "should be only one content-type header");
-                    A.areSame('text/plain; charset=utf-8', ct[0]);
-                }
+            adapter.done = function(data, meta) {
+                var ct = meta.http.headers['content-type'];
+                doneCalled = true;
+                A.areSame('hi',data, 'bad string to done');
+                A.areSame(1, ct.length, "should be only one content-type header");
+                A.areSame('text/plain; charset=utf-8', ct[0]);
             };
 
             ac.done('hi');
@@ -348,19 +350,17 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                done: function(data, meta) {
-                    var ct = meta.http.headers['content-type'];
-                    doneCalled = true;
-                    A.areSame('hi',data, 'bad string to done');
-                    A.areSame(1, ct.length, "should be only one content-type header");
-                    A.areSame('my favorite type', ct[0]);
-                }
+            adapter.done = function(data, meta) {
+                var ct = meta.http.headers['content-type'];
+                doneCalled = true;
+                A.areSame('hi',data, 'bad string to done');
+                A.areSame(1, ct.length, "should be only one content-type header");
+                A.areSame('my favorite type', ct[0]);
             };
 
             ac.done('hi', {
@@ -387,20 +387,18 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
             var json = {hi:'there'};
 
-            ac._adapter = {
-                done: function(data, meta) {
-                    var ct = meta.http.headers['content-type'];
-                    doneCalled = true;
-                    A.areSame(Y.JSON.stringify(json), data, 'bad string to done');
-                    A.areSame(1, ct.length, "should be only one content-type header");
-                    A.areSame('application/json; charset=utf-8', ct[0]);
-                }
+            adapter.done = function(data, meta) {
+                var ct = meta.http.headers['content-type'];
+                doneCalled = true;
+                A.areSame(Y.JSON.stringify(json), data, 'bad string to done');
+                A.areSame(1, ct.length, "should be only one content-type header");
+                A.areSame('application/json; charset=utf-8', ct[0]);
             };
 
             ac.done(json, 'json');
@@ -421,20 +419,18 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
             var json = {hi:'there'};
 
-            ac._adapter = {
-                done: function(data, meta) {
-                    var ct = meta.http.headers['content-type'];
-                    doneCalled = true;
-                    A.areSame('<xml><hi>there</hi></xml>', data, 'bad string to done');
-                    A.areSame(1, ct.length, "should be only one content-type header");
-                    A.areSame('application/xml; charset=utf-8', ct[0]);
-                }
+            adapter.done = function(data, meta) {
+                var ct = meta.http.headers['content-type'];
+                doneCalled = true;
+                A.areSame('<xml><hi>there</hi></xml>', data, 'bad string to done');
+                A.areSame(1, ct.length, "should be only one content-type header");
+                A.areSame('application/xml; charset=utf-8', ct[0]);
             };
 
             ac.done(json, 'xml');
@@ -455,19 +451,17 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
             var data = 'data';
             var meta = {};
 
-            ac._adapter = {
-                done: function(d, m) {
-                    doneCalled = true;
-                    A.areSame(data, d, 'bad data to done');
-                    A.areSame(meta, m, 'bad meta to done');
-                }
+            adapter.done = function(d, m) {
+                doneCalled = true;
+                A.areSame(data, d, 'bad data to done');
+                A.areSame(meta, m, 'bad meta to done');
             };
 
             ac.done(data, meta);
@@ -512,16 +506,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         }
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
             var data = {};
             var meta = { view: {name: 'viewName'} };
-            ac._adapter = {
-                done: function() {
-                    A.fail('done should not be called, the view renderer should be calling it');
-                }
+            adapter.done = function() {
+                A.fail('done should not be called, the view renderer should be calling it');
             };
 
             ac.done(data, meta, false);
@@ -558,17 +550,15 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         }
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
 
-            ac._adapter = {
-                done: function(data, meta) {
-                    doneCalled = true;
-                    A.isObject(meta.binders.binderid, 'no binder id');
-                    A.isUndefined(meta.binders.binderid.children.params, 'children.params should be undefined');
-                }
+            adapter.done = function(data, meta) {
+                doneCalled = true;
+                A.isObject(meta.binders.binderid, 'no binder id');
+                A.isUndefined(meta.binders.binderid.children.params, 'children.params should be undefined');
             };
             // mock view renderer
             var VR = Y.mojito.ViewRenderer;
@@ -594,15 +584,14 @@ YUI().use('mojito-action-context', 'test', function (Y) {
         },
 
         'test timer trigger done': function() {
-            var store = {
-                getStaticAppConfig: function() {
-                    return {
-                        actionTimeout: 1
-                    };
-                },
-                getRoutes: function(ctx) {
-                    return 'routes';
-                }
+            adapter.page.staticAppConfig = {
+                actionTimeout: 1
+            };
+            adapter.done = function(data, meta) {
+                adapterDoneCalled = true;
+            };
+            adapter.error = function(err) {
+                adapterErrorCalled = true;
             };
             var adapterDoneCalled = false;
             var adapterErrorCalled = false;
@@ -633,27 +622,19 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     }
                 },
                 store: store,
-                adapter: {
-                    done: function(data, meta) {
-                        adapterDoneCalled = true;
-                    },
-                    error: function(err) {
-                        adapterErrorCalled = true;
-                    }
-                }
+                adapter: adapter
             });
         },
 
         'test timer notrigger done': function() {
-            var store = {
-                getStaticAppConfig: function() {
-                    return {
-                        actionTimeout: 1000
-                    };
-                },
-                getRoutes: function(ctx) {
-                    return 'routes';
-                }
+            adapter.page.staticAppConfig = {
+                actionTimeout: 1000
+            };
+            adapter.done = function(data, meta) {
+                adapterDoneCalled = true;
+            };
+            adapter.error = function(err) {
+                adapterErrorCalled = true;
             };
             var adapterDoneCalled = false;
             var adapterErrorCalled = false;
@@ -682,27 +663,19 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     }
                 },
                 store: store,
-                adapter: {
-                    done: function(data, meta) {
-                        adapterDoneCalled = true;
-                    },
-                    error: function(err) {
-                        adapterErrorCalled = true;
-                    }
-                }
+                adapter: adapter
             });
         },
 
         'test timer notrigger error': function() {
-            var store = {
-                getStaticAppConfig: function() {
-                    return {
-                        actionTimeout: 1000
-                    };
-                },
-                getRoutes: function(ctx) {
-                    return 'routes';
-                }
+            adapter.page.staticAppConfig = {
+                actionTimeout: 1000
+            };
+            adapter.done = function(data, meta) {
+                adapterDoneCalled = true;
+            };
+            adapter.error = function(err) {
+                adapterErrorCalled = true;
             };
             var adapterDoneCalled = false;
             var adapterErrorCalled = false;
@@ -731,14 +704,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     }
                 },
                 store: store,
-                adapter: {
-                    done: function(data, meta) {
-                        adapterDoneCalled = true;
-                    },
-                    error: function(err) {
-                        adapterErrorCalled = true;
-                    }
-                }
+                adapter: adapter
             });
         },
 
@@ -754,7 +720,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         views: {}
                     }
                 },
-                adapter: Y.Mock(),
+                adapter: adapter,
                 controller: {index: function() {}},
                 store: store
             });
@@ -788,7 +754,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 ac = new Y.mojito.ActionContext({
                     dispatch: 'the dispatch',
                     command: command,
-                    adapter: Y.Mock(),
+                    adapter: adapter,
                     controller: {
                         // no index() action
                     },
@@ -815,7 +781,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
             var ac = new Y.mojito.ActionContext({
                     dispatch: 'the dispatch',
                     command: command,
-                    adapter: Y.Mock(),
+                    adapter: adapter,
                     controller: {
                         __call: function() {
                             callCalled = true;
@@ -827,14 +793,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
         },
 
         'test no view': function() {
-            var store = {
-                getStaticAppConfig: function() {
-                    return {};
-                },
-                getRoutes: function(ctx) {
-                    return {};
-                }
-            };
             var command = {
                     action: 'index',
                     instance: {
@@ -843,10 +801,6 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                         acAddons: [],
                         views: {}
                     }
-                };
-            var adapter = {
-                    done: function(data, meta) {},
-                    error: function(err) {}
                 };
 
             var ac, error;

--- a/tests/unit/lib/test-mojito.js
+++ b/tests/unit/lib/test-mojito.js
@@ -659,6 +659,9 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                                 middleware: ['mojito-handler-dispatcher']
                             };
                         },
+                        getRoutes: function () {
+                            return {};
+                        },
                         getStaticContext: function () {
                             A.isTrue(true);
                         },


### PR DESCRIPTION
For the sake of performance, and in preparation for adopting a more `express`-like approach, which is a less defensive approach btw, we now:
- compute `appConfig` and `routes` once per request (by default) instead of computing them per mojit instance from within the addons.
- deprecate `ac.staticAppConfig` in favor of `adapter.page.staticAppConfig` to easy the GC process by having less big objects hanging around.
