### PR TITLE
Use any glob pattern to run test subsets.

### DIFF
--- a/tests/run.js
+++ b/tests/run.js
@@ -400,14 +400,9 @@ function runMojitoApp(app, cliOptions, basePath, port, params, callback) {
 
 function runFuncAppTests(cmd, callback) {
     var descriptor = cmd.descriptor || '**/*_descriptor.json',
-        descriptors = [],
-        exeSeries = [];
-
-    if (descriptor === '**/*_descriptor.json') {
+        exeSeries = [],
         descriptors = glob.sync(cmd.funcPath + '/' + descriptor);
-    } else {
-        descriptors.push(cmd.funcPath + '/' + descriptor);
-    }
+
     async.forEachSeries(descriptors, function(des, callback) {
         var appConfig = JSON.parse(fs.readFileSync(des, 'utf8')),
             app = appConfig[0].config.application,


### PR DESCRIPTION
Currently there is a problem trying to run partial tests like this:
 ./run.js test -f --path func --descriptor examples/quickstartguide/*_descriptor.json

globs different than '**/8_descriptor.json' are ignored and only full descripto paths are taken into account.

Whit this change we can use either the full path or any glob to match the descriptors, as the command help says:
"--descriptor <value>    which descriptor to run. filename (or glob) relative to --path", which makes easier and less time consuming to run/validate individual tests.
