### PR TITLE
fix #1192 apidocs for Data.common (ac.data and ac.pageData)

### DIFF
--- a/lib/app/addons/ac/data.common.js
+++ b/lib/app/addons/ac/data.common.js
@@ -16,8 +16,9 @@ YUI.add('mojito-data-addon', function (Y, NAME) {
 
     /**
      * <strong>Access point:</strong> <em>ac.data.*</em> and  <em>ac.pageData.*</em>
-     * Addon that provides access to the data and pageData models
-     * @class Data.common
+     * Addon that provides access to the data and pageData models.
+     * See also http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html#sharing-data
+     * @submodule Data.common
      */
     function Addon(command, adapter, ac) {
         var data = command.instance.data,
@@ -32,6 +33,28 @@ YUI.add('mojito-data-addon', function (Y, NAME) {
 
     // The trick here is not to define the plugin namespace,
     // so we can hang data and pageData from ac object directly.
+
+    /**
+     * <strong>Access point:</strong> <em>ac.data.*</em>
+     *
+     * A model for getting and setting data  that is shared by a single mojit
+     * controller, binder, and/or template.
+     *
+     * See also http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html#sharing-data
+     * @class data
+     * @namespace Data.common
+     * @uses Model.Vanilla
+     */
+    /**
+     * <strong>Access point:</strong> <em>ac.data.*</em>
+     *
+     * A model for getting and setting data that is shared between mojits on a page.
+     *
+     * See also http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html#sharing-data
+     * @class pageData
+     * @namespace Data.common
+     * @uses Model.Vanilla
+     */
 
     Y.namespace('mojito.addons.ac').data = Addon;
 

--- a/lib/app/addons/ac/data.common.js
+++ b/lib/app/addons/ac/data.common.js
@@ -46,7 +46,7 @@ YUI.add('mojito-data-addon', function (Y, NAME) {
      * @uses Model.Vanilla
      */
     /**
-     * <strong>Access point:</strong> <em>ac.data.*</em>
+     * <strong>Access point:</strong> <em>ac.pageData.*</em>
      *
      * A model for getting and setting data that is shared between mojits on a page.
      *

--- a/lib/app/autoload/model-vanilla.common.js
+++ b/lib/app/autoload/model-vanilla.common.js
@@ -14,7 +14,8 @@ YUI.add('model-vanilla', function (Y, NAME) {
     /**
     TODO: This will eventually become part of the YUI Core, (work in progress here
     https://github.com/yui/yui3/pull/323), and the only pending work in mojito will
-    be to remove this file :)
+    be to remove this file, and replace apidoc references to Model.Vanilla with
+    Y.Model.
 
     @module app
     @submodule model-vanilla
@@ -30,8 +31,6 @@ YUI.add('model-vanilla', function (Y, NAME) {
         YObject         = Y.Object;
 
     /**
-    TODO: Update description.
-
     Attribute-based data model with APIs for getting, setting, validating, and
     syncing attribute values.
 
@@ -39,6 +38,8 @@ YUI.add('model-vanilla', function (Y, NAME) {
     a regular prototype definition to mix in the model api with the AttributeCore
     and AttributeExtras to provide the exact same API that `Y.Model` exposes but
     with better performance when it comes to the server runtime.
+
+    See also http://yuilibrary.com/yui/docs/api/classes/Model.html
 
     @class Model.Vanilla
     @constructor

--- a/lib/app/autoload/mojit-proxy.client.js
+++ b/lib/app/autoload/mojit-proxy.client.js
@@ -50,18 +50,62 @@ YUI.add('mojito-mojit-proxy', function(Y, NAME) {
         this.config = opts.config;
 
         /**
-         * The mojit data model
+         * The mojit data model, for getting and setting data that is shared by
+         * a single mojit controller, binder, and/or template.
+         * Use this.data.get() and this.data.set(). See also
+         * http://yuilibrary.com/yui/docs/api/classes/Model.html
+         * and http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html#sharing-data
          * @property data
-         * @type {Object}
+         * @type {Model.Vanilla}
          */
         this.data = new Y.Model(opts.data || {});
+            /**
+             * Returns the value of the specified attribute.
+             * @method data.get
+             * @param {string} name Attribute name.
+             * @return {Any} Attribute value, or `undefined` if the attribute doesn't
+             * exist.
+             */
+            /**
+             * Sets the value of a single attribute.
+             * @method data.set
+             * @param {string} name Attribute name.
+             * @param {any} value Value to set.
+             * @param {Object} [options] Data to be mixed into the event facade
+             * of the `change` event(s) for these attributes.
+             *    @param {Boolean} [options.silent=false] If `true`, no `change`
+             *    event will be fired.
+             * @chainable
+             */
 
         /**
-         * The page data model
+         * The page data model, or getting and setting data that is shared
+         * between mojits on a page.
+         * Use this.pageData.get() and this.pageData.set(). See also
+         * http://yuilibrary.com/yui/docs/api/classes/Model.html
+         * and http://developer.yahoo.com/cocktails/mojito/docs/topics/mojito_data.html#sharing-data
          * @property pageData
-         * @type {Object}
+         * @type {Model.Vanilla}
          */
         this.pageData = opts.pageData;
+            /**
+             * Returns the value of the specified attribute.
+             * @method pageData.get
+             * @param {string} name Attribute name.
+             * @return {Any} Attribute value, or `undefined` if the attribute doesn't
+             * exist.
+             */
+            /**
+             * Sets the value of a single attribute.
+             * @method pageData.set
+             * @param {string} name Attribute name.
+             * @param {any} value Value to set.
+             * @param {Object} [options] Data to be mixed into the event facade
+             * of the `change` event(s) for these attributes.
+             *    @param {Boolean} [options.silent=false] If `true`, no `change`
+             *    event will be fired.
+             * @chainable
+             */
 
         /**
          * The context used to generate this page


### PR DESCRIPTION
This adds two items to the class nav in the mojito api docs, and references Model.Vanilla. Technically it's `Y.Model` on the server, but it is api-compatible.
- Data.common.pageData
- Data.common.data
