### PR TITLE
Fix the test module for mocking mojit models.

### DIFF
--- a/lib/app/autoload/mojito-test.common.js
+++ b/lib/app/autoload/mojito-test.common.js
@@ -35,11 +35,14 @@ YUI.add('mojito-test', function(Y, NAME) {
         source[name] = new EasyMock();
     }
 
-
     function createMockModel(source, name) {
+        source._models.push(name);
         source.models[name] = new EasyMock();
-    }
 
+        source.models.get = function () {
+            return source.models[name];
+        };
+    }
 
     function createMockExtra(source, ns, name) {
         var mock = new EasyMock();
@@ -61,6 +64,7 @@ YUI.add('mojito-test', function(Y, NAME) {
         opts = opts || {};
         mock._addons = [];
         mock.models = {};
+        mock._models = [];
         mock._extras = {};
 
         if (opts.addons) {
@@ -94,17 +98,17 @@ YUI.add('mojito-test', function(Y, NAME) {
         mock.verify = function() {
             var i,
                 j,
-                mockAddon;
+                mockAddon,
+                mockModel;
 
             YUITest.Mock.verify(mock);
             for (i = 0; i < mock._addons.length; i += 1) {
                 mockAddon = mock[mock._addons[i]];
                 mockAddon.verify();
             }
-            for (i in mock.models) {
-                if (mock.models.hasOwnProperty(i)) {
-                    mock.models[i].verify();
-                }
+            for (i = 0; i < mock._models.length; i += 1) {
+                mockModel = mock.models[mock._models[i]];
+                mockModel.verify();
             }
             for (i in mock._extras) {
                 if (mock._extras.hasOwnProperty(i)) {


### PR DESCRIPTION
With this fix, apps can test their models, which are now accessed via the `ac.models` addon, like this:

```
var ac = new Y.mojito.MockActionContext({
    addons: [ 'http' ],
    models: [ 'foo' ]
});

ac.models.get('foo').expect({
    method: 'getData',
    args: ...
});

controller.index(ac);

// somewhere in controller
ac.models.get('foo').getData(....);
```
