### PR TITLE
cleanup callback handling logic, add as err listener

### DIFF
--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -497,8 +497,7 @@ MojitoServer.prototype.getHttpServer = function() {
  */
 MojitoServer.prototype.listen = function(port, host, callback) {
 
-    var logger, // <- not used in this function, cruft?
-        app = this._app,
+    var app = this._app,
         p = port || this._options.port,
         h = host || this._options.host,
         listenArgs = [p];

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -497,15 +497,10 @@ MojitoServer.prototype.getHttpServer = function() {
  */
 MojitoServer.prototype.listen = function(port, host, callback) {
 
-    var logger,
+    var logger, // <- not used in this function, cruft?
         app = this._app,
         p = port || this._options.port,
         h = host || this._options.host,
-        handler = function(err) {
-            if (callback) {
-                callback(err, app);
-            }
-        },
         listenArgs = [p];
 
     // Track startup time and use it to ensure we don't try to listen() twice.
@@ -524,15 +519,18 @@ MojitoServer.prototype.listen = function(port, host, callback) {
     if (h) {
         listenArgs.push(h);
     }
+
+    // close on app for callback
+    function handler(err) {
+        callback(err, app);
+    }
+
     if (callback) {
+        app.on('error', handler);
         listenArgs.push(handler);
     }
 
-    try {
-        app.listen.apply(app, listenArgs);
-    } catch (err) {
-        handler(err);
-    }
+    app.listen.apply(app, listenArgs);
 };
 
 

--- a/tests/unit/lib/test-mojito.js
+++ b/tests/unit/lib/test-mojito.js
@@ -349,6 +349,11 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                 args: [port, host, V.Function]
             });
 
+            Y.Mock.expect(app, {
+                method: 'on',
+                args: ['error', V.Function]
+            });
+
             this_scope._app = app;
             Mojito.Server.prototype.listen.call(this_scope, port, host, cb);
 
@@ -366,7 +371,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [port, host, V.Function]
+                args: [port, host]
             });
 
             this_scope._app = app;
@@ -382,6 +387,16 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                         verbose: false,
                         port: 9876,
                         host: 'conan'
+                    },
+                    _app: {
+                        listen: function(p, h) {
+                            A.areSame(9876, p);
+                            A.areSame('conan', h);
+                        },
+                        on: function(ev, cb) {
+                            A.areSame('error', ev);
+                            A.isFunction(cb);
+                        }
                     }
                 },
                 actual;
@@ -400,7 +415,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [this_scope._options.port, this_scope._options.host, V.Function]
+                args: [this_scope._options.port]
             });
 
             this_scope._app = app;
@@ -421,6 +436,10 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                             A.areSame(host, h);
                             A.isFunction(cb);
                             cb('fake error');
+                        },
+                        on: function(ev, cb) {
+                            A.areSame('error', ev);
+                            A.isFunction(cb);
                         }
                     }
                 };
@@ -445,7 +464,12 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [port, host, cb]
+                args: [port, host, V.Function]
+            });
+
+            Y.Mock.expect(app, {
+                method: 'on',
+                args: ['error', V.Function]
             });
 
             this_scope._app = app;


### PR DESCRIPTION
errors on app.listen do not invoke the callback passed as a parameter, but emit an 'error' event. So if a callback is provided, add it as an error event listener.
