### PR TITLE
[doc] Removed remnants of the old module naming syntax for models.

### DIFF
--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -378,7 +378,7 @@ To set up and run ``adding_view_engines``:
             });  
           }
         };
-      }, '0.0.1', {requires: ['mojito', 'myMojitModelFoo']});
+      }, '0.0.1', {requires: ['mojito', 'myMojitModel']});
  
 #. Create the template ``views/default_ve.hb.html`` that uses Handlebar 
    expressions with the following:

--- a/docs/dev_guide/topics/mojito_testing.rst
+++ b/docs/dev_guide/topics/mojito_testing.rst
@@ -441,7 +441,7 @@ controller.server.js
            });
          }
        };
-   }, '0.0.1', {requires: ['mojito', 'myMojitModelFoo']});
+   }, '0.0.1', {requires: ['mojito', 'myMojitModel']});
 
 .. _mock_addons_ex-controller_test:
 


### PR DESCRIPTION
Made sure that the old model naming syntax {mojit_name}Model{Name} is now  {mojit_name}Model in the code examples and snippets throughout the documentation.
