### PR TITLE
better output handler response header check

### DIFF
--- a/lib/output-handler.server.js
+++ b/lib/output-handler.server.js
@@ -123,7 +123,7 @@ OutputHandler.prototype = {
 
 
     _writeHeaders: function() {
-        if (!this.headersSent) {
+        if (!this.res.headersSent) {
 
             // passing a falsy reason phrase would break, because node uses every non-string arguments[1]
             // as header object/array
@@ -132,8 +132,6 @@ OutputHandler.prototype = {
             } else {
                 this.res.writeHead(this.statusCode || 200, this.headers);
             }
-
-            this.headersSent = true;
         }
     }
 };


### PR DESCRIPTION
The output handler was maintaining its own guard to prevent writing headers when they are already sent. This is not an efficient solution as the headers can potentially have been written by virtually anyone that has access to the response. This was causing our app to crash and stop when we had two errors.
