### PR TITLE
Pin express-state and express-map version to specific version for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     ],
     "dependencies": {
         "debug": "*",
-        "express-state": "~1.0.0",
-        "express-map": "~0.0.2",
+        "express-state": "1.0.1",
+        "express-map": "0.0.2",
         "glob": "~3.1.11",
         "js-yaml": "1.0.2",
         "mime": "1.2.4",


### PR DESCRIPTION
`express-map` is introducing some non-BC changes in their next release and mojito-next will have to be updated.
