### PR TITLE
fixes issue #1151 client-side route maker error IE6-8

### DIFF
--- a/lib/app/autoload/route-maker.common.js
+++ b/lib/app/autoload/route-maker.common.js
@@ -119,8 +119,8 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
              */
             route.requires = {};
             matches = route.path.match(/:([^\/]+)/g);
-            for (i in matches) {
-                if (matches.hasOwnProperty(i)) {
+            if (matches) {
+                for (i = 0; i < matches.length; i++) {
                     route.requires[matches[i].substr(1)] = '[^&]+';
                 }
             }


### PR DESCRIPTION
@chetanankola reports http://git.io/Si_T_g

```
route.requires[matches[i].substr(1)] = '[^&]+';
fails when matches[i] is a number!
```

Since String#match returns null or an array, replacing the
for/in with a plain old for-loop behind an if(matches) is the better
thing to do anyway. @chetanankola reports this works in IE now. 
This error appears to already be covered by the test cases in 
tests/unit/lib/app/autoload/test-route-maker.common.js
