### PR TITLE
add checking to make sure testing element is loaded

### DIFF
--- a/tests/func/common/common_descriptor.json
+++ b/tests/func/common/common_descriptor.json
@@ -970,6 +970,12 @@
                             }
                         },
                         {
+                            "controller": "locator",
+                            "params": {
+                                "value": "#finalLazyResult"
+                            }
+                        },
+                        {
                             "test" : "testlazyloadclient.js"
                         }
                     ]


### PR DESCRIPTION
testlazyloadclient test failed when running with firefox.
