### PR TITLE
introducing mojito-output-buffer

### DIFF
--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -14,48 +14,6 @@
  */
 YUI.add('mojito-composite-addon', function (Y, NAME) {
 
-    function AdapterBuffer(id, callback) {
-        this.id = id;
-        this.callback = function () {
-            if (callback) {
-                callback.apply(this, arguments);
-            }
-            callback = function () {
-                Y.log('ac.done/flush/error called multiple times in child: ' +
-                        id, 'warn', NAME);
-            };
-        };
-    }
-
-    AdapterBuffer.prototype = {
-
-        done: function (data, meta) {
-            this.callback(null, data, meta);
-        },
-
-        flush: function (data, meta) {
-            // TODO: we do not support flush at the composite level
-            //       what else can we do?
-            this.callback(null, data, meta);
-        },
-
-        error: function (err) {
-            Y.log("Error executing child mojit at '" + this.id + "':", 'error',
-                    NAME);
-            if (err.message) {
-                Y.log(err.message, 'error', NAME);
-            } else {
-                Y.log(err, 'error', NAME);
-            }
-            if (err.stack) {
-                Y.log(err.stack, 'error', NAME);
-            }
-
-            this.callback(err);
-        }
-
-    };
-
     /**
     * <strong>Access point:</strong> <em>ac.composite.*</em>
     * Provides methods for working with many Mojits.
@@ -298,7 +256,8 @@ ac.composite.addChild('slot-1', {
             var originalChild = child,
                 my = this,
                 childAdapter,
-                newCommand;
+                newCommand,
+                id;
 
             // check to ensure children doesn't have a null child
             // in which case it will be automatically skipped to
@@ -347,7 +306,10 @@ ac.composite.addChild('slot-1', {
                 params: child.params || this.command.params
             };
 
-            childAdapter = new AdapterBuffer(childName,
+            // identifier for the child (only used in the logs)
+            id = NAME + '::' + (newCommand.base ? '' : '@' + newCommand.type) + ':' + newCommand.action;
+
+            childAdapter = new Y.mojito.OutputBuffer(id,
                     this.queue.add(function (err, data, meta) {
 
                     // HookSystem::StartBlock
@@ -398,5 +360,6 @@ ac.composite.addChild('slot-1', {
     'mojito',
     'mojito-util',
     'mojito-hooks',
+    'mojito-output-buffer',
     'mojito-assets-addon'
 ]});

--- a/lib/app/addons/ac/composite.common.js
+++ b/lib/app/addons/ac/composite.common.js
@@ -309,26 +309,25 @@ ac.composite.addChild('slot-1', {
             // identifier for the child (only used in the logs)
             id = NAME + '::' + (newCommand.base ? '' : '@' + newCommand.type) + ':' + newCommand.action;
 
-            childAdapter = new Y.mojito.OutputBuffer(id,
-                    this.queue.add(function (err, data, meta) {
+            childAdapter = new Y.mojito.OutputBuffer(id, this.queue.add(function (err, data, meta) {
 
-                    // HookSystem::StartBlock
-                    Y.mojito.hooks.hook('adapterBuffer', this.hook, 'end', this);
-                    // HookSystem::EndBlock
+                // HookSystem::StartBlock
+                Y.mojito.hooks.hook('adapterBuffer', this.hook, 'end', this);
+                // HookSystem::EndBlock
 
-                    if (err && originalChild.propagateFailure) {
-                        my._onChildFailure(childName, err);
-                        return;
-                    }
+                if (err && originalChild.propagateFailure) {
+                    my._onChildFailure(childName, err);
+                    return;
+                }
 
-                    // This ends up in my.queue.results array.
-                    return {
-                        name: childName,
-                        data: (data || ''),
-                        meta: meta
-                    };
+                // This ends up in my.queue.results array.
+                return {
+                    name: childName,
+                    data: (data || ''),
+                    meta: meta
+                };
 
-                }));
+            }));
 
             // HookSystem::StartBlock
             Y.mojito.hooks.hook('adapterBuffer', this.adapter.hook, 'start', childAdapter);

--- a/lib/app/addons/ac/partial.common.js
+++ b/lib/app/addons/ac/partial.common.js
@@ -14,6 +14,49 @@
  */
 YUI.add('mojito-partial-addon', function(Y, NAME) {
 
+    function InvokeAdapter(callback) {
+        this.data = '';
+        this.callback = function () {
+            if (callback) {
+                callback.apply(this, arguments);
+            }
+            callback = function () {
+                Y.log('ac.done/flush/error called multiple times in partial invoke',
+                        'warn', NAME);
+            };
+        };
+    }
+
+    InvokeAdapter.prototype = {
+
+        done: function (data, meta) {
+            this.flush(data, meta);
+            this.callback(null, this.data, this.meta);
+        },
+
+        flush: function (data, meta) {
+            this.data += data;
+            // this trick is to call metaMerge only after the first pass
+            this.meta = (this.meta ? Y.mojito.util.metaMerge(this.meta, meta) : meta);
+        },
+
+        error: function (err) {
+            Y.log("Error executing partial invoke", 'error',
+                    NAME);
+            if (err.message) {
+                Y.log(err.message, 'error', NAME);
+            } else {
+                Y.log(err, 'error', NAME);
+            }
+            if (err.stack) {
+                Y.log(err.stack, 'error', NAME);
+            }
+
+            this.callback(err);
+        }
+
+    };
+
     /**
     * <strong>Access point:</strong> <em>ac.partial.*</em>
     * Provides methods for working with "actions" and "views" on the current
@@ -21,12 +64,11 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
     * @class Partial.common
     */
     function Addon(command, adapter, ac) {
-        this.command = command;
-        this.dispatch = ac._dispatch;
-        this.ac = ac;
+        this._command = command;
+        this._ac = ac;
+        this._adapter = adapter;
         this._page = adapter.page;
     }
-
 
     Addon.prototype = {
 
@@ -44,7 +86,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
         render: function(data, view, cb) {
             var renderer,
                 mojitView,
-                instance = this.command.instance,
+                instance = this._command.instance,
                 meta = {view: {}};
 
             if (!instance.views[view]) {
@@ -78,23 +120,26 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
          * This method calls the current mojit's controller with the "action"
          * given and returns its output via the callback.
          *
-         * The <em>options</em> parameter is optional and may contain:
-         * <dl>
-         *     <dt>params</dt><dd>&lt;object&gt; must be broken out explicitly:
-         *     <dl>
-         *      <dt>route</dt><dd>&lt;object&gt; Map of key/value pairs.</dd>
-         *      <dt>url</dt><dd>&lt;object&gt; Map of key/value pairs.</dd>
-         *      <dt>body</dt><dd>&lt;object&gt; Map of key/value pairs.</dd>
-         *      <dt>file</dt><dd>&lt;object&gt; Map of key/value pairs.</dd>
-         *     </dl></dd>
-         * </dl>
          * @method invoke
          * @param {string} action name of the action to invoke.
-         * @param {object} options see above.
+         * @param {object} options a literal object with the configuration
+         *
+         *      @param {boolean} propagateFailure whether or not errors
+         *      invoke should affect the original action by calling adapter.error
+         *      @param {object} params optional object to be passed as params in the
+         *      invoke command. It defaults to the current action params.
+         *
+         *          @param {object} route Map of key/value pairs.
+         *          @param {object} url Map of key/value pairs.
+         *          @param {object} body Map of key/value pairs.
+         *          @param {object} file Map of key/value pairs.
+         *
          * @param {function} cb callback function to be called on completion.
          */
         invoke: function(action, options, cb) {
-            var command;
+            var my = this,
+                newCommand,
+                newAdapter;
 
             // If there are no options use it as the callback
             if ('function' === typeof options) {
@@ -102,41 +147,47 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
                 options = {};
             }
 
-            command = {
+            // the new command baesd on the original command
+            newCommand = {
                 instance: {
-                    base: this.command.instance.base,
-                    type: this.command.instance.type
+                    base: this._command.instance.base,
+                    type: this._command.instance.type
                 },
                 action: action,
-                context: this.ac.context,
-                params: options.params || this.ac.params.getAll()
+                context: this._ac.context,
+                params: options.params || this._ac.params.getAll()
             };
 
+            // the new adapter that inherit from the original adapter
+            newAdapter = new InvokeAdapter(function (err, data, meta) {
 
-            this.dispatch(command, {
-                data: '',
+                // HookSystem::StartBlock
+                Y.mojito.hooks.hook('adapterInvoke', my._adapter.hook, 'end', this);
+                // HookSystem::EndBlock
 
-                meta: {},
+                if (err && options.propagateFailure) {
+                    my._adapter.error(err);
+                    return;
+                }
 
-                done: function(data, meta, more) {
-                    Y.mojito.util.metaMerge(this.meta, meta);
-                    this.data += data;
-
+                if (meta) {
                     // Remove whatever "content-type" was set
                     meta.http.headers['content-type'] = undefined;
-
                     // Remove whatever "view" was set
                     meta.view = undefined;
-
-                    if (!more) {
-                        cb(null, this.data, this.meta);
-                    }
-                },
-
-                flush: function(data, meta) {
-                    this.done(data, meta, true);
                 }
+
+                cb(err, data, meta);
+
             });
+
+            // HookSystem::StartBlock
+            Y.mojito.hooks.hook('adapterInvoke', this._adapter.hook, 'start', newAdapter);
+            // HookSystem::EndBlock
+
+            newAdapter = Y.mix(newAdapter, this._adapter);
+
+            this._ac._dispatch(newCommand, newAdapter);
         }
     };
 
@@ -144,6 +195,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
 
 }, '0.1.0', {requires: [
     'mojito-util',
+    'mojito-hooks',
     'mojito-params-addon',
     'mojito-view-renderer'
 ]});

--- a/lib/app/addons/ac/partial.common.js
+++ b/lib/app/addons/ac/partial.common.js
@@ -16,6 +16,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
 
     function InvokeAdapter(callback) {
         this.data = '';
+        this.meta = undefined;
         this.callback = function () {
             if (callback) {
                 callback.apply(this, arguments);

--- a/lib/app/addons/ac/partial.common.js
+++ b/lib/app/addons/ac/partial.common.js
@@ -12,51 +12,7 @@
 /**
  * @module ActionContextAddon
  */
-YUI.add('mojito-partial-addon', function(Y, NAME) {
-
-    function InvokeAdapter(callback) {
-        this.data = '';
-        this.meta = undefined;
-        this.callback = function () {
-            if (callback) {
-                callback.apply(this, arguments);
-            }
-            callback = function () {
-                Y.log('ac.done/flush/error called multiple times in partial invoke',
-                        'warn', NAME);
-            };
-        };
-    }
-
-    InvokeAdapter.prototype = {
-
-        done: function (data, meta) {
-            this.flush(data, meta);
-            this.callback(null, this.data, this.meta);
-        },
-
-        flush: function (data, meta) {
-            this.data += data;
-            // this trick is to call metaMerge only after the first pass
-            this.meta = (this.meta ? Y.mojito.util.metaMerge(this.meta, meta) : meta);
-        },
-
-        error: function (err) {
-            Y.log("Error executing partial invoke", 'error',
-                    NAME);
-            if (err.message) {
-                Y.log(err.message, 'error', NAME);
-            } else {
-                Y.log(err, 'error', NAME);
-            }
-            if (err.stack) {
-                Y.log(err.stack, 'error', NAME);
-            }
-
-            this.callback(err);
-        }
-
-    };
+YUI.add('mojito-partial-addon', function (Y, NAME) {
 
     /**
     * <strong>Access point:</strong> <em>ac.partial.*</em>
@@ -84,11 +40,16 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
          * @param {string} view The view name to be used for rendering.
          * @param {function} cb callback signature is function(error, result).
          */
-        render: function(data, view, cb) {
+        render: function (data, view, cb) {
             var renderer,
                 mojitView,
                 instance = this._command.instance,
-                meta = {view: {}};
+                meta = {view: {}},
+                id;
+
+            if (!cb) {
+                throw new Error('missing callback when trying to render view: ' + view);
+            }
 
             if (!instance.views[view]) {
                 cb('View "' + view + '" not found');
@@ -100,21 +61,9 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
             renderer = new Y.mojito.ViewRenderer(mojitView.engine,
                 this._page.staticAppConfig.viewEngine);
 
-            Y.log('Rendering "' + view + '" view for "' + (instance.id || '@' +
-                instance.type) + '"', 'debug', NAME);
+            id = NAME + '::' + (instance.id || '@' + instance.type) + '>render:' + view;
 
-            renderer.render(data, instance.type, mojitView, {
-                buffer: '',
-
-                flush: function(data) {
-                    this.buffer += data;
-                },
-
-                done: function(data) {
-                    this.buffer += data;
-                    cb(null, this.buffer);
-                }
-            }, meta);
+            renderer.render(data, instance.type, mojitView, new Y.mojito.OutputBuffer(id, cb), meta);
         },
 
         /**
@@ -137,10 +86,13 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
          *
          * @param {function} cb callback function to be called on completion.
          */
-        invoke: function(action, options, cb) {
+        invoke: function (action, options, cb) {
             var my = this,
                 newCommand,
-                newAdapter;
+                newAdapter,
+                base = this._command.instance.base,
+                type = this._command.instance.type,
+                id = NAME + '::' + (base ? '' : '@' + type) + ':' + action;
 
             // If there are no options use it as the callback
             if ('function' === typeof options) {
@@ -151,8 +103,8 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
             // the new command baesd on the original command
             newCommand = {
                 instance: {
-                    base: this._command.instance.base,
-                    type: this._command.instance.type
+                    base: base,
+                    type: type
                 },
                 action: action,
                 context: this._ac.context,
@@ -160,7 +112,7 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
             };
 
             // the new adapter that inherit from the original adapter
-            newAdapter = new InvokeAdapter(function (err, data, meta) {
+            newAdapter = new Y.mojito.OutputBuffer(id, function (err, data, meta) {
 
                 // HookSystem::StartBlock
                 Y.mojito.hooks.hook('adapterInvoke', my._adapter.hook, 'end', this);
@@ -195,8 +147,8 @@ YUI.add('mojito-partial-addon', function(Y, NAME) {
     Y.namespace('mojito.addons.ac').partial = Addon;
 
 }, '0.1.0', {requires: [
-    'mojito-util',
     'mojito-hooks',
+    'mojito-output-buffer',
     'mojito-params-addon',
     'mojito-view-renderer'
 ]});

--- a/lib/app/autoload/output-buffer.common.js
+++ b/lib/app/autoload/output-buffer.common.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+
+/*jslint anon:true, nomen:true*/
+/*global YUI*/
+
+
+/**
+ * @module OutputBuffer
+ * @requires mojito
+ */
+YUI.add('mojito-output-buffer', function (Y, NAME) {
+
+    'use strict';
+
+    /**
+    OutputBuffer is an advanced adapter that can be use to dispatch a command
+    while controlling the output of the operation for that command. This is
+    useful for composite executions, and child rendering.
+
+        var newAdapter = new Y.mojito.OutputBuffer('foo', function (err, data, meta) {
+            // do something here...
+        });
+        newAdapter = Y.mix(newAdapter, originalAdapter); // inherit mojito stuff
+        dispatcher(newCommand, newAdapter);
+
+    The `newAdapter` exposes a regular adapter api, which means it has `flush`,
+    `done` and `error` methods, plus anything else coming from `originalAdapter`.
+
+    @class OutputBuffer
+    @constructor
+    @param {string} id identified for the mojit instance/action to be buffered
+    @param {function} callback
+    **/
+    function OutputBuffer(id, callback) {
+        this.id = id;
+        this.data = '';
+        this.meta = undefined;
+        this.callback = function () {
+            if (callback) {
+                callback.apply(this, arguments);
+            }
+            callback = function () {
+                Y.log('ac.done/flush/error called multiple times for: ' +
+                        id, 'warn', NAME);
+            };
+        };
+    }
+
+    OutputBuffer.prototype = {
+
+        done: function (data, meta) {
+            this.data += data;
+            // this trick is to call metaMerge only after the first pass
+            this.meta = (this.meta ? Y.mojito.util.metaMerge(this.meta, meta) : meta);
+            // calling back with the merged data and metas
+            this.callback(null, this.data, this.meta);
+        },
+
+        flush: function (data, meta) {
+            this.data += data;
+            // this trick is to call metaMerge only after the first pass
+            this.meta = (this.meta ? Y.mojito.util.metaMerge(this.meta, meta) : meta);
+        },
+
+        error: function (err) {
+            Y.log("Error executing: '" + this.id + "':", 'error',
+                    NAME);
+            if (err.message) {
+                Y.log(err.message, 'error', NAME);
+            } else {
+                Y.log(err, 'error', NAME);
+            }
+            if (err.stack) {
+                Y.log(err.stack, 'error', NAME);
+            }
+
+            this.callback(err);
+        }
+
+    };
+
+    Y.namespace('mojito').OutputBuffer = OutputBuffer;
+
+}, '0.1.0', {requires: ['mojito-util']});

--- a/lib/app/autoload/output-buffer.common.js
+++ b/lib/app/autoload/output-buffer.common.js
@@ -11,7 +11,7 @@
 
 /**
  * @module OutputBuffer
- * @requires mojito
+ * @requires mojito-util
  */
 YUI.add('mojito-output-buffer', function (Y, NAME) {
 

--- a/tests/base/mojito-test.js
+++ b/tests/base/mojito-test.js
@@ -80,6 +80,7 @@ YUI.add('mojito-dispatcher', function(Y, NAME) {
 });
 YUI.add('mojito-mojit-proxy', function(Y, NAME) {});
 YUI.add('mojito-output-handler', function(Y, NAME) {});
+YUI.add('mojito-output-buffer', function(Y, NAME) {});
 YUI.add('mojito-perf', function(Y, NAME) {});
 YUI.add('mojito-hooks', function(Y, NAME) {
 

--- a/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
+++ b/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
@@ -34,7 +34,7 @@
             },
             "composite.common": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/ac/composite.common.js",
+                    "lib": "$$config.lib$$/app/addons/ac/composite.common.js,../../../../../../lib/app/autoload/output-buffer.common.js",
                     "test": "./test-composite.common.js",
                     "page": "$$config.base$$/mojito-test.html"
                 },
@@ -114,7 +114,7 @@
             },
             "partial.common": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/ac/partial.common.js",
+                    "lib": "$$config.lib$$/app/addons/ac/partial.common.js,../../../../../../lib/app/autoload/output-buffer.common.js",
                     "test": "./test-partial.common.js",
                     "page": "$$config.base$$/mojito-test.html"
                 },

--- a/tests/unit/lib/app/addons/ac/test-partial.common.js
+++ b/tests/unit/lib/app/addons/ac/test-partial.common.js
@@ -127,6 +127,18 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
 
         name: 'invoke() tests',
 
+        'setUp': function () {
+            ac = {};
+            adapter = {
+                page: {
+                    staticAppConfig: {
+                        viewEngine: 'page static app config view engine'
+                    }
+                },
+                hook: {}
+            };
+        },
+
         'test populates command object for dispatch': function() {
             var command = {
                     instance: {
@@ -152,6 +164,7 @@ YUI().use('mojito-partial-addon', 'test', function (Y) {
                     Mock.Value.Object
                 ]
             });
+
             ac.command = command;
             ac.context = 'myContext';
             ac._dispatch = mockDispatch.dispatch;


### PR DESCRIPTION
- partial addon should honor the original adapter configuration
- composite and partial can use `Y.mojito.OutputBuffer` as the primary interface with dispatcher and render
- composite and partial support `ac.flush`
- fixes jenkins func tests

_Note: I don't think `ac.partial.invoke()` feature should be part of partial addon, but for the sake of BC, here is the fix._
