### PR TITLE
Specify package depth level of node_modules dirs to load tests from

### DIFF
--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -209,7 +209,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
          *      those found in mojito (false).
          * @return {object} datastructure for configuring YUI
          */
-        getModulesConfig: function(env, justApp) {
+        getModulesConfig: function(env, justApp, depth) {
             var store = this.get('host'),
                 m,
                 mojit,
@@ -233,6 +233,9 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                         continue;
                     }
                     if (justApp && ('mojito' === res.source.pkg.name)) {
+                        continue;
+                    }
+                    if (depth !== undefined && res.source.pkg.depth > depth) {
                         continue;
                     }
                     modules[res.yui.name] = this._makeYUIModuleConfig(env, res);

--- a/lib/app/commands/test.js
+++ b/lib/app/commands/test.js
@@ -549,6 +549,7 @@ function runTests(opts) {
         path = libpath.resolve(opts.path),
         coverage = inputOptions.coverage,
         verbose = inputOptions.verbose,
+        depth = inputOptions.depth,
         store,
         testRunner,
         runNext,
@@ -586,7 +587,7 @@ function runTests(opts) {
             configureYUI(YUI, store);
 
             if (testType === 'app') {
-                testConfigs = store.yui.getModulesConfig('server').modules;
+                testConfigs = store.yui.getModulesConfig('server', null, depth).modules;
             }
         }
 
@@ -740,6 +741,7 @@ exports.run = run;
 
 exports.usage = usage = [
     'Options: -c --coverage  Instruments code under test and prints coverage report',
+    '         -d --depth     Depth of node_modules to include (0 = app only)',
     '         -v --verbose   Verbose logging',
     'To test a mojit:',
     '    mojito test mojit ./path/to/mojit/directory',
@@ -760,6 +762,11 @@ exports.options = [
     {
         longName: 'tmpdir',
         shortName: 't',
+        hasValue: true
+    },
+    {
+        longName: 'depth',
+        shortName: 'd',
         hasValue: true
     }
 ];


### PR DESCRIPTION
Specify package depth level of node_modules dirs to load tests from
Use the same depth config to get yui modules config.

When doing a `mojito test`, mojito will run all the tests in the app (or npm bundle package) as well as all the tests it finds recursively in the node_modules.

In some occasions it is desirable to run only the first level of tests (without going into node_modules), or specify the depth level (0=app, 1, 2, etc).

This change add the capability in the yui rs addon to specify the depth, as well as the -d option in the `test` command to specify it in the command line.

The default behavior of including all tests is kept for backwards compatibility when the option is not specified. 
