### PR TITLE
[code_exs] Updated the routing for the examples to use app.js, not routes.json.

### DIFF
--- a/docs/dev_guide/code_exs/route_config.rst
+++ b/docs/dev_guide/code_exs/route_config.rst
@@ -65,7 +65,7 @@ action is called from the ``custom-route`` instance.
 
    // Defining route `/custom-route` and executing (dispatching)
    // the action `index` of the mojit instance `mapped_mojit`.
-   app.get('/custom-route', libmojito.dispath('mapped_mojit.index'));
+   app.get('/custom-route', libmojito.dispatch('mapped_mojit.index'));
 
    app.listen(app.get('port'), function () {
       debug('Server listening on port ' + app.get('port') + ' ' +
@@ -104,7 +104,7 @@ for handling HTTP POST requests and calls the method ``post_params`` from the
 
    // Defining the route `/*` and executing (dispatching)
    // the action `post_params` of the mojit instance `post-route`.
-   app.post('/*', libmojito.dispath('post-route.post_params'));
+   app.post('/*', libmojito.dispatch('post-route.post_params'));
 
    app.listen(app.get('port'), function () {
       debug('Server listening on port ' + app.get('port') + ' ' +
@@ -169,15 +169,15 @@ To set up and run ``configure_routing``:
 
           // Defining route `GET /` and executing (dispatching)
           // the action `index` of the mojit instance `mapped_mojit`.
-          app.get('/', libmojito.dispath('mapped_mojit.index'));
+          app.get('/', libmojito.dispatch('mapped_mojit.index'));
 
           // Defining route `GET /index` and executing (dispatching)
           // the action `index` of the mojit instance `mapped_mojit`.
-          app.get('/index', libmojito.dispath('mapped_mojit.index'));
+          app.get('/index', libmojito.dispatch('mapped_mojit.index'));
 
           // Defining the route `POST /*` and executing (dispatching)
           // the action `post_params` of the mojit instance `post-route`.
-          app.post('/show', libmojito.dispath('mapped_mojit.show'));
+          app.post('/show', libmojito.dispatch('mapped_mojit.show'));
 
           app.get('/status', function (req, res) {
               res.send('200 OK');

--- a/examples/developer-guide/adding_view_engines/app.js
+++ b/examples/developer-guide/adding_view_engines/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+//app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('myMojit.default_ve'));
+app.get('/ejs', libmojito.dispatch('myMojit.added_ve'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/binding_events/app.js
+++ b/examples/developer-guide/binding_events/app.js
@@ -21,11 +21,18 @@ libmojito.extend(app);
 
 app.use(customContextualizerMiddleware());
 app.use(libmojito.middleware());
+
+// To use the routing configured in `routes.json`, which
+// is deprecated.
+// The controller uses the Url addon, which requires the
+// `routes.json` file.
 app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/configure_routing/app.js
+++ b/examples/developer-guide/configure_routing/app.js
@@ -19,11 +19,26 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+// Defining route `GET /` and executing (dispatching)
+// the action `index` of the mojit instance `mapped_mojit`.
+app.get('/', libmojito.dispatch('mapped_mojit.index'));
+
+// Defining route `GET /index` and executing (dispatching)
+// the action `index` of the mojit instance `mapped_mojit`.
+app.get('/index', libmojito.dispatch('mapped_mojit.index'));
+
+// Defining the route `POST /*` and executing (dispatching)
+// the action `post_params` of the mojit instance `post-route`.
+app.post('/show', libmojito.dispatch('mapped_mojit.show'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/02_mojits/app.js
+++ b/examples/developer-guide/dashboard/02_mojits/app.js
@@ -19,11 +19,19 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('github.index'));
+app.get('/header', libmojito.dispatch('header.index'));
+app.get('/body', libmojito.dispatch('body.index'));
+app.get('/footer', libmojito.dispatch('footer.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/03_frame_mojits/app.js
+++ b/examples/developer-guide/dashboard/03_frame_mojits/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('tribframe.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/04_composite_mojits/app.js
+++ b/examples/developer-guide/dashboard/04_composite_mojits/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('tribframe.index'));
+
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/04_composite_mojits/routes.json
+++ b/examples/developer-guide/dashboard/04_composite_mojits/routes.json
@@ -4,20 +4,5 @@
         "verbs": ["get"],
         "path": "/",
         "call": "tribframe.index"
-    },
-    "header": {
-        "verbs":["get"],
-        "path": "/header",
-        "call": "header.index"
-    },
-    "body": {
-        "verbs": ["get"],
-        "path": "/body",
-        "call": "body.index"
-    },
-    "footer": {
-        "verbs": ["get"],
-        "path": "/footer",
-        "call": "footer.index"
     }
 }]

--- a/examples/developer-guide/dashboard/05_getting_data/app.js
+++ b/examples/developer-guide/dashboard/05_getting_data/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('tribframe.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/05_getting_data/routes.json
+++ b/examples/developer-guide/dashboard/05_getting_data/routes.json
@@ -4,22 +4,5 @@
         "verbs": ["get"],
         "path": "/",
         "call": "tribframe.index"
-    },
-    "header": {
-        "verbs":["get"],
-        "path": "/header",
-        "call": "header.index"
-    },
-    "body": {
-        "verbs": ["get"],
-        "path": "/body",
-        "call": "body.index"
-    },
-    "footer": {
-        "verbs": ["get"],
-        "path": "/footer",
-        "call": "footer.index"
     }
-
-
 }]

--- a/examples/developer-guide/dashboard/06_testing/app.js
+++ b/examples/developer-guide/dashboard/06_testing/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('tribframe.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/06_testing/routes.json
+++ b/examples/developer-guide/dashboard/06_testing/routes.json
@@ -4,22 +4,5 @@
         "verbs": ["get"],
         "path": "/",
         "call": "tribframe.index"
-    },
-    "header": {
-        "verbs":["get"],
-        "path": "/header",
-        "call": "header.index"
-    },
-    "body": {
-        "verbs": ["get"],
-        "path": "/body",
-        "call": "body.index"
-    },
-    "footer": {
-        "verbs": ["get"],
-        "path": "/footer",
-        "call": "footer.index"
     }
-
-
 }]

--- a/examples/developer-guide/dashboard/07_binders/app.js
+++ b/examples/developer-guide/dashboard/07_binders/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('tribframe.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/07_binders/mojits/Blog/controller.server.js
+++ b/examples/developer-guide/dashboard/07_binders/mojits/Blog/controller.server.js
@@ -25,7 +25,7 @@ YUI.add('blog', function (Y, NAME) {
             var view_type = "yui", feedURL = "http://www.yuiblog.com/blog/feed/", title = "YUI Blog Posts";
 
 
-            ac.models.get('model').getData({}, feedURL, function (data) {
+            ac.models.get('blog').getData({}, feedURL, function (data) {
                 // add mojit specific css
                 ac.assets.addCss('./index.css');
 

--- a/examples/developer-guide/dashboard/07_binders/routes.json
+++ b/examples/developer-guide/dashboard/07_binders/routes.json
@@ -4,22 +4,5 @@
         "verbs": ["get"],
         "path": "/",
         "call": "tribframe.index"
-    },
-    "header": {
-        "verbs":["get"],
-        "path": "/header",
-        "call": "header.index"
-    },
-    "body": {
-        "verbs": ["get"],
-        "path": "/body",
-        "call": "body.index"
-    },
-    "footer": {
-        "verbs": ["get"],
-        "path": "/footer",
-        "call": "footer.index"
     }
-
-
 }]

--- a/examples/developer-guide/dashboard/08_adv_config/app.js
+++ b/examples/developer-guide/dashboard/08_adv_config/app.js
@@ -19,6 +19,9 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/', function (req, res, next) {
     req.params.view_type = "yui";

--- a/examples/developer-guide/dashboard/09_hb_templates/app.js
+++ b/examples/developer-guide/dashboard/09_hb_templates/app.js
@@ -19,6 +19,9 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/', function (req, res, next) {
     req.params.view_type = "yui";

--- a/examples/developer-guide/dashboard/10_localization/app.js
+++ b/examples/developer-guide/dashboard/10_localization/app.js
@@ -18,6 +18,10 @@ app = express();
 app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
+
 app.use(libmojito.middleware());
 
 app.get('/', function (req, res, next) {

--- a/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_en-US.js
+++ b/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_en-US.js
@@ -9,7 +9,7 @@
 
 YUI.add("lang/PageLayout_en-US", function (Y) {
     Y.Intl.add(
-        "PageLayout",  // associated module
+        "pagelayout",  // associated module
         "en-US",    // BCP 47 language tag  
         // key-value pairs for this module and language
         {

--- a/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_es-419.js
+++ b/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_es-419.js
@@ -8,7 +8,7 @@
 
 YUI.add("lang/PageLayout_es-419", function (Y) {
     Y.Intl.add(
-        "PageLayout",  // associated module 
+        "pagelayout",  // associated module 
         "es-419",    // BCP 47 language tag
         // key-value pairs for this module and language
         {

--- a/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_zh-Hans.js
+++ b/examples/developer-guide/dashboard/10_localization/mojits/PageLayout/lang/PageLayout_zh-Hans.js
@@ -8,7 +8,7 @@
 
 YUI.add("lang/PageLayout_zh-Hans", function (Y) {
     Y.Intl.add(
-        "PageLayout",  // associated module
+        "pagelayout",  // associated module
         "zh-Hans",    // BCP 47 language tag 
         // key-value pairs for this module and language
         {

--- a/examples/developer-guide/dashboard/trib/app.js
+++ b/examples/developer-guide/dashboard/trib/app.js
@@ -22,6 +22,10 @@ libmojito.extend(app);
 app.use(customContextualizerMiddleware());
 app.use(libmojito.middleware());
 
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
+
 app.get('/', function (req, res, next) {
     req.params.view_type = "yui";
     next();
@@ -31,10 +35,6 @@ app.get('/mojito', function (req, res, next) {
     req.params.view_type = "mojito";
     next();
 }, libmojito.dispatch('tribframe.index'));
-
-app.get('/header', libmojito.dispatch('header.index'));
-app.get('/body', libmojito.dispatch('body.index'));
-app.get('/footer', libmojito.dispatch('footer.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/dashboard/trib/routes.json
+++ b/examples/developer-guide/dashboard/trib/routes.json
@@ -11,21 +11,5 @@
         "path": "/mojito",
         "call": "tribframe.index",
         "params": {"view_type": "mojito"}
-    },
-    "header": {
-        "verbs":["get"],
-        "path": "/header",
-        "call": "header.index"
-    },
-    "body": {
-        "verbs": ["get"],
-        "path": "/body",
-        "call": "body.index"
-    },
-    "footer": {
-        "verbs": ["get"],
-        "path": "/footer",
-        "call": "footer.index"
     }
-
 }]

--- a/examples/developer-guide/device_assets/app.js
+++ b/examples/developer-guide/device_assets/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/device_views/app.js
+++ b/examples/developer-guide/device_views/app.js
@@ -19,11 +19,15 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('device.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/framed_assets/app.js
+++ b/examples/developer-guide/framed_assets/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/framed_config/app.js
+++ b/examples/developer-guide/framed_config/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/generating_urls/app.js
+++ b/examples/developer-guide/generating_urls/app.js
@@ -19,11 +19,20 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
+
+// This line allows you to use the routing
+// configuration in `routes.json`, which is deprecated.
+// In this example, you are using the Url addon to create an URL,
+// which depends on the routing configuration, so this line must
+// be uncommented.
 app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('mymojit.index'));
+app.get('/some-really-long-url-that-we-dont-need-to-remember-contactus', libmojito.dispatch('mymojit.contactus'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/global_assets/app.js
+++ b/examples/developer-guide/global_assets/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('ohhai.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/hello/app.js
+++ b/examples/developer-guide/hello/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('hello.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/htmlframe_mojit/app.js
+++ b/examples/developer-guide/htmlframe_mojit/app.js
@@ -19,11 +19,17 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/inter-mojit/app.js
+++ b/examples/developer-guide/inter-mojit/app.js
@@ -19,11 +19,18 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+
+app.get('/', libmojito.dispatch('frame.index'));
+app.get('/receiver/show', libmojito.dispatch('receiver.show'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/locale_i18n/app.js
+++ b/examples/developer-guide/locale_i18n/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/model_yql/app.js
+++ b/examples/developer-guide/model_yql/app.js
@@ -21,11 +21,16 @@ libmojito.extend(app);
 
 app.use(customContextualizerMiddleware());
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/multiple_mojits/app.js
+++ b/examples/developer-guide/multiple_mojits/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('parent.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/scroll_views/app.js
+++ b/examples/developer-guide/scroll_views/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/simple_assets/app.js
+++ b/examples/developer-guide/simple_assets/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('simple.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/simple_config/app.js
+++ b/examples/developer-guide/simple_config/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('simple.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/simple_logging/app.js
+++ b/examples/developer-guide/simple_logging/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/simple_view/app.js
+++ b/examples/developer-guide/simple_view/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('simple.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/unittest_model_controller/app.js
+++ b/examples/developer-guide/unittest_model_controller/app.js
@@ -21,11 +21,17 @@ libmojito.extend(app);
 
 app.use(customContextualizerMiddleware());
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/using_configs/app.js
+++ b/examples/developer-guide/using_configs/app.js
@@ -19,11 +19,17 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('corporate.index'));
+app.get('/booyah', libmojito.dispatch('subsidiary.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/using_cookies/app.js
+++ b/examples/developer-guide/using_cookies/app.js
@@ -19,11 +19,17 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('frame.index'));
+app.get('/example1', libmojito.dispatch('frame.example1'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/using_parameters/app.js
+++ b/examples/developer-guide/using_parameters/app.js
@@ -19,11 +19,23 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+
+app.get('/', libmojito.dispatch('frame.index'));
+app.get('/example1', libmojito.dispatch('frame.example1'));
+app.get('/example2', libmojito.dispatch('frame.example2'));
+app.post('/example2', libmojito.dispatch('frame.example2'));
+app.get('/example3', libmojito.dispatch('frame.example3', { "from": "routing", "foo": "bar", "bar": "foo" }));
+app.get('/example4', libmojito.dispatch('frame.example4', { "from": "routing", "foo3": "bar3" }));
+app.post('/example4', libmojito.dispatch('frame.example4', { "from": "routing", "foo3": "bar3" }));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +

--- a/examples/developer-guide/yui_module/app.js
+++ b/examples/developer-guide/yui_module/app.js
@@ -19,11 +19,16 @@ app.set('port', process.env.PORT || 8666);
 libmojito.extend(app);
 
 app.use(libmojito.middleware());
-app.mojito.attachRoutes();
+
+// To use the routing configured in `routes.json`, which
+// is deprecated, you uncomment this line.
+// app.mojito.attachRoutes();
 
 app.get('/status', function (req, res) {
     res.send('200 OK');
 });
+
+app.get('/', libmojito.dispatch('notepad.index'));
 
 app.listen(app.get('port'), function () {
     debug('Server listening on port ' + app.get('port') + ' ' +


### PR DESCRIPTION
The only examples that still attach routes from `routes.json` were those that used the Url addon, which requires the `routes.json`.  Some errors were also fixed in the dashboard module apps, which are not tested. 

Note: the `app.js` for each example has the line `app.mojito.attachRoutes();` commented out with a note about what it does and that `routes.json` has been deprecated.
