### PR TITLE
Handle invalid context exceptions with output handler

### DIFF
--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -122,7 +122,12 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             // HookSystem::StartBlock
             Y.mojito.hooks.hook('dispatch', adapter.hook, 'start', command);
             // HookSystem::EndBlock
-            store.validateContext(command.context);
+            try {
+                store.validateContext(command.context);
+            } catch (err) {
+                adapter.error(err);
+                return;
+            }
 
             if (command.rpc) {
                 // forcing to dispatch command through RPC tunnel

--- a/tests/unit/lib/app/autoload/test-dispatch.server.js
+++ b/tests/unit/lib/app/autoload/test-dispatch.server.js
@@ -7,7 +7,7 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
 
     var suite = new Y.Test.Suite(NAME),
         A = Y.Assert,
-        dispatcher = Y.mojito.Dispatcher,
+        dispatcher,
         store,
         command,
         adapter;
@@ -17,6 +17,7 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
         name: 'dispatch',
 
         'setUp': function() {
+            dispatcher = Y.mojito.util.heir(Y.mojito.Dispatcher);
             store = {
                 getStaticAppConfig: function() {
                     return { yui: {} };
@@ -57,6 +58,7 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
         },
 
         'tearDown': function() {
+            dispatcher = null;
             store = null;
             command = null;
             adapter = null;
@@ -119,8 +121,7 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
 
         'test dispatch with valid controller': function () {
             var tunnel,
-                acCommand,
-                _createActionContext = dispatcher._createActionContext;
+                acCommand;
 
             errorTriggered = false;
             dispatcher.init(store, tunnel);
@@ -142,15 +143,11 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
                 }
             });
             A.areSame(command, acCommand, 'AC should be created based on the original command');
-
-            // restoring references
-            dispatcher._createActionContext = _createActionContext;
         },
 
         'test dispatch with invalid controller': function () {
             var tunnel,
-                adapterErrorCalled,
-                _createActionContext = dispatcher._createActionContext;
+                adapterErrorCalled;
 
             errorTriggered = false;
             dispatcher.init(store, tunnel);
@@ -168,16 +165,12 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
                 }
             });
             A.isTrue(adapterErrorCalled, 'adapter.error should be called for invalid controllers');
-
-            // restoring references
-            dispatcher._createActionContext = _createActionContext;
         },
 
         'test dispatch with invalid context': function () {
             var tunnel,
                 adapterError,
-                adapterErrorCalled,
-                _createActionContext = dispatcher._createActionContext;
+                adapterErrorCalled;
 
             dispatcher.init(store, tunnel);
             // if the expandInstance calls with an error, the tunnel
@@ -198,9 +191,6 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
             });
             A.isTrue(adapterErrorCalled, 'adapter.error should be called for invalid context');
             A.areEqual(400, adapterError.code, 'adapter.error should be called with custom error');
-
-            // restoring references
-            dispatcher._createActionContext = _createActionContext;
         },
 
         'test dispatch with rpc and tunnel': function () {

--- a/tests/unit/lib/app/autoload/test-dispatch.server.js
+++ b/tests/unit/lib/app/autoload/test-dispatch.server.js
@@ -185,6 +185,7 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
             store.validateContext = function (context) {
                 var error = new Error('Invalid context dimension key "foo"');
                 error.code = 400; //bad request
+                throw error;
             };
             dispatcher._createActionContext = function (c) {
                 A.fail('adapter.error should be called instead');

--- a/tests/unit/lib/app/autoload/test-dispatch.server.js
+++ b/tests/unit/lib/app/autoload/test-dispatch.server.js
@@ -173,6 +173,35 @@ YUI.add('mojito-dispatcher-server-tests', function(Y, NAME) {
             dispatcher._createActionContext = _createActionContext;
         },
 
+        'test dispatch with invalid context': function () {
+            var tunnel,
+                adapterError,
+                adapterErrorCalled,
+                _createActionContext = dispatcher._createActionContext;
+
+            dispatcher.init(store, tunnel);
+            // if the expandInstance calls with an error, the tunnel
+            // should be tried.
+            store.validateContext = function (context) {
+                var error = new Error('Invalid context dimension key "foo"');
+                error.code = 400; //bad request
+            };
+            dispatcher._createActionContext = function (c) {
+                A.fail('adapter.error should be called instead');
+            };
+            dispatcher.dispatch(command, {
+                error: function (error) {
+                    adapterError = error;
+                    adapterErrorCalled = true;
+                }
+            });
+            A.isTrue(adapterErrorCalled, 'adapter.error should be called for invalid context');
+            A.areEqual(400, adapterError.code, 'adapter.error should be called with custom error');
+
+            // restoring references
+            dispatcher._createActionContext = _createActionContext;
+        },
+
         'test dispatch with rpc and tunnel': function () {
             var tunnel,
                 tunnelCommand;


### PR DESCRIPTION
The `validateContext` method of the resource store throws exceptions for invalid contexts, however the dispatcher doesn't handle these exceptions and the app crashes.

```
Error: INVALID dimension key "foo"
    at RSAddonSuperBundle.Y.extend.validateContext (/git-data/common/utils/mojito-dimensions-base/addons/rs/super-bundle.server.js:198:33)
    at ResourceStore.<anonymous> (/git-data/apps/search-apps-news/node_modules/mojito/node_modules/yui/oop/oop-min.js:1:2230)
    at i.Method.exec (/git-data/apps/search-apps-news/node_modules/mojito/node_modules/yui/event-custom-base/event-custom-base-min.js:1:1161)
    at ResourceStore.o.(anonymous function).r.(anonymous function) [as validateContext] (/git-data/apps/search-apps-news/node_modules/mojito/node_modules/yui/event-custom-base/event-custom-base-min.js:1:616)
    at Object.Y.namespace.Dispatcher.dispatch (/git-data/apps/search-apps-news/node_modules/mojito/lib/app/autoload/dispatch.server.js:125:19)
    at Object.dispatcher [as handle] (/git-data/apps/search-apps-news/node_modules/mojito/lib/mojito.js:363:41)
    at next (/git-data/apps/search-apps-news/node_modules/mojito/node_modules/express/node_modules/connect/lib/http.js:204:15)
    at Object.handle (/git-data/apps/search-apps-news/node_modules/mojito/lib/app/middleware/mojito-router.js:101:13)
    at next (/git-data/apps/search-apps-news/node_modules/mojito/node_modules/express/node_modules/connect/lib/http.js:204:15)
    at run (/git-data/apps/search-apps-news/node_modules/mojito/lib/app/middleware/mojito-handler-tunnel.js:34:24)

//client sees this
Internal Server Error
```

With this small change the dispatcher handles gracefully invalid context errors, and gives users the ability to implement their own version of validateContext and throw custom errors, in our case some context dimensions would result in a "Bad request" 400 error instead of the default 500.

Instead of crashing we would get:

```
error: (outputhandler.server): { [Error: INVALID dimension key "foo"] code: 400 }
info: (outputhandler.server): done

// client sees this
Error: 400

Error details are not available.
```
