### PR TITLE
Intl Addon Fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+version 0.9.5
+=============
+
+Notes
+-----
+
+* Better handling of translations in the Intl addon, which finds the best available lang while avoiding potential interference from a previously set language.
+
 version 0.9.4
 =============
 

--- a/lib/app/addons/ac/intl.common.js
+++ b/lib/app/addons/ac/intl.common.js
@@ -45,17 +45,13 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
          * @return {string|Object} translated string for label or if no label was provided an object containing all resources.
          */
         lang: function(label, args) {
-            var lang = this.ac.instance.closestLang || 'yuiRootLang',
+            var lang = this.ac.instance.closestLang,
                 module = this.ac.instance.controller,
-                activeLang = Y.Intl._mod(module).yuiActiveLang,
                 string;
 
-            // Deleting the active lang in order to be independent of
-            // previous languages set.
-            delete Y.Intl._mod(module).yuiActiveLang;
-            Y.Intl.setLang(module, lang);
-            string = Y.Intl.get(module, label);
-            Y.Intl._mod(module).yuiActiveLang = activeLang;
+            if (this.setLang(module, lang)) {
+                string = Y.Intl.get(module, label);
+            }
             if (string && args) {
                 // simple string substitution
                 return Y.Lang.sub(string, Y.Lang.isString(args) ? [args] : args);
@@ -71,18 +67,43 @@ YUI.add('mojito-intl-addon', function(Y, NAME) {
          * @return {string} formatted data for language.
          */
         formatDate: function(date) {
-            var lang = this.ac.instance.closestLang || 'en',
+            var lang = this.ac.instance.closestLang,
                 module = 'datatype-date-format',
-                activeLang = Y.Intl._mod(module).yuiActiveLang,
                 formattedDate;
 
-            // Deleting the active lang in order to be independent of
-            // previous languages set.
-            delete Y.Intl._mod(module).yuiActiveLang;
-            Y.Intl.setLang(module, lang);
-            formattedDate = Y.DataType.Date.format(date, {format: '%x'});
-            Y.Intl._mod(module).yuiActiveLang = activeLang;
+            if (this.setLang(module, lang, 'en-US')) {
+                formattedDate = Y.DataType.Date.format(date, {format: '%x'});
+            }
             return formattedDate;
+        },
+
+
+        /*
+         * Sets the closest lang available to the specified lang, resorting to the closest
+         * lang to the specified default lang or the root lang.
+         * @method setLang
+         * @param {String} module The module name.
+         * @param {String} lang The BCP 47 language tag.
+         * @param {String} defaultLang The BCP 47 language tag of the back up lang.
+         * @return boolean true if successful, false if not.
+         */
+        setLang: function (module, lang, defaultLang) {
+            var availableLangs = Object.keys(Y.Intl._mod(module));
+
+            // Choose the best language available.
+            // Preferably this is the closest lang available to the lang specified,
+            // otherwise it is the closest lang to the specified default lang,
+            // otherwise it is the root lang.
+            lang = Y.Intl.lookupBestLang(lang, availableLangs)
+                || (defaultLang && Y.Intl.lookupBestLang(defaultLang, availableLangs))
+                || 'yuiRootLang';
+
+            // If none of these are available then this method returns false and
+            // this.lang and this.formatDate do not translate, because otherwise the current active
+            // lang would be used, which would mean that different requests or mojits can
+            // interfere with each other.
+
+            return Y.Intl.setLang(module, lang);
         }
     };
 

--- a/tests/unit/lib/app/addons/ac/test-intl.common.js
+++ b/tests/unit/lib/app/addons/ac/test-intl.common.js
@@ -36,6 +36,11 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                 args: [ac.instance.controller, 'key'],
                 returns: 'translation'
             });
+            Mock.expect(mockYIntl, {
+                method: 'lookupBestLang',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Object],
+                returns: 'foo'
+            });
 
             var yIntl = Y.Intl;
             Y.Intl = mockYIntl;
@@ -75,6 +80,11 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                 args: [ac.instance.controller, 'key'],
                 returns: 'translation {0} {1}'
             });
+            Mock.expect(mockYIntl, {
+                method: 'lookupBestLang',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Object],
+                returns: 'foo'
+            });
 
             var yIntl = Y.Intl;
             Y.Intl = mockYIntl;
@@ -113,6 +123,12 @@ YUI().use('mojito-intl-addon', 'test', 'datatype-date', function(Y) {
                 args: ['datatype-date-format', 'foo'],
                 returns: 'true'
             });
+            Mock.expect(mockYIntl, {
+                method: 'lookupBestLang',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Object],
+                returns: 'foo'
+            });
+
             var yIntl = Y.Intl;
             Y.Intl = mockYIntl;
             Y.Intl._mod = function () {


### PR DESCRIPTION
Removed hack that ensured mojits/requests translations didn't interfere. Now the closest available language is determined, resorting to a default lang or the root lang; if no language is set, then no translation is performed, this prevent the active language from being used, thereby eliminating mojits/requests interference.
