### PR TITLE
resource store honors yui.config during preload

### DIFF
--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -1927,7 +1927,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                         if (versions[res.id][priority].source.fs.fullPath !== res.source.fs.fullPath) {
                             Y.log('Resource version collision for ' + res.id +
                                 '\nchoosing: ' + versions[res.id][priority].source.fs.fullPath +
-                                '\nskipping: ' + res.source.fs.fullPath, 'warn', NAME);
+                                '\nskipping: ' + res.source.fs.fullPath, 'info', NAME);
                         }
                     } else {
                         versions[res.id][priority] = res;

--- a/lib/store.js
+++ b/lib/store.js
@@ -41,6 +41,7 @@ Store.createStore = function(options) {
 
     var store,
         YUI,
+        appConfig,
         Y;
 
     if (!options) {
@@ -60,7 +61,6 @@ Store.createStore = function(options) {
     // metadata with the main Mojito execution context and the execution context
     // of the ResourceStore instance.
     YUI = YUIFactory.getYUI();
-
 
     // Configure the prerequisites and load the resource store impl code.
     Y = YUI({
@@ -84,6 +84,9 @@ Store.createStore = function(options) {
         context: options.context,
         appConfig: options.appConfig
     });
+
+    appConfig = store.getStaticAppConfig();
+    Y.applyConfig((appConfig && appConfig.yui && appConfig.yui.config) || {});
 
     if ('initial' === options.preload) {
         store.preloadInitial();


### PR DESCRIPTION
This will only really work once we move to yui@3.10.1 since earlier versions don't honor `logLevel` in the config.
