### PR TITLE
 [Fixes #1127] Allow `Y.Handlebars.registerHelper` to register helpers

### DIFF
--- a/lib/app/addons/view-engines/hb.server.js
+++ b/lib/app/addons/view-engines/hb.server.js
@@ -14,7 +14,7 @@ YUI.add('mojito-hb', function (Y, NAME) {
     'use strict';
 
     var fs = require('fs'),
-        HB = require('yui/handlebars').Handlebars,
+        HB = Y.Handlebars,
         cache = YUI.namespace('Env.Mojito.Handlebars');
 
     /**
@@ -209,6 +209,7 @@ YUI.add('mojito-hb', function (Y, NAME) {
 
 }, '0.1.0', {requires: [
     'mojito',
+    'handlebars',
     'parallel',
     'mojito-hooks'
 ]});


### PR DESCRIPTION
As per http://yuilibrary.com/yui/docs/handlebars/#defining-custom-helpers, the Handlebars helpers are defined using `Y.Handlebars.registerHelper`.

However, any helper registered using the above way are not available while generating views from hb templates on server.

Use case: Adding set of global handlebar helpers that works on both client and server. (helpers like pluralize, lowercase, uppercase, truncate etc. which are independent of mojit). More like, I want the Handlebars engine to be enhanced where I've access to a bigger set of helpers with almost no extra effort.

I understand `ac.helpers.set` and `ac.helpers.expose` are available, but I find a couple of concerns using this approach:
1. Needs access to `ac` which is available in each function of controller, and hence every function needs to attach these helpers.
2. Incompatibility with existing YUI code, which declared helpers this way.
