### PR TITLE
[docs] Updated the documentation for the developer guide code examples for v0.9.

### DIFF
--- a/docs/dev_guide/code_exs/adding_assets.rst
+++ b/docs/dev_guide/code_exs/adding_assets.rst
@@ -173,6 +173,48 @@ To create and run ``simple_assets``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+#. Confirm that your ``package.json`` has the correct dependencies as shown below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. Change to the directory of ``simple`` mojit.
 
    ``$ cd mojits/simple``
@@ -253,7 +295,7 @@ To create and run ``simple_assets``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/app_config.rst
+++ b/docs/dev_guide/code_exs/app_config.rst
@@ -101,9 +101,51 @@ To set up and run ``simple_config``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+#. Confirm that your ``package.json`` has the correct dependencies as shown below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/binding_events.rst
+++ b/docs/dev_guide/code_exs/binding_events.rst
@@ -693,6 +693,48 @@ To set up and run ``binding_events``:
         }
       ]
 
+#. Confirm that your ``app.js`` has the following content:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+#. Also, confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. Change to ``mojits/Pager``.
 #. To have the controller get data from the model and create links for paging, replace the 
    code in ``controller.server.js`` with the following:
@@ -961,7 +1003,7 @@ To set up and run ``binding_events``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/calling_yql.rst
+++ b/docs/dev_guide/code_exs/calling_yql.rst
@@ -273,7 +273,48 @@ To set up and run ``model_yql``:
           }
         }
       ]
+#. Update your ``app.js`` with the following:
 
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. Change to ``mojits/flickr``.
 #. Modify the mojit model to call YQL to get Flickr photos by creating the model 
    ``models/model.server.js`` with the code below.
@@ -428,7 +469,7 @@ To set up and run ``model_yql``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL below:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/cookies.rst
+++ b/docs/dev_guide/code_exs/cookies.rst
@@ -144,6 +144,48 @@ To set up and run ``using_cookies``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. Change to ``mojits/Cookie``.
 #. To set a cookie from your controller, replace the code in ``controller.server.js`` with 
    the following:
@@ -200,7 +242,7 @@ To set up and run ``using_cookies``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL below:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/dynamic_assets.rst
+++ b/docs/dev_guide/code_exs/dynamic_assets.rst
@@ -231,6 +231,50 @@ To create and run ``device_assets``:
         }
       ]
 
+. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 #. Change to ``mojits/device``.
 #. Modify your controller to dynamically add assets to the rendered template by replacing 
    the code in ``controller.server.js`` with the following:
@@ -385,7 +429,7 @@ To create and run ``device_assets``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/framed_assets.rst
+++ b/docs/dev_guide/code_exs/framed_assets.rst
@@ -157,6 +157,51 @@ To create and run ``framed_assets``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/framed``.
 #. Modify your controller to pass an array of objects to the template by replacing the 
    code in ``controller.server.js`` with the following:
@@ -225,7 +270,7 @@ To create and run ``framed_assets``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/generating_urls.rst
+++ b/docs/dev_guide/code_exs/generating_urls.rst
@@ -146,6 +146,51 @@ To set up and run ``generating_urls``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/GenerateURL``.
 #. Enable the controller to create a URL using the route paths defined in ``routes.json`` 
    by replacing the code in ``controller.server.js`` with the following:

--- a/docs/dev_guide/code_exs/global_assets.rst
+++ b/docs/dev_guide/code_exs/global_assets.rst
@@ -213,6 +213,50 @@ To set up and run ``global_assets``:
           }
         }
       ]
+. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 
 #. Create the file ``assets/ohhai.css`` using the following:
 
@@ -252,7 +296,7 @@ To set up and run ``global_assets``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application with the sad walrus image, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/htmlframe_view.rst
+++ b/docs/dev_guide/code_exs/htmlframe_view.rst
@@ -156,6 +156,51 @@ To set up and run ``htmlframe_mojit``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/framed``.
 #. Modify the controller of the ``framed`` mojit by replacing the code in 
    ``controller.server.js`` with the following:
@@ -200,7 +245,7 @@ To set up and run ``htmlframe_mojit``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/i18n_apps.rst
+++ b/docs/dev_guide/code_exs/i18n_apps.rst
@@ -223,6 +223,50 @@ To set up and run ``locale_i18n``:
           }
         }
       ]
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 
 #. Change to ``mojits/i18n``.
 #. Replace the code in ``controller.server.js`` with the following:
@@ -301,7 +345,7 @@ To set up and run ``locale_i18n``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application in the default language used by your browser, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/intermojit_communication.rst
+++ b/docs/dev_guide/code_exs/intermojit_communication.rst
@@ -405,6 +405,51 @@ To set up and run ``inter-mojit``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/Master``.
 #. To allow the ``Master`` to execute its children mojits, replace the code in 
    ``controller.server.js`` with the following:
@@ -607,7 +652,7 @@ To set up and run ``inter-mojit``:
 
 #. From the application directory, start the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/multiple_mojits.rst
+++ b/docs/dev_guide/code_exs/multiple_mojits.rst
@@ -188,6 +188,51 @@ To set up and run ``multiple_mojits``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/Frame``.
 #. To allow the ``Frame`` to execute its child mojits, replace the code in 
    ``controller.server.js`` with the following:
@@ -309,7 +354,7 @@ To set up and run ``multiple_mojits``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/query_params.rst
+++ b/docs/dev_guide/code_exs/query_params.rst
@@ -283,6 +283,50 @@ To set up and run ``using_parameters``:
           }
         }
       ]
+. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 
 #. Change to ``mojits/Query``.
 #. Modify the controller to access different query parameters by replacing the code in 
@@ -458,7 +502,7 @@ To set up and run ``using_parameters``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To see the query string parameters fetched by the controller, go to the URL with the 
    query string below:
 

--- a/docs/dev_guide/code_exs/route_config.rst
+++ b/docs/dev_guide/code_exs/route_config.rst
@@ -153,6 +153,51 @@ To set up and run ``configure_routing``:
    configured here to be used when HTTP GET calls are made on the paths 
    ``/index`` or ``/show``.
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/Routing``.
 #. Modify your controller to contain the ``index`` and ``show`` actions by 
    replacing the code in ``controller.server.js`` with the following:

--- a/docs/dev_guide/code_exs/scroll_views.rst
+++ b/docs/dev_guide/code_exs/scroll_views.rst
@@ -225,6 +225,50 @@ To set up and run ``scroll_views``:
           }
         }
       ]
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 
 #. Change to ``mojits/scroll``.
 #. To have the controller send image data to the template for the scrolling 
@@ -398,7 +442,7 @@ To set up and run ``scroll_views``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/simple_logging.rst
+++ b/docs/dev_guide/code_exs/simple_logging.rst
@@ -205,6 +205,51 @@ To set up and run ``simple_logging``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/log``.
 #. Modify your controller so that one log message uses the default log level and one log 
    message has the log level set by ``Y.log`` by replacing the code in 
@@ -265,7 +310,7 @@ To set up and run ``simple_logging``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. Open the URL below in a browser and look at the output from the Mojito 
    server. You should see the log messages from the controller that start 
    with the string "\[CONTROLLER]:". Notice that the two messages have 

--- a/docs/dev_guide/code_exs/simple_view_template.rst
+++ b/docs/dev_guide/code_exs/simple_view_template.rst
@@ -143,6 +143,51 @@ To set up and run ``simple_view``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/simple``.
 #. Modify the mojit controller to pass data to the view by replacing the 
    code in ``controller.server.js`` with the following:
@@ -188,7 +233,7 @@ To set up and run ``simple_view``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL below:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/view_engines.rst
+++ b/docs/dev_guide/code_exs/view_engines.rst
@@ -304,9 +304,53 @@ To set up and run ``adding_view_engines``:
         }
       ]
 
-#. Install the ``ejs`` module.
+#. Update your ``app.js`` with the following:
 
-   ``$ npm install ejs``
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``. Notice that we're adding the ``ejs`` module for rendering
+   embedded JavaScript (EJS) templates.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "ejs": "*",
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Create the addons directory for your view engine addon.
 
    ``$ mkdir -p addons/view-engines``
@@ -419,7 +463,7 @@ To set up and run ``adding_view_engines``:
 
 #. From your application directory, start Mojito.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. Open the following URL in your browser to see the template rendered by the 
    Handlebars rendering engine.   
 

--- a/docs/dev_guide/code_exs/views_multiple_devices.rst
+++ b/docs/dev_guide/code_exs/views_multiple_devices.rst
@@ -242,6 +242,51 @@ To set up and run ``device_views``:
         }
       ]
 
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
+
 #. Change to ``mojits/device``.
 #. Replace the code in ``controller.server.js`` with the following:
 
@@ -395,7 +440,7 @@ To set up and run ``device_views``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. To view your application, go to the URL:
 
    http://localhost:8666

--- a/docs/dev_guide/code_exs/yui_modules.rst
+++ b/docs/dev_guide/code_exs/yui_modules.rst
@@ -176,6 +176,50 @@ To set up and run ``yui_module``:
           }
         }
       ]
+#. Update your ``app.js`` with the following:
+
+   .. code-block:: javascript
+
+      'use strict';
+
+      var debug = require('debug')('app'),
+          express = require('express'),
+          libmojito = require('mojito'),
+          app;
+
+          app = express();
+          app.set('port', process.env.PORT || 8666);
+          libmojito.extend(app);
+
+          app.use(libmojito.middleware());
+          app.mojito.attachRoutes();
+
+          app.get('/status', function (req, res) {
+              res.send('200 OK');
+          });
+
+          app.listen(app.get('port'), function () {
+              debug('Server listening on port ' + app.get('port') + ' ' +
+              'in ' + app.get('env') + ' mode');
+          });
+          module.exports = app;
+
+#. Confirm that your ``package.json`` has the correct dependencies as show below. If not,
+   update ``package.json``.
+
+   .. code-block:: javascript
+
+      "dependencies": {
+          "debug": "*",
+           "mojito": "~0.9.0"
+      },
+      "devDependencies": {
+          "mojito-cli": ">= 0.2.0"
+      },
+
+#. From the application directory, install the application dependencies:
+
+   ``$ npm install``
 
 #. Create the ``yui_modules`` directory for storing the Storage Lite module.
 
@@ -250,7 +294,7 @@ To set up and run ``yui_module``:
 
 #. From the application directory, run the server.
 
-   ``$ mojito start``
+   ``$ node app.js``
 #. Go to the application at the URL below and enter some text into the form.
 
    http://localhost:8666/


### PR DESCRIPTION
Replaced `mojito start` with `node app.js` and added the following to the example steps:
- `app.js`
- dependences for `package.json`
- `npm install` to install dependencies.
