### PR TITLE
Search next

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
         "node": ">0.6",
         "npm": ">1.0"
     },
-    "peerDependencies": {
-    },
     "devDependencies": {
         "async": "*",
         "benchmark": "1.x",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "npm": ">1.0"
     },
     "peerDependencies": {
-        "express": "3.x"
+        "express": "3.4.1"
     },
     "devDependencies": {
         "async": "*",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "async": "*",
         "benchmark": "1.x",
         "commander": "1.0.1",
-        "express": "3.x",
         "mockery": "~1.4.0",
         "mojito-cli": "~0.1",
         "node-static": ">0.6.8",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
         "npm": ">1.0"
     },
     "peerDependencies": {
-        "express": "3.4.1"
     },
     "devDependencies": {
         "async": "*",
         "benchmark": "1.x",
         "commander": "1.0.1",
+        "express": "3.4.1",
         "mockery": "~1.4.0",
         "mojito-cli": "~0.1",
         "node-static": ">0.6.8",

--- a/tests/func/common/common_descriptor.json
+++ b/tests/func/common/common_descriptor.json
@@ -1227,14 +1227,14 @@
                             }
                         },
                         {
-                            "test" : "testmojitproxybroadcastdynamic.js",
-                            "testName": "part1"
-                        },
-                        {
                             "controller": "locator",
                             "params": {
                                 "value": "#childred"
                             }
+                        },
+                        {
+                            "test" : "testmojitproxybroadcastdynamic.js",
+                            "testName": "part1"
                         },
                         {
                             "test" : "testmojitproxybroadcastdynamic.js"


### PR DESCRIPTION
Changes in this PR:
- Now that Mojito extends Express, moving the `express` `peerDependencies` to `devDependencies`.
- Pinning the version of `express` to 3.4.1 to avoid the issues documented [https://github.com/visionmedia/express/issues/1816](https://github.com/visionmedia/express/issues/1816).

This should get us to blue builds.
