### PR TITLE
rm lazyloadrpc test from flatfile list

### DIFF
--- a/tests/func/common/html5apptest_descriptor.json
+++ b/tests/func/common/html5apptest_descriptor.json
@@ -84,13 +84,6 @@
                     "page" : "$$config.baseUrl$$/"
                 }
             },
-            "lazyloadrpc" : {
-                "group" : "smoke,common,lazyloadrpc",
-                "params" : {
-                    "test" : "testlazyloadrpcclient.js",
-                    "page" : "$$config.baseUrl$$/"
-                }
-            },
             "acmojitnoparamclient" : {
                 "group" : "smoke,html5app,acmojit",
                 "params" : {


### PR DESCRIPTION
The mojit has server affinity and will not work with flatfile. Remove the test from html5app test descriptor
