### PR TITLE
add command "npm run <commands>" to run unit, func, lint, docs, etc

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,8 +26,11 @@ windows. We plan to consolidate this going forward, but until after [travis-ci.o
 supports `windows` [environment](http://about.travis-ci.org/docs/user/ci-environment/) as part of the
 build process to do sanity check, we cannot guarantee that everything will work on `windows`.
 * `mojito-composite-addon` and `mojito-partial-addon` support `ac.flush` from child mojits.
-* Add command "npm test" to run all mojito unit and functional tests with Phantomjs. 
+* Added command "npm test" to run all mojito unit and functional tests with Phantomjs. 
   Test results can be found under <mojitosrcdir>/artifacts/arrowreport by default.
+* Added command "npm run-script testunit" to run mojito unit tests with Phantomjs. 
+  Test results can be found under <mojitosrcdir>/tests/unit/artifacts/arrowreport by default.
+  Unit tests code coverage data will be generated too at <mojitosrcdir>/tests/unit/coverage.
 
 Bug Fixes
 ---------

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,11 +26,10 @@ windows. We plan to consolidate this going forward, but until after [travis-ci.o
 supports `windows` [environment](http://about.travis-ci.org/docs/user/ci-environment/) as part of the
 build process to do sanity check, we cannot guarantee that everything will work on `windows`.
 * `mojito-composite-addon` and `mojito-partial-addon` support `ac.flush` from child mojits.
-* Added command "npm test" to run all mojito unit and functional tests with Phantomjs. 
+* Command "npm test" is added to run all mojito unit and functional tests with Phantomjs. 
   Test results can be found under <mojitosrcdir>/artifacts/arrowreport by default.
-* Added command "npm run-script testunit" to run mojito unit tests with Phantomjs. 
-  Test results can be found under <mojitosrcdir>/tests/unit/artifacts/arrowreport by default.
-  Unit tests code coverage data will be generated too at <mojitosrcdir>/tests/unit/coverage.
+  "npm run unit", "npm run func", "npm run doc", "npm run lint" are also added.
+  
 
 Bug Fixes
 ---------

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "phantomjs": ">=1.8.0"
     },
     "scripts": {
-        "test": "cd tests && ./run.js test --browser phantomjs",
-        "testunit": "cd tests && ./run.js test -u --browser phantomjs --coverage"
+        "test": "cd tests && node run.js test --browser phantomjs",
+        "testunit": "cd tests && node run.js test -u --browser phantomjs --coverage"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "unit": "cd tests && node run.js test -u --browser phantomjs",
         "func": "cd tests && node run.js test -f --browser phantomjs",
         "lint": "node bin/mojito jslint",
-        "doc": "node bin/mojito docs mojito"
+        "docs": "node bin/mojito docs mojito"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
     },
     "scripts": {
         "test": "cd tests && node run.js test --browser phantomjs",
-        "testunit": "cd tests && node run.js test -u --browser phantomjs --coverage"
+        "unit": "cd tests && node run.js test -u --browser phantomjs",
+        "func": "cd tests && node run.js test -f --browser phantomjs",
+        "lint": "node bin/mojito jslint",
+        "doc": "node bin/mojito docs mojito"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     },
     "scripts": {
         "test": "cd tests && ./run.js test --browser phantomjs",
-        "testunit": "cd tests && ./run.js test -u --browser phantomjs --coverage "
+        "testunit": "cd tests && ./run.js test -u --browser phantomjs --coverage"
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "phantomjs": ">=1.8.0"
     },
     "scripts": {
-        "test": "cd tests && ./run.js test --browser phantomjs"
+        "test": "cd tests && ./run.js test --browser phantomjs",
+        "testunit": "cd tests && ./run.js test -u --browser phantomjs --coverage "
     },
     "homepage": "http://developer.yahoo.com/cocktails/mojito/",
     "repository": {


### PR DESCRIPTION
This is basing on Caridy's feedback and Isao's suggestion:
"npm run testunit" or "npm run-script testunit" will run unit tests only with coverage data generated too.
