### PR TITLE
update arrow to v0.0.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "mojito-cli": "~0.1",
         "node-static": ">0.6.8",
         "wrench": "~1.3.9",
-        "yahoo-arrow": "0.0.82",
+        "yahoo-arrow": "0.0.86",
         "portfinder": "0.2.1"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Mojito integration job passed with arrow 0.0.86. 
Update mojito to use this verison of arrow so that we can continue setup Mojito job on node10.
