### PR TITLE
Introduce a backward compatibility change for mix and match middleware with Mojito. Unit tests included.

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -64,10 +64,21 @@ The most common usage is:
 
     app = express();
     libmojito.extend(app);
+    // Will load the middleware configuration from `application.json`
     app.use(libmojito.middleware());
 
-    // Or to use a specific Mojito middleware
+    // NOTE: Only Mojito built-in middleware are accessible via
+    //       `libmojito.middleware` object.
+    //       See `MOJITO_MIDDLEWARE` for the complete list.
+    //
+    // Or use the following format to specify explicit order:
+    //
     // app.use(libmojito.middleware['mojito-handler-static']);
+    // app.use(require('./middleware/my-middleware'));
+    // app.use(libmojito.middleware['mojito-handler-body']);
+    // app.use(libmojito.middleware['mojito-contextualizer']);
+    //
+    // etc etc
 
 @method middleware 
 @public

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -26,7 +26,7 @@ There are 2 use cases when `application.json have middleware configuration.
 The behavior is backward compatible with previous versions of Mojito.
 
 Usage:
-    
+
     app.use(libmojito.middleware());
 
 @module mojito
@@ -50,7 +50,6 @@ MOJITO_MIDDLEWARE = [
     'mojito-parser-cookies',
     'mojito-contextualizer',
     'mojito-handler-tunnel'
-    // 'mojito-handler-error'
 ];
 
 
@@ -67,7 +66,7 @@ The most common usage is:
     libmojito.extend(app);
     app.use(libmojito.middleware());
 
-    // TODO to use a specific Mojito middleware
+    // Or to use a specific Mojito middleware
     // app.use(libmojito.middleware['mojito-handler-static']);
 
 @method middleware 
@@ -132,7 +131,11 @@ function middleware() {
             } else {
                 mid  = libpath.join(appDir, m);
                 mid = require(mid);
-                handlers.push(mid(midConfig));
+                if (m.indexOf('mojito-') > -1) {
+                    handlers.push(mid(midConfig));
+                } else {
+                    handlers.push(mid);
+                }
             }
             debug('adding middleware %s to be exec', m);
         });
@@ -198,3 +201,4 @@ function middleware() {
 module.exports = {
     middleware: middleware
 };
+

--- a/tests/fixtures/middleware/foo.js
+++ b/tests/fixtures/middleware/foo.js
@@ -1,0 +1,5 @@
+
+module.exports = function (req, res, next) {
+    console.log('--------- foo exec');
+    next();
+};

--- a/tests/fixtures/middleware/foo.js
+++ b/tests/fixtures/middleware/foo.js
@@ -1,5 +1,4 @@
 
 module.exports = function (req, res, next) {
-    console.log('--------- foo exec');
     next();
 };

--- a/tests/fixtures/middleware/mojito-foo.js
+++ b/tests/fixtures/middleware/mojito-foo.js
@@ -1,9 +1,7 @@
 
 module.exports = function (midConfig) {
-    console.log('------ mojito-foo init');
     return function (req, res, next) {
         res.midConfig = midConfig;
-        console.log('------ mojito-foo exec');
         next();
     };
 };

--- a/tests/fixtures/middleware/mojito-foo.js
+++ b/tests/fixtures/middleware/mojito-foo.js
@@ -1,0 +1,9 @@
+
+module.exports = function (midConfig) {
+    console.log('------ mojito-foo init');
+    return function (req, res, next) {
+        res.midConfig = midConfig;
+        console.log('------ mojito-foo exec');
+        next();
+    };
+};

--- a/tests/unit/lib/lib_test_descriptor.json
+++ b/tests/unit/lib/lib_test_descriptor.json
@@ -39,6 +39,14 @@
                     "driver": "nodejs"
                 },
                 "group": "fw,unit,server"
+            },
+            "middleware": {
+                "params": {
+                    "lib": "$$config.lib$$/middleware.js",
+                    "test": "./test-middleware.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,unit,server"
             }
         }
     },

--- a/tests/unit/lib/test-middleware.js
+++ b/tests/unit/lib/test-middleware.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI, require, __dirname*/
+
+
+YUI().use('test', function (Y) {
+    var A = Y.Assert,
+        AA = Y.ArrayAssert,
+        OA = Y.ObjectAssert,
+        sub = Y.Lang.sub,
+        libpath = require('path'),
+        mockery = require('mockery'),
+        suite = new Y.Test.Suite('lib/dispatcher tests'),
+        libmiddleware,
+        req,
+        res,
+        next;
+
+    suite.add(new Y.Test.Case({
+        'setUp': function () {
+            libmiddleware = require('../../../lib/middleware');
+
+            req = {
+                app: {
+                    mojito: {
+                    }
+                }
+            };
+            res = {};
+            next = function () {};
+        },
+        'tearDown': function () {
+            libmiddleware = null;
+
+            req = null;
+            res = null;
+            next = null;
+        },
+
+        'test module.exports': function () {
+            A.isFunction(libmiddleware.middleware);
+        },
+
+        'test build-in middleware registration': function () {
+            A.isFunction(libmiddleware.middleware);
+            var mid = libmiddleware.middleware;
+
+            A.isFunction(mid['mojito-handler-static']);
+            A.isFunction(mid['mojito-parser-body']);
+            A.isFunction(mid['mojito-parser-cookies']);
+            A.isFunction(mid['mojito-contextualizer']);
+            A.isFunction(mid['mojito-handler-tunnel']);
+        },
+
+        'test middleware() function': function () {
+            var midFn = libmiddleware.middleware();
+
+            A.isFunction(midFn);
+        },
+
+        // verify that :
+        // - "mojito-*" named middleware export a function that returns a
+        //   middleware
+        // - otherwise should export middleware function
+        'test middleware() invocation': function () {
+            var midFn = libmiddleware.middleware(),
+                count = 0;
+
+            req.app.mojito = {
+                Y: {
+                    log: function () {}
+                },
+                store: {
+                    getStaticAppConfig: function () {
+                        return {
+                            middleware: [
+                                'mojito-foo.js',
+                                'foo.js'
+                            ]
+                        };
+                    }
+                },
+                options: {
+                    root: libpath.resolve(__dirname, '../../fixtures', 'middleware')
+                },
+                _options: {
+                    context: { foo: 'bar' }
+                }
+            };
+
+            next = function () { count = count + 1; };
+
+            midFn(req, res, next);
+
+            A.areEqual(1, count, 'next() should be invoked once');
+            A.isNotUndefined(res.midConfig.Y);
+            A.isNotUndefined(res.midConfig.store);
+            A.isNotUndefined(res.midConfig.logger);
+            A.isNotUndefined(res.midConfig.context);
+        }
+
+    }));
+
+    Y.Test.Runner.add(suite);
+});
+


### PR DESCRIPTION
`libmiddleware.middleware()` now can mix and match middleware that either exports a middleware function, or exports a function that returns a middleware function, based on the name convention of the middleware with the "mojito-" prefix.
