### PR TITLE
[docs|ex] Removed unnecessary routing paths in  in example and documentation.

### DIFF
--- a/docs/dev_guide/code_exs/multiple_mojits.rst
+++ b/docs/dev_guide/code_exs/multiple_mojits.rst
@@ -83,21 +83,6 @@ of the ``frame`` mojit and not in the route configuration.
          "verbs": ["get"],
          "path": "/",
          "call": "frame.index"
-       },
-       "header": {
-         "verbs": ["get"],
-         "path": "/header",
-         "call": "header.index"
-       },
-       "body": {
-         "verbs": ["get"],
-         "path": "/body",
-         "call": "body.index"
-       },
-       "footer": {
-         "verbs": ["get"],
-         "path": "/footer",
-         "call": "footer.index"
        }
      }
    ]
@@ -200,21 +185,6 @@ To set up and run ``multiple_mojits``:
             "verbs": ["get"],
             "path": "/",
             "call": "frame.index"
-          },
-          "header": {
-            "verbs": ["get"],
-            "path": "/header",
-            "call": "header.index"
-          },
-          "body": {
-            "verbs": ["get"],
-            "path": "/body",
-            "call": "body.index"
-          },
-          "footer": {
-            "verbs": ["get"],
-            "path": "/footer",
-            "call": "footer.index"
           }
         }
       ]

--- a/examples/developer-guide/multiple_mojits/routes.json
+++ b/examples/developer-guide/multiple_mojits/routes.json
@@ -5,21 +5,6 @@
       "verbs": ["get"],
       "path": "/", 
       "call": "parent.index"
-    },
-    "header": {
-      "verbs": ["get"],
-      "path": "/header",
-      "call": "header.index"
-    },
-    "body": {
-      "verbs": ["get"],
-      "path": "/body",
-      "call": "body.index"
-    },
-    "footer": { 
-      "verbs": ["get"],
-      "path": "/footer",
-      "call": "footer.index" 
-    } 
+    }
   }
 ]


### PR DESCRIPTION
Fixes issue #1124 (https://github.com/yahoo/mojito/issues/1124).
