### PR TITLE
Read YUI modules only once

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,18 @@
+version 0.9.5
+=============
+
+Notes
+-----
+
+* Reduced start up time by up to 20% by capturing YUI module details and executing them in one step instead of separetely.
+* Now YUI modules are only executed once, with the real runtime YUI object scoped.
+* Syntax errors are now reported with line numbers after failing to compile YUI modules.
+
+Bug Fixes
+---------
+
+* Fixed issue where application start up would crash due to syntax error in a YUI module.
+
 version 0.9.4
 =============
 

--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -27,6 +27,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
         libmime = require('mime'),
         liburl  = require('url'),
         libutil = require('../../../util.js'),
+        Module = require('module'),
         serialize = require('express-state/lib/serialize'),
 
         WARN_SERVER_MODULES = /\b(dom-[\w\-]+|node-[\w\-]+|io-upload-iframe)/ig,
@@ -35,20 +36,6 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
             tests: true,
             yui_modules: true
         },
-
-        // creating a vm context to execute all files
-        // we want to reuse it because it is 200x faster
-        // than creating a new one per file
-        contextForRunInContext = libvm.createContext({
-            require: require,
-            module: require('module'),
-            console: {
-                log: function() {}
-            },
-            window: {},
-            document: {},
-            YUI: null
-        }),
 
         resourceSortByDepthTest = function (a, b) {
             return a.source.pkg.depth - b.source.pkg.depth;
@@ -1160,43 +1147,54 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
          */
         _captureYUIModuleDetails: function(res, runSandbox) {
 
-            var file,
-                ctx,
-                yui = {};
-            file = libfs.readFileSync(res.source.fs.fullPath, 'utf8');
-            // setting up the fake YUI before executing the file
-            contextForRunInContext.YUI = {
-                ENV: {},
-                config: {},
-                use: function() {},
-                add: function(name, fn, version, meta) {
-                    yui.name = name;
-                    yui.version = version;
-                    yui.meta = meta || {};
-                    if (!yui.meta.requires) {
-                        yui.meta.requires = [];
-                    }
-                    if (runSandbox) {
-                        try {
-                            fn(runSandbox, yui.name);
-                        } catch (e) {
-                            Y.log('failed to run javascript file ' + res.source.fs.fullPath + '\n' + e.message, 'error', NAME);
-                        }
+            var file = libfs.readFileSync(res.source.fs.fullPath, 'utf8'),
+                yui = {},
+                store = this.get('host'),
+                originalAdd = store.YUI.add,
+                mod = new Module(res.source.fs.fullPath, module);
+
+            mod.filename =  res.source.fs.fullPath;
+            mod.paths = Module._nodeModulePaths(libpath.dirname(res.source.fs.fullPath));
+
+            try {
+                mod._compile('module.exports = function (YUI) {' +
+                    'return (function () {' + file + '\n;}).apply(global);' +
+                    '};', res.source.fs.fullPath);
+            } catch (e1) {
+                Y.log('Error compiling ' + mod.filename +  ': ' + e1.message, 'error', NAME);
+                return;
+            }
+
+            store.YUI.add = function(name, fn, version, meta) {
+                if (res.affinity !== 'client') {
+                    originalAdd.apply(store.YUI, arguments);
+                }
+
+                yui.name = name;
+                yui.version = version;
+                yui.meta = meta || {};
+                if (!yui.meta.requires) {
+                    yui.meta.requires = [];
+                }
+
+                if (runSandbox) {
+                    try {
+                        fn(runSandbox, yui.name);
+                    } catch (e) {
+                        Y.log('failed to run javascript file ' + res.source.fs.fullPath + '\n' + e.message, 'error', NAME);
                     }
                 }
             };
+
             try {
-                libvm.runInContext(file, contextForRunInContext, res.source.fs.fullPath);
-            } catch (e) {
-                yui = null;
-                Y.log('failed to parse javascript file ' + res.source.fs.fullPath + '\n' + e.message, 'error', NAME);
-            }
-            if (yui) {
+                mod.exports(store.YUI);
                 res.yui = Y.merge(res.yui || {}, yui);
+            } catch (e2) {
+                Y.log('Error running ' + mod.filename + '\n' + e2.stack, 'error', NAME);
             }
+
+            store.YUI.add = originalAdd;
         }
-
-
     });
     Y.namespace('mojito.addons.rs');
     Y.mojito.addons.rs.yui = RSAddonYUI;

--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -101,6 +101,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
             // once during the preload process.
             syntheticStat = libfs.statSync(libpath.join(__dirname, '../../../..'));
 
+            this.afterHostMethod('preloadResourceVersions', this.preloadResourceVersions, this);
             this.afterHostMethod('findResourceVersionByConvention', this.findResourceVersionByConvention, this);
             this.beforeHostMethod('parseResourceVersion', this.parseResourceVersion, this);
             this.beforeHostMethod('addResourceVersion', this.addResourceVersion, this);
@@ -117,6 +118,10 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
             this.yuiModulesDetails = {};    // res.yui.name: static handler details
 
             this._langLoaderCreated = {};   // lang mapping indicating whether a lang specific loader has been created.
+        },
+
+        preloadResourceVersions: function () {
+            this._langLoaderCreated = {};
         },
 
         loadConfigs: function () {
@@ -521,6 +526,12 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                     }
                 };
                 this._captureYUIModuleDetails(res, sandbox);
+
+                if (!res.yui) {
+                    // This resource is not a valid YUI module and should not be added.
+                    return new Y.Do.Halt();
+                }
+
                 res.name = res.yui.name;
                 res.id = [res.type, res.subtype, res.name].join('-');
                 this.langs[res.yui.lang] = true;
@@ -550,6 +561,11 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                     return;
                 }
                 this._captureYUIModuleDetails(res);
+
+                if (!res.yui) {
+                    // This resource is not a valid YUI module and should not be added.
+                    return new Y.Do.Halt();
+                }
                 res.name = res.yui.name;
                 res.id = [res.type, res.subtype, res.name].join('-');
                 return new Y.Do.Halt(null, res);
@@ -1137,7 +1153,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
 
         /**
          * If the resource is a YUI module, augments its metadata with metadata
-         * about the YUI module.
+         * about the YUI module and execute the module if it has a server/common affinity.
          * @private
          * @method _captureYUIModuleDetails
          * @param {object} res resource metadata
@@ -1148,7 +1164,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
         _captureYUIModuleDetails: function(res, runSandbox) {
 
             var file = libfs.readFileSync(res.source.fs.fullPath, 'utf8'),
-                yui = {},
+                yui = res.yui || {},
                 store = this.get('host'),
                 originalAdd = store.YUI.add,
                 mod = new Module(res.source.fs.fullPath, module);
@@ -1165,8 +1181,14 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
                 return;
             }
 
+            // Hook into YUI.add in order to capture the module's YUI metadata.
             store.YUI.add = function(name, fn, version, meta) {
-                if (res.affinity !== 'client') {
+                // Check YUI.Env.mods to make sure the same module is not added multiple times.
+                // This is important because if multiple modules have the same name, Mojito uses the first one,
+                // so it should not be overwritten.
+                if (res.affinity !== 'client' && !store.YUI.Env.mods[name]) {
+                    // Client side modules are never used on the server so only add
+                    // modules with server or common affinity.
                     originalAdd.apply(store.YUI, arguments);
                 }
 
@@ -1188,7 +1210,7 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
 
             try {
                 mod.exports(store.YUI);
-                res.yui = Y.merge(res.yui || {}, yui);
+                res.yui = yui;
             } catch (e2) {
                 Y.log('Error running ' + mod.filename + '\n' + e2.stack, 'error', NAME);
             }

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -116,6 +116,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
     libs.semver = require('semver');
     libs.walker = require('./package-walker.server');
     libs.util = require('../../util.js');
+    libs.logger = require('../../logger.js');
 
     // The Affinity object is to manage the use of the affinity string in
     // filenames.  Some files have affinities that have multiple parts
@@ -202,6 +203,9 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this._unloadedDirs = {};     // mojit mapping to an array of unprocessed directories, when lazyMojits is on.
             this._updateLoaderCount = 0; // count keeping track of newly loaded mojits requiring the loader to be updated.
 
+            this.YUI = null; // The runtime YUI object.
+            this.Y = null;   // The runtime YUI instance.
+
             /**
              * All selectors that are actually in the app.
              * Key is selector, value is just boolean `true`.
@@ -229,6 +233,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this.plug(Y.mojito.addons.rs.config, { appRoot: this._config.root, mojitoRoot: this._config.mojitoRoot });
 
             this.loadConfigs();
+
+            this._createRuntimeYUIInstance();
 
             Y.log('Store initialized', 'info', NAME);
         },
@@ -1697,6 +1703,50 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
         // PRIVATE METHODS
 
         /**
+         * Creates the YUI instance used by the application's server-side.
+         *
+         * @method _createRuntimeYUIInstance
+         * @private
+         * @param {Object} options Same as the `options` parameter to `_configureAppInstance()`.
+         * @param {Object} appConfig The static configuration for the application.
+         */
+        _createRuntimeYUIInstance: function () {
+            var appConfig = this.getStaticAppConfig(),
+                yuiConfig;
+
+            yuiConfig = (appConfig.yui && appConfig.yui.config) || {};
+
+            // redefining "combine" and/or "base" in the server side have side effects
+            // and might try to load yui from CDN, so we bypass them.
+            // TODO: report bug.
+            // is there a better alternative for this delete?
+            // maybe not, but it might introduce a perf penalty
+            // in v8 engine, and we can't use the undefined trick
+            // because loader is doing hasOwnProperty :(
+            delete yuiConfig.combine;
+            delete yuiConfig.base;
+
+            // in case we want to collect some performance metrics,
+            // we can do that by defining the "perf" object in:
+            // application.json (master)
+            // You can also use the option --perf path/filename.log when
+            // running mojito start to dump metrics to disk.
+            if (appConfig.perf) {
+                yuiConfig.perf = appConfig.perf;
+                yuiConfig.perf.logFile = this._config.perf || yuiConfig.perf.logFile;
+            }
+
+            // getting yui module, or yui/debug if needed, and applying
+            // the default configuration from application.json->yui-config
+            this.YUI = require('yui' + (yuiConfig.filter === 'debug' ? '/debug' : '')).YUI;
+            this.Y = this.YUI(yuiConfig, {
+                useSync: true
+            });
+
+            libs.logger.configureLogger(this.Y);
+        },
+
+        /**
          * Used for unit testing.
          * @private
          * @method _mockLib
@@ -2138,7 +2188,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 this.yui.getMojitModulesConfig(mojitType, modules, 'server', false, this.lazyLangs && details.closestLang);
 
                 // Inform app's YUI instance about the new modules.
-                this._appY.applyConfig({
+                this.Y.applyConfig({
                     modules: modules
                 });
 
@@ -2150,8 +2200,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 }
 
                 // Use the new modules.
-                this._appY.applyConfig({ useSync: true });
-                this._appY.use.apply(this._appY, modules);
+                this.Y.applyConfig({ useSync: true });
+                this.Y.use.apply(this.Y, modules);
 
                 this._updateLoaderCount++;
             } else {

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -117,6 +117,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
     libs.walker = require('./package-walker.server');
     libs.util = require('../../util.js');
     libs.logger = require('../../logger.js');
+    libs.yuiFactory =  require('../../yui-sandbox.js');
 
     // The Affinity object is to manage the use of the affinity string in
     // filenames.  Some files have affinities that have multiple parts
@@ -233,8 +234,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this.plug(Y.mojito.addons.rs.config, { appRoot: this._config.root, mojitoRoot: this._config.mojitoRoot });
 
             this.loadConfigs();
-
-            this._createRuntimeYUIInstance();
 
             Y.log('Store initialized', 'info', NAME);
         },
@@ -1202,6 +1201,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this._mojitRVs = {};
             this._packagesVisited = {};
 
+            this.YUI = null;
+            this.Y = null;
+            this._createRuntimeYUIInstance();
+
             walker = new this._libs.walker.BreadthFirst(this._config.root);
             walker.walk(function(err, info) {
                 if (err) {
@@ -1738,7 +1741,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             // getting yui module, or yui/debug if needed, and applying
             // the default configuration from application.json->yui-config
-            this.YUI = require('yui' + (yuiConfig.filter === 'debug' ? '/debug' : '')).YUI;
+            this.YUI = libs.yuiFactory.getYUI(yuiConfig.filter);
             this.Y = this.YUI(yuiConfig, {
                 useSync: true
             });

--- a/lib/mojito.js
+++ b/lib/mojito.js
@@ -97,7 +97,6 @@ Mojito.prototype._init = function () {
         options = this._options,
         context = options.context,
         appRoot = process.cwd(),
-        appConfig,      // application.json
         store;          // reference to resource store
 
     if (!app.mojito) {
@@ -105,15 +104,12 @@ Mojito.prototype._init = function () {
     }
 
     context.runtime = 'server';
-    appConfig = libstore.getAppConfig(appRoot, context);
 
     options.root = appRoot;
-    options.Y = this._createYUIInstance(options, appConfig);
-    liblogger.configureLogger(options.Y);
 
     store = libstore.createStore(options);
 
-    this._configureAppInstance(app, store, options, appConfig);
+    this._configureAppInstance(app, store, options);
 };
 
 
@@ -141,58 +137,17 @@ Mojito.prototype._configureYUI = function (Y, store) {
     // NOTE:  Not all of these module names are guaranteed to be valid,
     // but the loader tolerates them anyways.
     for (lang in store.yui.langs) {
-        if (store.yui.langs.hasOwnProperty(lang) && lang) {
+        // Make sure that YUI has the module.
+        // This prevents warning messages regarding missing modules.
+        if (store.Y.Env.lang.hasOwnProperty(lang)) {
             load.push('lang/datatype-date-format_' + lang);
         }
     }
-
     return load;
 };
 
 
-/**
-Creates the YUI instance used by the server.
 
-@method _createYUIInstance
-@protected
-@param {Object} options Same as the `options` parameter to `_configureAppInstance()`.
-@param {Object} appConfig The static configuration for the application.
-*/
-Mojito.prototype._createYUIInstance = function (options, appConfig) {
-    var yuiConfig,
-        modules = [],
-        Y;
-
-    yuiConfig = (appConfig.yui && appConfig.yui.config) || {};
-
-    // redefining "combine" and/or "base" in the server side have side effects
-    // and might try to load yui from CDN, so we bypass them.
-    // TODO: report bug.
-    // is there a better alternative for this delete?
-    // maybe not, but it might introduce a perf penalty
-    // in v8 engine, and we can't use the undefined trick
-    // because loader is doing hasOwnProperty :(
-    delete yuiConfig.combine;
-    delete yuiConfig.base;
-
-    // in case we want to collect some performance metrics,
-    // we can do that by defining the "perf" object in:
-    // application.json (master)
-    // You can also use the option --perf path/filename.log when
-    // running mojito start to dump metrics to disk.
-    if (appConfig.perf) {
-        yuiConfig.perf = appConfig.perf;
-        yuiConfig.perf.logFile = options.perf || yuiConfig.perf.logFile;
-    }
-
-    // getting yui module, or yui/debug if needed, and applying
-    // the default configuration from application.json->yui-config
-    Y = require('yui' + (yuiConfig.filter === 'debug' ? '/debug' : '')).YUI(yuiConfig, {
-        useSync: true
-    });
-
-    return Y;
-};
 
 
 /**
@@ -206,10 +161,9 @@ Adds Mojito framework components to the Express application instance.
     @param {Object} options.context static context set at startup
     @param {String} options.mojitoRoot
     @param {String} options.root the app root dir
-@param {Object} appConfig The static configuration for the application.
 **/
-Mojito.prototype._configureAppInstance = function (app, store, options, appConfig) {
-    var Y = options.Y,
+Mojito.prototype._configureAppInstance = function (app, store, options) {
+    var Y = store.Y,
         modules = [];
 
     modules = this._configureYUI(Y, store);
@@ -230,10 +184,6 @@ Mojito.prototype._configureAppInstance = function (app, store, options, appConfi
     Y.use.apply(Y, modules);
     Y.applyConfig({ useSync: false });
 
-    // Give the store access to the application YUI instance, so that it can use newly added modules
-    // when either lazyMojits or lazyLangs is on.
-    store._appY = Y;
-
     libextend(app.mojito, {
         store: store,
         Y: Y,
@@ -244,9 +194,7 @@ Mojito.prototype._configureAppInstance = function (app, store, options, appConfi
     });
 
     console.log('✔\tMojito ready to serve.');
-
-}; // _configureAppInstance
-
+};
 
 
 //  ----------------------------------------------------------------------------

--- a/lib/store.js
+++ b/lib/store.js
@@ -35,16 +35,15 @@ var Store = {};
  * @param {string "skip"|"initial"|"full"} options.preload Whether to preload
  *      the application. Defaults to "full". If you only care about appConfig
  *      and package.json you can use the 'skip' option which is faster.
- * @param {object} options.Y The runtime Y instance used by the mojito server.
- * This will be exposed to store addons as `store.runtimeYUI`.
  * @return Y.mojito.ResourceStore
  */
 Store.createStore = function(options) {
 
     var store,
+        Y,
         YUI,
         appConfig,
-        Y;
+        yuiConfig;
 
     if (!options) {
         options = {};
@@ -87,13 +86,13 @@ Store.createStore = function(options) {
     store = new Y.mojito.ResourceStore({
         root: options.root,
         context: options.context,
-        appConfig: options.appConfig
+        appConfig: options.appConfig,
+        perf: options.perf
     });
 
     appConfig = store.getStaticAppConfig();
-    Y.applyConfig((appConfig && appConfig.yui && appConfig.yui.config) || {});
 
-    store.runtimeYUI = options.Y;
+    Y.applyConfig((appConfig && appConfig.yui && appConfig.yui.config) || {});
 
     if ('initial' === options.preload) {
         store.preloadInitial();

--- a/tests/unit/lib/app/addons/rs/test-yui.js
+++ b/tests/unit/lib/app/addons/rs/test-yui.js
@@ -53,6 +53,7 @@ YUI().use(
             this._mojits = {};
             this.publish('getMojitTypeDetails', {emitFacade: true, preventable: false});
             this._appConfig = { yui: {} };
+            this.YUI = { add: function () {}, Env: { mods: {} } };
         },
 
         listAllMojits: function() {
@@ -347,6 +348,7 @@ YUI().use(
             store._fwConfig = store.config.readConfigSimple(libpath.join(mojitoRoot, 'config.json'));
             store._appConfigStatic = store.getStaticAppConfig();
             store.plug(Y.mojito.addons.rs.yui, { appRoot: fixtures, mojitoRoot: mojitoRoot } );
+            store.YUI = { add: function () {}, Env: { mods: {} } };
 
             var pkg = { name: 'test', version: '6.6.6' };
             var mojitType = 'testing';

--- a/tests/unit/lib/app/autoload/test-store.server.js
+++ b/tests/unit/lib/app/autoload/test-store.server.js
@@ -271,8 +271,7 @@ YUI().use(
                     appResources: Y.clone(store._appResources, true),
                     mojitResources: Y.clone(store._mojitResources, true)
                 };
-                // clear yui rs _langLoaderCreated such that the loaders are created again.
-                store.yui._langLoaderCreated = {};
+
                 store.preload();
                 var post = {
                     appRVs: Y.clone(store._appRVs, true),


### PR DESCRIPTION
Currently YUI modules are read twice; once to capture YUI metadata and then again when they are actually added to the runtime YUI. This is inefficient since each module requires two synchronous reads, and potentially problematic since part of the code is executed twice. This pull request manages to capture YUI metadata and adds YUI modules at the same time by hooking into the YUI.add method. This reduces startup time by up to 20%, and only executes modules once with the actual YUI object. Instead of using VM to execute modules, it does exactly what YUI does (wrapping code in module.exports); this actually allows us to capture the line number of syntax errors and runtime errors within the module (VM does not give line numbers).
