### PR TITLE
expose the runtime YUI instance to RS addons

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,10 @@ Deprecations, Removals
 
 Features
 --------
+* The `lib/store.js` has a new `getAppConfig()` function. This is a better choice
+for reading the static application configuration than `createStore()`.
+* The resource store now exposes the server's runtime YUI instance via the
+`runtimeYUI` member. Resource store addons can access it via `this.get('host').runtimeYUI`.
 
 Bug Fixes
 ---------

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -56,18 +56,22 @@ global._mojito = {};
  * @return {MojitoServer}
  */
 function MojitoServer(options) {
+    var appConfig;
 
     this._options = options || {};
     this._options.port = this._options.port || process.env.PORT || 8666;
+    this._options.dir = this._options.dir || process.cwd();
+    this._options.context = this._options.context || {};
     this._options.mojitoRoot = __dirname;
 
     // TODO: Note we could pass some options to the express server instance.
     this._app = express.createServer();
 
+    appConfig = store.getAppConfig(this._options.dir, this._options.context);
+    this._options.Y = this._createYUIInstance(this._options, appConfig);
+    this._configureLogger(this._options.Y);
     this._app.store = store.createStore(this._options);
-
-    this._configureAppInstance(this._app, this._options);
-
+    this._configureAppInstance(this._app, this._options, appConfig);
     this._app.store.optimizeForEnvironment();
 
     return this;
@@ -245,38 +249,16 @@ MojitoServer.prototype._useMiddleware = function (app, dispatcher, midDir, midCo
 };
 
 /**
- * Adds Mojito framework components to the Express application instance.
- * @method _configureAppInstance
- * @param {Object} app The Express application instance to Mojito-enable.
- * @param {{port: number,
- *          dir: string,
- *          context: Object,
- *          appConfig: Object,
- *          verbose: boolean}} options An object containing server options.
+ * Creates the YUI instance.
+ * @private
+ * @method _createYUIInstance
+ * @param {Object} options The options as passed to the constructor.
+ * @param {Object} appConfig The static application configuration.
+ * @return {Object} The YUI instances.
  */
-MojitoServer.prototype._configureAppInstance = function(app, options) {
-    var store = app.store,
-        Y,
-        appConfig,
-        yuiConfig,
-        logConfig = {},
-        modules = [],
-        middleware,
-        midConfig,
-        debugConfig;
-
-    if (!options) {
-        options = {};
-    }
-    if (!options.dir) {
-        options.dir = process.cwd();
-    }
-    if (!options.context) {
-        options.context = {};
-    }
-
-    appConfig = store.getStaticAppConfig();
-    yuiConfig = (appConfig.yui && appConfig.yui.config) || {};
+MojitoServer.prototype._createYUIInstance = function(options, appConfig) {
+    var yuiConfig = (appConfig.yui && appConfig.yui.config) || {},
+        Y;
 
     // redefining "combine" and/or "base" in the server side have side effects
     // and might try to load yui from CDN, so we bypass them.
@@ -304,7 +286,28 @@ MojitoServer.prototype._configureAppInstance = function(app, options) {
         useSync: true
     });
 
-    this._configureLogger(Y);
+    return Y;
+};
+
+/**
+ * Adds Mojito framework components to the Express application instance.
+ * @private
+ * @method _configureAppInstance
+ * @param {Object} app The Express application instance to Mojito-enable.
+ * @param {{port: number,
+ *          dir: string,
+ *          context: Object,
+ *          appConfig: Object,
+ *          verbose: boolean}} options An object containing server options.
+ * @param {Object} appConfig The static application configuration.
+ */
+MojitoServer.prototype._configureAppInstance = function(app, options, appConfig) {
+    var store = app.store,
+        Y = options.Y,
+        modules = [],
+        middleware,
+        midConfig;
+
     modules = this._configureYUI(Y, store);
 
     // attaching all modules available for this application for the server side

--- a/lib/store.js
+++ b/lib/store.js
@@ -35,6 +35,8 @@ var Store = {};
  * @param {string "skip"|"initial"|"full"} options.preload Whether to preload
  *      the application. Defaults to "full". If you only care about appConfig
  *      and package.json you can use the 'skip' option which is faster.
+ * @param {object} options.Y The runtime Y instance used by the mojito server.
+ * This will be exposed to store addons as `store.runtimeYUI`.
  * @return Y.mojito.ResourceStore
  */
 Store.createStore = function(options) {
@@ -91,6 +93,8 @@ Store.createStore = function(options) {
     appConfig = store.getStaticAppConfig();
     Y.applyConfig((appConfig && appConfig.yui && appConfig.yui.config) || {});
 
+    store.runtimeYUI = options.Y;
+
     if ('initial' === options.preload) {
         store.preloadInitial();
     } else if ('skip' !== options.preload) {
@@ -99,6 +103,25 @@ Store.createStore = function(options) {
 
     return store;
 };
+
+
+/**
+ * Returns the application config.
+ * @method getAppConfig
+ * @param {string} dir The directory containing the application config.
+ * @param {Object} context The runtime context.
+ * @return {Object} The application config.
+ */
+Store.getAppConfig = function(dir, context) {
+    var store;
+    store = this.createStore({
+        root:       dir,
+        context:    context,
+        preload:    'skip'
+    });
+    return store.getStaticAppConfig();
+};
+
 
 //  ----------------------------------------------------------------------------
 //  EXPORT(S)

--- a/tests/unit/lib/test-mojito.js
+++ b/tests/unit/lib/test-mojito.js
@@ -665,8 +665,7 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
 
         'test configureAppInstance': function () {
             var dispatcher,
-                madeY,      // the Y instance made in mojito.js
-                appwtf = {
+                app = {
                     store: {
                         getAllURLDetails: function () {
                             return {};
@@ -713,16 +712,19 @@ YUI().use('mojito', 'mojito-test-extra', 'test', function (Y) {
                     use: function (x) {
                         dispatcher = x;
                     }
+                },
+                options = {},
+                appConfig = {
+                    perf: true,
+                    middleware: ['mojito-handler-dispatcher']
                 };
 
-            Mojito.Server.prototype._configureLogger = function(y) {
-                madeY = y;
-            };
-            Mojito.Server.prototype._configureAppInstance(appwtf);
+            options.Y = Mojito.Server.prototype._createYUIInstance(options, appConfig);
+            Mojito.Server.prototype._configureAppInstance(app, options, appConfig);
             dispatcher({command: {}}, {}, function() {});
-            A.isObject(madeY.mojito.Dispatcher.outputHandler, 'output handler object');
-            A.isObject(madeY.mojito.Dispatcher.outputHandler.page, 'page object');
-            A.isObject(madeY.mojito.Dispatcher.outputHandler.page.staticAppConfig, 'staticAppConfig object');
+            A.isObject(options.Y.mojito.Dispatcher.outputHandler, 'output handler object');
+            A.isObject(options.Y.mojito.Dispatcher.outputHandler.page, 'page object');
+            A.isObject(options.Y.mojito.Dispatcher.outputHandler.page.staticAppConfig, 'staticAppConfig object');
         }
 
     }));


### PR DESCRIPTION
This is made of the following changes:
- added `getAppConfig()` to `lib/store.js`
- rearranged the server startup to:
  - call new `getAppConfig()` to get YUI configuration
  - create YUI instance
  - create store, passing along the YUI instance
  - rest of server initialization as before
- update `Store.createStore()` to attach the passed YUI instances to the returned store object as `store.runtimeYUI`

This supersedes the non-addon changes in PR #1200 .
