### PR TITLE
inject express into mojito instance

### DIFF
--- a/examples/newsboxes/app.js
+++ b/examples/newsboxes/app.js
@@ -10,11 +10,8 @@
 'use strict';
 
 var debug = require('debug')('app'),
-    express = require('express'),
-    mojito = require('../../'),
-    app;
-
-app = express();
+    app = require('express')(),
+    mojito = require('../../')(app);
 
 app.use(mojito.middleware());
 app.mojito.attachRoutes();

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -16,11 +16,8 @@ instantiate their app the `express` way.
 
 Usage:
 
-    var app = require('express'),
-        mojito = require('mojito'),
-        app;
-
-    app = express(); // Mojito instance will be created during that call
+    var app = require('express')(),
+        mojito = require('mojito')(app); // inject app into mojito, vis a versa
 
     app.use(mojito.middleware()); // register the Mojito specific middleware
 
@@ -38,11 +35,7 @@ Usage:
 'use strict';
 
 
-var debug = require('debug')('mojito'),
-    express = require('express'),
-    libpath = require('path'),
-    appProto = express.application,
-    defaultConfiguration = appProto.defaultConfiguration,
+var libpath = require('path'),
     libdispatcher = require('./dispatcher'),
     liblogger = require('./logger'),
     libmiddleware = require('./middleware'),
@@ -69,9 +62,13 @@ Mojito extension for Express.
 **/
 function Mojito(app) {
 
+    if (!(this instanceof Mojito)) {
+    	return new Mojito(app); // allow instantiation withoit "new"
+    }
+
     this._app = app;
     this._config = {};
-    extend(Mojito, libdispatcher, liblogger, libmiddleware, libtunnel);
+    extend(this, libdispatcher, liblogger, libmiddleware, libtunnel);
     app.mojito = {};
     this._init(app);
 
@@ -242,19 +239,6 @@ Mojito.prototype._configureAppInstance = function (app, store, options) {
 
 }; // _configureAppInstance
 
-
-/**
-Hook into `express` default configuration init phase.
-**/
-appProto.defaultConfiguration = function () {
-    defaultConfiguration.apply(this, arguments);
-
-    if (!this.mojito) {
-        var mojito = new Mojito(this);
-    } else {
-        debug('skipping creation of `app.mojito` because it is already defined');
-    }
-};
 
 //  ----------------------------------------------------------------------------
 //  EXPORT(S)


### PR DESCRIPTION
pass express app instance into mojito constructor explicitly,
instead of patching express.application.defaultConfiguration()
from mojito.js, and having app.js instantiate mojito by way of
express().
