### PR TITLE
Merging #develop into #next after 0.6.1 release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,8 +4,6 @@ version @VERSION@
 Notes
 -----
 
-YUI dependency was upgraded to yui@3.10.1
-
 Deprecations, Removals
 ----------------------
 
@@ -17,6 +15,36 @@ Bug Fixes
 
 Acknowledgements
 ----------------
+
+
+version 0.6.1
+=================
+
+Notes
+-----
+* Mojito contributors can now use the following `npm run-script` shortcuts when working inside the mojito repo:
+  * `npm test`
+  * `npm run unit`
+  * `npm run func`
+* YUI dependency was upgraded to yui@3.10.1
+* Arrow devDependency was upgraded to yahoo-arrow@~0.0.77
+* YCB dependency was upgraded to ycb@~1.0.5
+
+Deprecations, Removals
+----------------------
+
+Features
+--------
+
+Bug Fixes
+---------
+* fix #1151 client-side route-maker error IE6-8
+* fix #1146 use perf.logFile from app.json:perf.logFile if applicable
+* fix callback handling in mojito start sequence
+
+Acknowledgements
+----------------
+Thanks to @chetanankola for discovering and helping with issue #1151.
 
 version 0.6.0
 =================
@@ -51,10 +79,10 @@ windows. We plan to consolidate this going forward, but until after [travis-ci.o
 supports `windows` [environment](http://about.travis-ci.org/docs/user/ci-environment/) as part of the
 build process to do sanity check, we cannot guarantee that everything will work on `windows`.
 * `mojito-composite-addon` and `mojito-partial-addon` support `ac.flush` from child mojits.
-* Command "npm test" is added to run all mojito unit and functional tests with Phantomjs. 
+* Command "npm test" is added to run all mojito unit and functional tests with Phantomjs.
   Test results can be found under <mojitosrcdir>/artifacts/arrowreport by default.
   "npm run unit", "npm run func", "npm run doc", "npm run lint" are also added.
-  
+
 
 Bug Fixes
 ---------
@@ -71,8 +99,8 @@ Notes
 * The PR [#1059](/yahoo/mojito/issues/1059) adds the Mojito Quickstart Guide application
 to the `examples` directory. The application allows you to view documentation on
 different devices and serves as a reference application. You can view the live application
-at http://y.ahoo.it/mqsg. Also, see the wiki page 
-[Mojito Quickstart Guide: Intro](https://github.com/yahoo/mojito/wiki/Mojito-Quickstart-Guide) 
+at http://y.ahoo.it/mqsg. Also, see the wiki page
+[Mojito Quickstart Guide: Intro](https://github.com/yahoo/mojito/wiki/Mojito-Quickstart-Guide)
 for more information about the application.
 
 Deprecations, Removals
@@ -240,7 +268,7 @@ Features
 * Global models thru `ac.models.expose()` upgraded from experimental to beta.
 * Support for Handlebars helpers through `mojito-helpers-addon` and support for global Handlebars helpers using `ac.helpers.expose()`. This is an experimental feature!
 * Introducing error propagation in `mojito-composite-addon` by using the flag `propagateFailure` in a child.
-* Introduced a clear separation between YUI core modules and app-specific YUI modules. YUI core modules are now served from CDN by default; they are only served by the app origin server if `staticHandling.serveYUIFromAppOrigin` is set in `application.json`. This change optimizes the initial load time of the app as well as its offline capabilities when using [mojito build html5app](http://developer.yahoo.com/cocktails/mojito/docs/reference/mojito_cmdline.html#build-system). 
+* Introduced a clear separation between YUI core modules and app-specific YUI modules. YUI core modules are now served from CDN by default; they are only served by the app origin server if `staticHandling.serveYUIFromAppOrigin` is set in `application.json`. This change optimizes the initial load time of the app as well as its offline capabilities when using [mojito build html5app](http://developer.yahoo.com/cocktails/mojito/docs/reference/mojito_cmdline.html#build-system).
 * Improved Resource Store: minimized memory footprint.
 * Upgraded to YUI 3.8.1
 
@@ -658,7 +686,7 @@ Notes
 
 Features
 ------------
-* [#643](/yahoo/mojito/issues/643) new `hybrid` archetype 
+* [#643](/yahoo/mojito/issues/643) new `hybrid` archetype
    * new archetype: mojito create app hybrid myapp
    * new build type: mojito build hybrid path/to/packages/dir
    * new custom archetypes: mojito create custom path/to/your/archetype mything
@@ -775,7 +803,7 @@ Bug Fixes
 * fixed how commands instantiate the store
 * performance: use Y.mojito.util.copy() instead of Y.clone()
 * performance: removed Y.clone() from YCB library
-* fix multiple done() calls in client-side Handlebar renderer, consequence of fixing [#408](/yahoo/mojito/issues/408) 
+* fix multiple done() calls in client-side Handlebar renderer, consequence of fixing [#408](/yahoo/mojito/issues/408)
 
 
 version 0.4.3
@@ -832,11 +860,11 @@ Providing the ability to provide a `reasonPhrase` property when calling `ac.erro
 
 It was discovered that `shareYUIInstance` was not usable in previous versions.
 We have addressed some of the issues such that `shareYUIInstance` should be usable, although should be considered experimental.
-This configuration now works in the following way: 
+This configuration now works in the following way:
 
 Default value is `false` at app level, mojits can override the app config by specifying `shareYUIInstance` in their defaults.json (parallel to the config key).
 
-* [#357](/yahoo/mojito/issues/357), [#386](/yahoo/mojito/issues/386): Fixed `shareYUIInstance` 
+* [#357](/yahoo/mojito/issues/357), [#386](/yahoo/mojito/issues/386): Fixed `shareYUIInstance`
 
 ### Docs
 
@@ -859,7 +887,7 @@ Bug Fixes
 * [Fix bz5712477] Make sure to callback when there is an error [#338](/yahoo/mojito/issues/338)
 * Porting mojito doc over to the new yuidocjs [#243](/yahoo/mojito/issues/243) - Thanks Fabian Frank!
 * [#270](/yahoo/mojito/issues/270): Added unit tests for client and server handlebars engines
-* [#357](/yahoo/mojito/issues/357), [#386](/yahoo/mojito/issues/386): Fixed `shareYUIInstance` 
+* [#357](/yahoo/mojito/issues/357), [#386](/yahoo/mojito/issues/386): Fixed `shareYUIInstance`
 
 
 version 0.4.0
@@ -894,7 +922,7 @@ Bug Fixes
 * bz 5495519: mojito is not loading - stuck retrieving all the datetype-date-format for each locale
 * bz 5530096: Mojito tries to parse .json~ files in [mojit]/specs/
 * bz 5541500: mojito not doing fallback
-* bz 5609501: L10n: Root strings file is not used by default when a non-root strings file is present 
+* bz 5609501: L10n: Root strings file is not used by default when a non-root strings file is present
 
 
 version 0.3.30
@@ -976,7 +1004,7 @@ Features
 Bug Fixes
 ------------
 * [#231](/yahoo/mojito/issues/231) Update sys references to util references.
-* [#219](/yahoo/mojito/issues/219) [bz5651900] stop mojit data memory leak - record dynamically 
+* [#219](/yahoo/mojito/issues/219) [bz5651900] stop mojit data memory leak - record dynamically
 * [#223](/yahoo/mojito/issues/223) [bz5646042] log warning if server mojit has DOM dependency.
 * [#232](/yahoo/mojito/issues/232) [bz5649382] Fix for `mojito test app`.
 * fix dynamic mojit regression introduced in [2dd7313](/yahoo/mojito/commit/2dd7313)
@@ -984,7 +1012,7 @@ Bug Fixes
 * [bz5491914] Fix client exception on `ac.error()`
 * [bz5649346] Updates yui and yuitest dependencies; +FreeBSD
 * [bz5494997] Fix for Mojito client throwing on tunnel timeout
-* More null fixes for Mustache 
+* More null fixes for Mustache
 * [bz5590319] Unicode and/or HTML escaping for config data.
 
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ version @VERSION@
 Notes
 -----
 
+YUI dependency was upgraded to yui@3.10.1
+
 Deprecations, Removals
 ----------------------
 

--- a/docs/dev_guide/faq/index.rst
+++ b/docs/dev_guide/faq/index.rst
@@ -519,42 +519,20 @@ Data
 .. _moj_params_controller_binder:
 .. topic:: **In Mojito applications, how are parameters passed from the controller to binders?** 
 
-    Your controllers can pass parameters to binders by assigning values to 
-    ``ac.instance.config.{property}`` in  methods that are passed the ``ActionContext`` 
-    object. The binder accesses those parameters through ``mojitProxy.config.{property}``.
+    Your controllers can pass parameters to binders using the ``Data`` addon.
+    The controller requires the ``Data`` addon and then uses the ``data`` object with
+    the ``set`` method to set (or expose) data for the client code (binders or templates):
+    ``ac.data.set('app_framework', "Mojito");`` 
+
+    From the binder, the ``mojitProxy`` object can then access the data set by the controller
+    from the ``data`` object with the ``get`` method: ``mojitProxy.data.get('app_framework');``
+
+    The mojit's template can access the set data through a Handlebars expression, so
+    the ``index.hb.html`` could use ``{{app_framework}}`` to get the data set in the controller.
     
-    In the ``index`` method of the controller below, the key-value pair 
-    ``"name": "Mojito"`` is stored with ``ac.instance.config.name = "Mojito"``.
-
-    .. code-block:: javascript
-
-       YUI.add('myMojit', function(Y, NAME) {
-         Y.namespace('mojito.controllers')[NAME] = {
-           index: function(ac) {
-             ac.instance.config.name = "Mojito";
-             ...
-           }
-           ...
-         };
-       }, '0.0.1', {requires: ['mojito', 'myMojitModelFoo']});
-
-    The code snippet of the binder shown below references the key ``name``
-    with ``this.mojitProxy.config.name``.
-
-    .. code-block:: javascript
-
-       YUI.add('myMojitBinderIndex', function(Y, NAME) {
-         Y.namespace('mojito.binders')[NAME] = {
-           init: function(mojitProxy) {
-             this.mojitProxy = mojitProxy;
-           },
-           bind: function(node) {
-             Y.log(this.mojitProxy.config.name);
-             ...
-           }
-           ...
-         };
-       }, '0.0.1', {requires: ['mojito-client']});
+    The ``Data`` addon also allows you to share page-level data, so that mojits on the
+    page can share data through ``ac.pageData.set`` and ``ac.pageData.get`` or ``mojitProxy.pageData.get``.
+    See  `Sharing Data <../topics/mojito_data.html#sharing>`_ for more information and example code.
 
 ------------
 

--- a/docs/dev_guide/intro/mojito_configuring.rst
+++ b/docs/dev_guide/intro/mojito_configuring.rst
@@ -191,7 +191,7 @@ configuration Object
 | ``tunnelPrefix``                                       | string               | "/tunnel/"        | The URL prefix for the communication tunnel            |
 |                                                        |                      |                   | from the client back to the server.                    |
 +--------------------------------------------------------+----------------------+-------------------+--------------------------------------------------------+
-| ``tunnelTimeout``                                      | number               | 30000             | The timeout in milliseconds for the communication      |
+| ``tunnelTimeout``                                      | number               | 10000             | The timeout in milliseconds for the communication      |
 |                                                        |                      |                   | tunnel from the client back to the server.             |
 +--------------------------------------------------------+----------------------+-------------------+--------------------------------------------------------+
 | :ref:`viewEngine <viewEngine_obj>`                     | object               | N/A               | Contains information about caching and preloading      |

--- a/docs/dev_guide/quickstart/index.rst
+++ b/docs/dev_guide/quickstart/index.rst
@@ -9,7 +9,7 @@ Requirements
 
 **System:** Unix-based system.
 
-**Software:** `Node.js (>= 0.6.0 < 0.9.0) <http://nodejs.org/>`_, `npm (> 1.0.0) <http://npmjs.org/>`_
+**Software:** `Node.js (>= 0.8.0) <http://nodejs.org/>`_, `npm (> 1.0.0) <http://npmjs.org/>`_
 
 .. _mojito_quickstart-install:
 

--- a/docs/dev_guide/quickstart/index.rst
+++ b/docs/dev_guide/quickstart/index.rst
@@ -16,11 +16,11 @@ Requirements
 Installation Steps
 ==================
 
-#. Get Mojito from the npm registry and globally install Mojito so that 
-   it can be run from the command line. You may need to use ``sudo`` if 
+#. Globally install the Mojito CLI package (``mojito-cli``) from the npm registry 
+   so that you run Mojito commands. You may need to use ``sudo`` if 
    you run into permission errors.
 
-   ``$ npm install mojito -g``
+   ``$ npm install mojito-cli -g``
 
 #. Confirm that Mojito has been installed by running the help command.
 

--- a/docs/dev_guide/quickstart/index.rst
+++ b/docs/dev_guide/quickstart/index.rst
@@ -17,7 +17,7 @@ Installation Steps
 ==================
 
 #. Globally install the Mojito CLI package (``mojito-cli``) from the npm registry 
-   so that you run Mojito commands. You may need to use ``sudo`` if 
+   so that you can run Mojito commands. You may need to use ``sudo`` if 
    you run into permission errors.
 
    ``$ npm install mojito-cli -g``

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -474,11 +474,21 @@ with the name ``'user'`` if one does not exist.
 Sharing Data
 ============
 
-The Mojito ``Data`` addon has methods that allows the server 
-to share data to the client and  for for sharing data among mojits on a page. 
+After you get data, your application may need to share that data with client-side code 
+(binders) or other mojits. Mojito provides the ``Data`` addon that allows your mojit
+controllers and binders to share and access data. We'll look at the addon and then look at
+some use cases with examples.
+
+Data Addon
+----------
+
+The ``Data`` addon is available through the ``ActionContext`` and ``mojitProxy`` objects
+from the controller and binders respectively. Because the addon has two different 
+functions, allowing data to be shared from the server to the client and allowing one
+mojit to share data with other mojits, the addon has two namespaces. 
 
 Requiring Data Addon
---------------------
+####################
 
 The Data addon is required liked other addons in the controller by
 specifying the addon as a string in the ``required`` array:
@@ -486,6 +496,21 @@ specifying the addon as a string in the ``required`` array:
 .. code-block::
 
    }, '0.0.1', {requires: ['mojito-data-addon']}); 
+
+TBD: Does addon have to be required in binders.
+
+pageData Object
+###############
+
+When you include the ``pageData`` object is  two methods for setting (exposing) and getting data.
+Mojit controllers 
+
+The Mojito ``Data`` addon has methods that allows the server 
+to share data to the client and  for for sharing data among mojits on a page. 
+
+.. _mojito_data_sharing-require_addon:
+
+
 
 .. _mojito_data_sharing-server_client:
 

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -1,12 +1,20 @@
-=============================
-Getting Input and Cookie Data
-=============================
+==============
+Data in Mojito
+==============
 
+This chapter will first discuss how your applications can get 
+data and then look at how mojits can share that data with
+binders, other mojits, as well as how to rehydrate data.
+
+.. _mojito_data-getting:
+
+Getting Input and Cookie Data
+============================
 
 .. _mojito_data-intro:
 
 Introduction
-============
+------------
 
 Mojito provides addons for accessing data from query string and routing 
 parameters, cookies, and the POST request body.
@@ -25,7 +33,7 @@ To see examples using these addons to get data, see
 .. _mojito_data-params:
 
 Getting Data from Parameters
-============================
+----------------------------
 
 The methods in the Params addon are called from the ``params`` namespace. 
 As a result, the call will have the following syntax where ``ac`` is the 
@@ -34,7 +42,7 @@ ActionContext object: ``ac.params.*``
 .. _mojito_data-params_get:
 
 GET
----
+###
 
 The GET parameters are the URL query string parameters. The Params addon 
 creates JSON using the URL query string parameters. The method ``getFromUrl`` 
@@ -55,7 +63,7 @@ addon would create the following object:
 .. _data_params-get_single:
 
 Single Parameter
-################
+****************
 
 To get the value for a specific parameter, you pass the key to the ``getFromUrl`` 
 method, which returns the associated value.
@@ -81,7 +89,7 @@ parameter is retrieved:
 .. _data_params-get_all:
 
 All Parameters
-##############
+**************
 
 To get all of the query string parameters, you call ``getFromUrl`` or its alias 
 ``url`` without passing a key as a parameter.
@@ -112,7 +120,7 @@ the ``qs_params`` array, which ``ac.done`` makes available in the template.
 .. _mojito_data-params_post:
 
 POST
-----
+####
 
 The POST parameters come from the HTTP POST request body and often consist of 
 form data. As with query string parameters, the ``Params`` addon has the method 
@@ -122,7 +130,7 @@ the POST body parameters.
 .. _data_params-post_single:
 
 Single
-######
+******
 
 To get a parameter from the POST body, call ``getFromBody`` with the key as the 
 parameter. You can also use the alias ``body`` to get a parameter from the POST 
@@ -149,7 +157,7 @@ and then uses the ``done`` method to make it accessible to the template.
 .. _data_params-post_all:
 
 All
-###
+***
 
 To get all of the parameters from the POST body, call ``getFromBody`` or ``body`` 
 without any parameters.
@@ -182,7 +190,7 @@ template.
 .. _mojito_data-routing:
 
 Routing
-=======
+-------
 
 Routing parameters are mapped to routing paths, actions, and HTTP methods. 
 You can use the routing parameters to provide data to mojit actions when 
@@ -191,7 +199,7 @@ specific routing conditions have been met.
 .. _data_routing-set:
 
 Setting Routing Parameters
---------------------------
+##########################
 
 The routing parameters are set in the routing configuration file 
 ``routes.json``. For each defined route, you can use the ``params`` 
@@ -229,7 +237,7 @@ a coupon to a user posting information.
 .. _data_routing-get:
 
 Getting Routing Parameters
---------------------------
+##########################
 
 
 The Params addon has the method ``getFromRoutes`` that allows you to specify 
@@ -239,7 +247,7 @@ the alias ``route`` to get routing parameters.
 .. _data_routing-get_single:
 
 Single
-######
+******
 
 To get a routing parameter, call ``getFromRoute`` with the key as the 
 parameter.
@@ -272,7 +280,7 @@ to determine whether the user gets a coupon.
 .. _data_routing-get_all:
 
 All
-###
+***
 
 To get all of the routing parameters, call ``getFromRoute`` or ``route`` without 
 any arguments.
@@ -298,7 +306,7 @@ a URL.
 .. _mojito_data-get_all:
 
 Getting All Parameters
-======================
+----------------------
 
 The Params addon also has the method ``getFromMerged`` that lets you get one or 
 all of the GET, POST, and routing parameters. Because all of the parameters are 
@@ -319,7 +327,7 @@ parameter will override both the GET and POST ``foo`` parameters.
 .. _mojito_data-get_single:
 
 Single
-------
+######
 
 To get one of any of the different type of parameters, call ``getFromMerged`` 
 or ``merged`` with the key as the parameter.
@@ -345,7 +353,7 @@ In the example controller below, the ``name`` parameter is obtained using
 .. _mojito_data-get_all:
 
 All
----
+###
 
 To get all of the GET, POST, and routing parameters, call ``getFromMerged`` or 
 ``merged`` without any arguments.
@@ -373,7 +381,7 @@ To get all of the GET, POST, and routing parameters, call ``getFromMerged`` or
 .. _mojito_params_addon-aliases:
 
 Params Addon Method Aliases
-===========================
+---------------------------
 
 We have looked at the methods of the ``Params`` addon for getting query string
 parameter, query string parameters, and HTTP body data. For simplicity,
@@ -400,7 +408,7 @@ for the methods that we have covered thus far.
 .. _mojito_data-cookie:
 
 Cookies
-=======
+-------
 
 The `Cookies addon <../../api/classes/Cookie.server.html>`_ offers methods for 
 reading and writing cookies. The API of the Cookie addon is the same as 
@@ -411,7 +419,7 @@ see `Using Cookies <../code_exs/cookies.html>`_.
 .. _data_cookie-get:
 
 Getting Cookie Data
--------------------
+*******************
 
 The method ``cookie.get(name)`` is used to get the cookie value associated 
 with ``name``. In the example controller below, the cookie value 
@@ -437,7 +445,7 @@ template.
 .. _data_cookies-write:
 
 Writing Data to Cookies
------------------------
+#######################
 
 The method ``cookie.set(name, value)`` is used to set a cookie with the a 
 given name and value.  The following example controller sets a cookie 
@@ -460,5 +468,77 @@ with the name ``'user'`` if one does not exist.
         }
      }
    }, '0.0.1', {requires: ['mojito-cookie-addon']});
+
+.. _mojito_data-sharing:
+
+Sharing Data
+============
+
+The Mojito ``Data`` addon has methods that allows the server 
+to share data to the client and  for for sharing data among mojits on a page. 
+
+Requiring Data Addon
+--------------------
+
+The Data addon is required liked other addons in the controller by
+specifying the addon as a string in the ``required`` array:
+
+.. code-block::
+
+   }, '0.0.1', {requires: ['mojito-data-addon']}); 
+
+.. _mojito_data_sharing-server_client:
+
+Server Sharing Data With the Client
+-----------------------------------
+
+The ``Data`` addon is used to pass information from the controller to the binder. 
+From the controller, you use the ``set`` method from the Data addon to 
+set or expose data that the binder can access with the ``mojitProxy`` object.
+
+Example
+#######
+
+controller.server.js
+********************
+
+binder.js
+*********
+
+.. _mojito_data_sharing-page_data:
+
+Sharing Page Data with Other Mojits 
+-----------------------------------
+
+The ``Data`` addon also introduces the page data, which is accessible thru ac.pageData. 
+This has a YUI Model API, i.e., ac.pageData.set(name, value) and ac.pageData.get(name). 
+The namespace ``pageData`` is unique to each request, but is a single store for all mojits 
+of the request, and you can use it to share data between mojits in a page. The binder 
+accesses this data with mojitProxy.pageData.get(name).
+
+The data set via ac.pageData.set() is also available in all templates thru this.page 
+(for example {{page}} in handlebars templates). Keep in mind that if ac.done({page: 'something'}) 
+is specified in your controller, the page key will override all data set via ac.pageData.
+
+This data will be sent to the client and rehydrated because the page is built on the server 
+will expand its scope to the client. In other words, the ``pageData`` namespace serves as a 
+mechanism to share data between mojits and runtimes. Both ``ac.pageData`` and ``mojitProxy.pageData`` 
+provide access to the same page model.
+
+Data Scope 
+##########
+
+The data is set via ac.data.set() is also available in all templates. Any data given to ac.done() will 
+be merged over the data given by ac.data.set(). (This is a shallow merge.)
+
+Example
+#######
+
+BodyMojit/controller.server.js
+******************************
+
+FlickrMojit/binders/index.js
+****************************
+
 
 

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -523,12 +523,15 @@ As you saw in the :ref:`Data Addon Objects table`, the scope of the ``data`` obj
 limited to a mojit. In other words, the controller can use the ``data`` object to share 
 data with its binder or templates, but not with other mojits. When you set data
 with ``ac.data.set(key, value)``, the data is merged with the data passed to ``ac.done`` 
-(this is a shallow merge). 
+(this is a shallow merge).  The data is also serialized and rehydrated 
+on the client when the page is rendered in the browser.
 
 From the controller, you use ``ac.data.set`` to set or expose data that the binder 
 can access with the ``mojitProxy`` object. The ``mojitProxy`` accesses the
 set data with the ``data`` object as well with ``mojitProxy.data.get``. Templates can
 have Handlebars expressions to inject the set data into a page.
+
+
 
 The following example shows you how you would set data and then access it from the binder
 or the template.
@@ -666,6 +669,10 @@ In this example we're expanding on the idea of sharing stock price information.
 The ``StockQuoteMojit`` mojit shares the stock price quotes with other mojits
 with the ``pageData``. 
 
+The example shows how to access and attach shared data to the page from 
+the binder and the template, but in your applications, you would normally only 
+use one method, and the template approach is preferred.
+
 .. _page_data_ex-controller:
 
 mojits/StockQuotes/controller.server.js
@@ -693,7 +700,35 @@ mojits/StockQuotes/controller.server.js
      };
    }, '0.0.1', {requires: ['mojito', 'mojito-models-addon', 'StockQuotesModel', 'mojito-data-addon']});
 
-.. _page_data_ex-binder:
+.. _page_data_ex`-binder:
+
+mojits/StockTicker/binders/index.js
+***********************************
+
+.. code-block:: javascript
+
+   YUI.add('StockQuotesBinderIndex', function(Y, NAME) {
+     Y.namespace('mojito.binders')[NAME] = {
+       init: function(mojitProxy) {
+         this.mojitProxy = mojitProxy;
+       },
+       bind: function(node) {
+         // From the mojitProxy, you use the data object to get the 
+         // value for stock_quotes that was set in the controller.
+         this.mojitProxy.pageData.on('change', function('stock_quotes');
+         this.node = node;
+         var list = "<ul>";
+         for (var s in stock_list) {
+           list += "<li>" + s + ": $" + stock_list[s] + "</li>";
+         }
+         list += "</ul>";
+         node.one('#stocks p').setHTML(list);
+       }
+     };
+   }, '0.0.1', {requires: ['event-mouseenter', 'mojito-client']});
+
+
+.. _page_data_ex2-binder:
 
 mojits/StockPortfolio/binders/index.js
 **************************************
@@ -722,6 +757,8 @@ mojits/StockPortfolio/binders/index.js
    }, '0.0.1', {requires: ['event-mouseenter', 'mojito-client']});
 
 
+
+
 .. _page_data_ex-template:
 
 mojits/Ticker/views/index.hb.html
@@ -734,8 +771,10 @@ mojits/Ticker/views/index.hb.html
           made available through ac.pageData.set in the controller of
           another mojit.
      -->
-     {{#each stock_quotes}}
-       <a href="http://finance.yahoo.com/q?s={{.}}">{{.}}</a> |&nbsp;
-      {{/each}}
+     {{#page}}
+       {{#each stock_quotes}}
+         <a href="http://finance.yahoo.com/q?s={{.}}">{{.}}</a> |&nbsp;
+        {{/each}}
+      {{/page}}
    </div>
 

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -419,7 +419,7 @@ see `Using Cookies <../code_exs/cookies.html>`_.
 .. _data_cookie-get:
 
 Getting Cookie Data
-*******************
+###################
 
 The method ``cookie.get(name)`` is used to get the cookie value associated 
 with ``name``. In the example controller below, the cookie value 

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -9,7 +9,7 @@ binders, other mojits, as well as how to re-hydrate data.
 .. _mojito_data-getting:
 
 Getting Input and Cookie Data
-============================
+=============================
 
 .. _mojito_data-intro:
 
@@ -507,7 +507,7 @@ Requiring Data Addon
 The Data addon is required liked other addons in the controller by
 specifying the addon as a string in the ``required`` array:
 
-.. code-block::
+.. code-block:: javascript
 
    }, '0.0.1', {requires: ['mojito-data-addon']}); 
 
@@ -617,6 +617,7 @@ index.hb.html
      <div id="stocks">
        <p></p>
      </div>
+   </div>
 
 
 .. _mojito_data_sharing-page_data:
@@ -737,5 +738,4 @@ mojits/Ticker/views/index.hb.html
        <a href="http://finance.yahoo.com/q?s={{.}}">{{.}}</a> |&nbsp;
       {{/each}}
    </div>
-
 

--- a/docs/dev_guide/topics/mojito_data.rst
+++ b/docs/dev_guide/topics/mojito_data.rst
@@ -655,7 +655,7 @@ provide access to the same page model.
 Now that you have a better understand of the page model and the ``page`` object,
 you can understand why passing a ``page`` object to ``ac.done`` is in your controller
 is **not** a good idea: ``ac.done({ page: "some data"})`` will override all of the page data 
-(the data set with ``pageData.set`` and contained in the ``page object).
+(the data set with ``pageData.set`` and contained in the ``page`` object).
 
 .. _page_data-ex:
 

--- a/docs/dev_guide/topics/mojito_testing.rst
+++ b/docs/dev_guide/topics/mojito_testing.rst
@@ -638,7 +638,7 @@ Using run.js
 #. To run the functional tests, you use the option ``-u`` and specify
    the path with the option ``--path``:
    
-   ``$ ./run.js test –u —path unit —browser phantomjs``
+   ``$ ./run.js test -u --path unit --browser phantomjs``
 
 #. To run individual unit and functional tests, you pass the test descriptor (JSON test 
    configuration file) to ``run.js``. 
@@ -714,8 +714,8 @@ Unit Tests
 
 * Default location when running ``npm test``:
 
-  * unit tests (XML) - ``mojito/tests/unit/artifacts/arrowreport/result.xml``
-  * unit tests (JSON) - ``mojito/tests/unit/artifacts/arrowreport/result.json``
+  * unit tests (XML) - ``mojito/tests/unit/artifacts/arrowreport/arrow-report/arrow-test-summary.xml``
+  * unit tests (JSON) - ``mojito/tests/unit/artifacts/arrowreport/arrow-report/arrow-test-summary.json``
 
 * Use the option ``--reportFolder`` to specify the location to write test results:
 
@@ -728,18 +728,14 @@ Functional Tests
 
 * Default Location when running ``npm test``:
 
-  * functional tests (XML) - ``mojito/artifacts/arrowreport/result.xml``
-  * functional tests (JSON) - ``mojito/artifacts/arrowreport/result.json``  
+  * functional tests (XML) - ``mojito/artifacts/arrowreport/arrow-report/arrow-test-summary.xml``
+  * functional tests (JSON) - ``mojito/artifacts/arrowreport/arrow-report/arrow-test-summary.json``  
 
 * As with the test results for unit tests, use the option ``--reportFolder`` to specify the 
   location to write test results. 
 
   ``$ ./run.js test -u --path unit --browser phantomjs --reportFolder <dir>``
 
-   .. warning:: Do not write your test results to ``mojito/tests`` as the results
-                for each test will overwrite the results of prior tests. This is
-                why the default location is ``mojito/artifacts/arrowreport`` and
-                not ``mojito/tests/``.
 
    
    

--- a/docs/dev_guide/topics/mojito_using_contexts.rst
+++ b/docs/dev_guide/topics/mojito_using_contexts.rst
@@ -621,7 +621,7 @@ Creating Custom Contexts
 
 The Mojito framework defines default contexts that developers can map 
 configurations to. These default contexts are defined in the file 
-``dimensions.json <https://github.com/yahoo/mojito/blob/develop/source/lib/dimensions.json>`_ 
+`dimensions.json <https://github.com/yahoo/mojito/blob/develop/source/lib/dimensions.json>`_ 
 found in the Mojito source code. Developers can create an application-level 
 ``dimensions.json`` to define custom contexts that can be mapped to configurations 
 as well. 

--- a/docs/dev_guide/topics/mojito_using_contexts.rst
+++ b/docs/dev_guide/topics/mojito_using_contexts.rst
@@ -204,7 +204,7 @@ configurations:
    files. Mojito will use the more qualified contexts if present over more 
    general contexts. For example, if the merged base and request context is 
    ``"environment:prod, device:iphone"``, then Mojito will use it over either 
-   ``"device:iphone"`` or ``"env:prod"``. If ``"environment:prod, device:iphone"`` 
+   ``"device:iphone"`` or ``"environment:prod"``. If ``"environment:prod, device:iphone"`` 
    is not present, Mojito will use the request context over the base context 
    as the resolved context. 
   

--- a/lib/app/autoload/route-maker.common.js
+++ b/lib/app/autoload/route-maker.common.js
@@ -120,7 +120,7 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
             route.requires = {};
             matches = route.path.match(/:([^\/]+)/g);
             if (matches) {
-                for (i = 0; i < matches.length; i++) {
+                for (i = 0; i < matches.length; i += 1) {
                     route.requires[matches[i].substr(1)] = '[^&]+';
                 }
             }

--- a/lib/app/autoload/route-maker.common.js
+++ b/lib/app/autoload/route-maker.common.js
@@ -119,8 +119,8 @@ YUI.add('mojito-route-maker', function(Y, NAME) {
              */
             route.requires = {};
             matches = route.path.match(/:([^\/]+)/g);
-            for (i in matches) {
-                if (matches.hasOwnProperty(i)) {
+            if (matches) {
+                for (i = 0; i < matches.length; i++) {
                     route.requires[matches[i].substr(1)] = '[^&]+';
                 }
             }

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -497,8 +497,7 @@ MojitoServer.prototype.getHttpServer = function() {
  */
 MojitoServer.prototype.listen = function(port, host, callback) {
 
-    var logger, // <- not used in this function, cruft?
-        app = this._app,
+    var app = this._app,
         p = port || this._options.port,
         h = host || this._options.host,
         listenArgs = [p];

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -497,15 +497,10 @@ MojitoServer.prototype.getHttpServer = function() {
  */
 MojitoServer.prototype.listen = function(port, host, callback) {
 
-    var logger,
+    var logger, // <- not used in this function, cruft?
         app = this._app,
         p = port || this._options.port,
         h = host || this._options.host,
-        handler = function(err) {
-            if (callback) {
-                callback(err, app);
-            }
-        },
         listenArgs = [p];
 
     // Track startup time and use it to ensure we don't try to listen() twice.
@@ -524,15 +519,18 @@ MojitoServer.prototype.listen = function(port, host, callback) {
     if (h) {
         listenArgs.push(h);
     }
+
+    // close on app for callback
+    function handler(err) {
+        callback(err, app);
+    }
+
     if (callback) {
+        app.on('error', handler);
         listenArgs.push(handler);
     }
 
-    try {
-        app.listen.apply(app, listenArgs);
-    } catch (err) {
-        handler(err);
-    }
+    app.listen.apply(app, listenArgs);
 };
 
 

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -296,7 +296,7 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
     // running mojito start to dump metrics to disk.
     if (appConfig.perf) {
         yuiConfig.perf = appConfig.perf;
-        yuiConfig.perf.logFile = options.perf;
+        yuiConfig.perf.logFile = options.perf || yuiConfig.perf.logFile;
     }
 
     // getting yui module, or yui/debug if needed, and applying

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "commander": "1.0.1",
         "mockery": "~1.4.0",
         "node-static": ">0.6.8",
-        "yahoo-arrow": "0.0.75",
+        "yahoo-arrow": "~0.0.77",
         "benchmark": "1.x"
     },
     "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "Martin Cooper <mcooper@yahoo-inc.com>",
         "Isao Yagi <isao@yahoo-inc.com>",
         "Michael Ridgway <mridgway@yahoo-inc.com>",
-        "Caridy Patino <caridy@yahoo-inc.com>"
+        "Caridy Patino <caridy@yahoo-inc.com>",
+        "Lichun Zhan <lzhan@yahoo-inc.com>"
     ],
     "dependencies": {
         "colors": "*",
@@ -26,7 +27,7 @@
         "semver": "1.0.14",
         "wrench": "~1.3.9",
         "ycb": "~1.0.5",
-        "yui": "~3.9.1",
+        "yui": "~3.10.0",
         "yuidocjs": "~0.3.14",
         "yuitest": "~0.7.4",
         "yuitest-coverage": "~0.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mojito",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Mojito provides an architecture, components and tools for developers to build complex web applications faster.",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [

--- a/tests/func/applications/frameworkapp/common/mojits_subdir2/mojits/SimpleModel/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits_subdir2/mojits/SimpleModel/models/model.common.js
@@ -28,6 +28,7 @@ YUI.add('SimpleModelModel', function(Y) {
                     "url": "http://farm6.static.flickr.com/5446/8784176565_6f21f6b7d5.jpg"           
                 }
             ];
+            //add delay to simulate the async nature of YQL
             setTimeout(function() {
                 callback(photos);
             }, 10);

--- a/tests/func/applications/frameworkapp/common/mojits_subdir2/mojits/SimpleModel/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits_subdir2/mojits/SimpleModel/models/model.common.js
@@ -6,42 +6,34 @@ YUI.add('SimpleModelModel', function(Y) {
         },
           
         getTurkeyImages: function(callback) {
-            var API_KEY = '84921e87fb8f2fc338c3ff9bf51a412e';
-            var queryString = 'wild turkey';
-            var q = 'select * from flickr.photos.search where text="wild turkey" and api_key="' + API_KEY + '"';
-            Y.YQL(q, function(rawYqlData) {
-                Y.log(rawYqlData);
-                var rawPhotos = rawYqlData.query.results.photo,
-                    rawPhoto = null,
-                    photos = [],
-                    photo = null,
-                    i = 0;
-
-                for (; i<rawPhotos.length; i++) {
-                    rawPhoto = rawPhotos[i];
-                    photo = {
-                        title: rawPhoto.title,
-                        url: buildFlickrUrlFromRecord(rawPhoto)
-                    };
-                    // some flickr photos don't have titles, so force them
-                    if (!photo.title) {
-                        photo.title = "[" + queryString + "]";
-                    }
-                    photos.push(photo);
+            var photos = [
+                {
+                    "title": "Wild turkey1",
+                    "url": "http://farm8.static.flickr.com/7456/8802989034_d4be06b6c9.jpg"
+                },
+                {
+                    "title": "Wild turkey2",
+                    "url": "http://farm3.static.flickr.com/2810/8790605005_ffabf53846.jpg"      
+                },
+                {
+                    "title": "Wild turkey3",
+                    "url": "http://farm8.static.flickr.com/7345/8796117836_bf224fdbfe.jpg"
+                },
+                {
+                    "title": "Wild turkey4",
+                    "url": "http://farm6.static.flickr.com/5332/8795818514_85d111d8e7.jpg"           
+                },
+                {
+                    "title": "Wild turkey5",
+                    "url": "http://farm6.static.flickr.com/5446/8784176565_6f21f6b7d5.jpg"           
                 }
-                Y.log('calling callback with photos');
-                Y.log(photos);
+            ];
+            setTimeout(function() {
                 callback(photos);
-
-            });
+            }, 10);
         },
         
         getConfigFromModel: function(callback){
-            Y.log("********In MODEL*************");
-            Y.log("*********************"+this.cfg.myconfig0);
-            Y.log("*********************"+this.cfg.myconfig1);
-            Y.log("*********************"+this.cfg.myconfig2);
-            Y.log("*********************"+this.cfg.myconfig3);
             var data = {
                 myconfig0: this.cfg.myconfig0,
                 myconfig1: this.cfg.myconfig1,

--- a/tests/func/common/testsimplemodelclient.js
+++ b/tests/func/common/testsimplemodelclient.js
@@ -1,11 +1,7 @@
 /*
  * This is a basic func test for a Common application.
  */
-YUI({
-    useConsoleOutput: true,
-    useBrowserConsole: true,
-    logInclude: { TestRunner: true }
-}).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
+YUI.add("common-testsimplemodelclient", function(Y) {
    
     var suite = new Y.Test.Suite("Common: simplemodelclient");
 
@@ -27,4 +23,6 @@ YUI({
 
     Y.Test.Runner.add(suite);
 
-});
+}, '0.0.1', {requires: [
+    'node', 'node-event-simulate', 'test', 'console'
+]});

--- a/tests/func/common/testsimplemodelserver.js
+++ b/tests/func/common/testsimplemodelserver.js
@@ -1,12 +1,9 @@
 /*
  * This is a basic func test for a Common application.
  */
-YUI({
-    useConsoleOutput: true,
-    useBrowserConsole: true,
-    logInclude: { TestRunner: true }
-}).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
-   
+
+YUI.add("common-testsimplemodelserver", function(Y) {
+
     var suite = new Y.Test.Suite("Common: simplemodelserver");
 
     suite.add(new Y.Test.Case({
@@ -23,4 +20,7 @@ YUI({
     }));
 
     Y.Test.Runner.add(suite);
-});
+    
+}, '0.0.1', {requires: [
+    'node', 'node-event-simulate', 'test', 'console'
+]});

--- a/tests/func/examples/developerguide/test_unittest_model_controller.js
+++ b/tests/func/examples/developerguide/test_unittest_model_controller.js
@@ -10,6 +10,9 @@ YUI.add('example-testunitestmodelcontroller-tests', function (Y) {
         "test unittest_model_controller": function() {
             var that = this;
             that.wait(function(){
+                if(Y.all('a').item(0) === null){
+                    Y.Assert.fail("no pic found!");
+                }
                 for(i=0; i<Y.all('a').size(); i++){
                     Y.Assert.areEqual("static.flickr.com", Y.all('a').item(i).getAttribute('href').match(/static.flickr.com/gi));
                 };

--- a/tests/func/examples/developerguide/test_unittest_model_controller.js
+++ b/tests/func/examples/developerguide/test_unittest_model_controller.js
@@ -10,8 +10,9 @@ YUI.add('example-testunitestmodelcontroller-tests', function (Y) {
         "test unittest_model_controller": function() {
             var that = this;
             that.wait(function(){
-                if(Y.all('a').item(0) === null){
-                    Y.Assert.fail("no pic found!");
+                //if(Y.all('a').item(0) === null){
+                if(Y.all('a').size() === 0){
+                    Y.Assert.fail("No pic is shown on the page!");
                 }
                 for(i=0; i<Y.all('a').size(); i++){
                     Y.Assert.areEqual("static.flickr.com", Y.all('a').item(i).getAttribute('href').match(/static.flickr.com/gi));

--- a/tests/func/examples/developerguide/test_unittest_model_controller.js
+++ b/tests/func/examples/developerguide/test_unittest_model_controller.js
@@ -10,7 +10,6 @@ YUI.add('example-testunitestmodelcontroller-tests', function (Y) {
         "test unittest_model_controller": function() {
             var that = this;
             that.wait(function(){
-                //if(Y.all('a').item(0) === null){
                 if(Y.all('a').size() === 0){
                     Y.Assert.fail("No pic is shown on the page!");
                 }

--- a/tests/run.js
+++ b/tests/run.js
@@ -59,10 +59,6 @@ function test(cmd) {
     cmd.funcPath = path.resolve(cwd, cmd.funcPath || cmd.path || './func');
     if (cmd.reportFolder) {
         cmd.reportFolder = path.resolve(cwd, cmd.reportFolder);
-        if(cmd.reportFolder.indexOf(cwd) !== -1 && !cmd.unit){
-            console.log('Please specify a report directory outside of tests/');
-            process.exit(1);
-        }
     }
 
     if (cmd.unit) {
@@ -164,6 +160,7 @@ function runUnitTests (cmd, callback) {
         cwd + "/../node_modules/yahoo-arrow/index.js",
         "--descriptor=" + cmd.unitPath + '/' + descriptor,
         "--exitCode=true",
+        "--keepTestReport=true",
         "--report=true",
         "--reportFolder=" + arrowReportDir
     ];
@@ -325,6 +322,7 @@ function runFuncTests(cmd, desc, port, thispid, callback) {
         "--descriptor=" + desc,
         "--baseUrl=" + baseUrl,
         "--exitCode=true",
+        "--keepTestReport=true",
         "--report=true",
         "--reportFolder=" + arrowReportDir,
         "--config=" + cwd + "/config/config.js"

--- a/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
+++ b/tests/unit/lib/app/addons/ac/ac_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider": {
             "analytics.common": {
                 "params": {

--- a/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
+++ b/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider": {
             "config.server": {
                 "params": {
@@ -18,7 +18,7 @@
             },
             "dispatch-helper.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.js,../../../../../../lib/app/addons/rs/config.js,../../../../../../lib/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/yui.js,../../../../../../lib/app/autoload/store.server.js,../../../../../../lib/app/addons/rs/url.js",
+                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/yui.js,$$config.lib$$/app/autoload/store.server.js,$$config.lib$$/app/addons/rs/url.js",
                     "test": "./test-dispatch-helper.js",
                     "driver": "nodejs"
                 },
@@ -34,7 +34,7 @@
             },
             "selector.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/config.js",
+                    "lib": "$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/config.js",
                     "test": "./test-selector.js",
                     "driver": "nodejs"
                 },
@@ -50,7 +50,7 @@
             },
             "yui.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/addons/rs/yui.js,../../../../../../lib/app/addons/rs/config.js,../../../../../../lib/app/addons/rs/selector.js,../../../../../../lib/app/addons/rs/url.js,../../../../../../lib/app/autoload/store.server.js",
+                    "lib": "$$config.lib$$/app/addons/rs/yui.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/url.js,$$config.lib$$/app/autoload/store.server.js",
                     "test": "./test-yui.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
+++ b/tests/unit/lib/app/addons/view-engines/view-engine_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../../lib",
             "base": "../../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "hb.client" : {
                 "params" : {
@@ -18,7 +18,7 @@
             },
             "hb.server" : {
                 "params" : {
-                    "lib": "./../../../../../../lib/app/addons/view-engines/hb.server.js",
+                    "lib": "$$config.lib$$/app/addons/view-engines/hb.server.js",
                     "test" : "./test-hb.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/autoload/autoload_test_descriptor.json
+++ b/tests/unit/lib/app/autoload/autoload_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../../../lib",
             "base": "../../../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "action-context.common": {
                 "params": {
@@ -19,7 +19,7 @@
             "dispatch.server": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",
-                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.server.js",
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,$$config.lib$$/app/autoload/dispatch.server.js",
                     "test": "./test-dispatch.server.js"
                 },
                 "group": "fw,unit,server"
@@ -27,7 +27,7 @@
             "dispatch.client": {
                 "params": {
                     "page": "$$config.base$$/mojito-test.html",
-                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,./../../../../../lib/app/autoload/dispatch.client.js",
+                    "lib": "$$config.lib$$/app/autoload/action-context.common.js,$$config.lib$$/app/autoload/dispatch.client.js",
                     "test": "./test-dispatch.client.js"
                 },
                 "group": "fw,unit,client"
@@ -105,7 +105,7 @@
             },
             "store.server": {
                 "params": {
-                    "lib": "$$config.lib$$/app/autoload/store.server.js,./../../../../../lib/app/addons/rs/config.js,./../../../../../lib/app/addons/rs/selector.js,./../../../../../lib/app/addons/rs/url.js,./../../../../../lib/app/addons/rs/yui.js",
+                    "lib": "$$config.lib$$/app/autoload/store.server.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/url.js,$$config.lib$$/app/addons/rs/yui.js",
                     "test": "./test-store.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/middleware/middleware_test_descriptor.json
+++ b/tests/unit/lib/app/middleware/middleware_test_descriptor.json
@@ -66,7 +66,7 @@
             },
             "router": {
                 "params": {
-                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,../../../../../lib/app/autoload/route-maker.common.js,../../../../../lib/app/autoload/util.common.js",
+                    "lib": "$$config.lib$$/app/middleware/mojito-handler-tunnel.js,$$config.lib$$/app/autoload/route-maker.common.js,$$config.lib$$/app/autoload/util.common.js",
                     "test": "./test-router.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/app/mojits/mojits_test_descriptor.json
+++ b/tests/unit/lib/app/mojits/mojits_test_descriptor.json
@@ -10,7 +10,7 @@
         "dataprovider" : {
             "htmlframemojit-controller": {
                 "params": {
-                    "lib": "$$config.lib$$/app/mojits/HTMLFrameMojit/controller.server.js,./../../../../../lib/app/autoload/util.common.js",
+                    "lib": "$$config.lib$$/app/mojits/HTMLFrameMojit/controller.server.js,./$$config.lib$$/app/autoload/util.common.js",
                     "test": "./test-htmlframemojit-controller.server.js",
                     "driver": "nodejs"
                 },

--- a/tests/unit/lib/lib_test_descriptor.json
+++ b/tests/unit/lib/lib_test_descriptor.json
@@ -6,7 +6,7 @@
             "lib": "../../../lib",
             "base": "../../base"
         },
-        "commonlib": "$$config.base$$/mojito-test.js,./../../../lib/app/autoload/util.common.js",
+        "commonlib": "$$config.base$$/mojito-test.js,$$config.lib$$/app/autoload/util.common.js",
         "dataprovider" : {
             "mojito": {
                 "params": {

--- a/tests/unit/lib/test-mojito.js
+++ b/tests/unit/lib/test-mojito.js
@@ -349,6 +349,11 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                 args: [port, host, V.Function]
             });
 
+            Y.Mock.expect(app, {
+                method: 'on',
+                args: ['error', V.Function]
+            });
+
             this_scope._app = app;
             Mojito.Server.prototype.listen.call(this_scope, port, host, cb);
 
@@ -366,7 +371,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [port, host, V.Function]
+                args: [port, host]
             });
 
             this_scope._app = app;
@@ -382,6 +387,16 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                         verbose: false,
                         port: 9876,
                         host: 'conan'
+                    },
+                    _app: {
+                        listen: function(p, h) {
+                            A.areSame(9876, p);
+                            A.areSame('conan', h);
+                        },
+                        on: function(ev, cb) {
+                            A.areSame('error', ev);
+                            A.isFunction(cb);
+                        }
                     }
                 },
                 actual;
@@ -400,7 +415,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [this_scope._options.port, this_scope._options.host, V.Function]
+                args: [this_scope._options.port]
             });
 
             this_scope._app = app;
@@ -421,6 +436,10 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                             A.areSame(host, h);
                             A.isFunction(cb);
                             cb('fake error');
+                        },
+                        on: function(ev, cb) {
+                            A.areSame('error', ev);
+                            A.isFunction(cb);
                         }
                     }
                 };
@@ -445,7 +464,12 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
             Y.Mock.expect(app, {
                 method: 'listen',
-                args: [port, host, cb]
+                args: [port, host, V.Function]
+            });
+
+            Y.Mock.expect(app, {
+                method: 'on',
+                args: ['error', V.Function]
             });
 
             this_scope._app = app;


### PR DESCRIPTION
- Resolved conflicts
- Disabled the command jslint.js unit test which is causing the unit test suite to fail (command tests are no longer used in #next, and should be removed at some point - added a card to Trello)

Travis CI build results [here](https://travis-ci.org/yahoo/mojito/builds/7816388).
