### PR TITLE
Removing connect's deprecation warnings

### DIFF
--- a/lib/app/middleware/mojito-parser-body.js
+++ b/lib/app/middleware/mojito-parser-body.js
@@ -18,3 +18,27 @@ Export a function which can create a body parser.
 @return {Object} The newly constructed body parser.
 **/
 module.exports = require('express').bodyParser;
+
+var express = require('express'),
+    json = express.json,
+    urlencoded = express.urlencoded;
+
+module.exports = function bodyParser(options) {
+    var _json = json(options),
+        _urlencoded = urlencoded(options);
+
+
+    return function (req, res, next) {
+        _json(req, res, function (err) {
+            if (err) {
+                return next(err);
+            }
+            _urlencoded(req, res, function (err) {
+                if (err) {
+                    return next(err);
+                }
+                next();
+            });
+        });
+    };
+};

--- a/lib/app/middleware/mojito-parser-body.js
+++ b/lib/app/middleware/mojito-parser-body.js
@@ -27,7 +27,6 @@ module.exports = function bodyParser(options) {
     var _json = json(options),
         _urlencoded = urlencoded(options);
 
-
     return function (req, res, next) {
         _json(req, res, function (err) {
             if (err) {


### PR DESCRIPTION
Connect's multipart has been deprecated (see [connect multipart](http://www.senchalabs.org/connect/multipart.html)), and [express.bodyParser](https://github.com/senchalabs/connect/blob/2.x/lib/middleware/bodyParser.js#L54) is still making use of it. Since mojito's [parser-body middleware](https://github.com/yahoo/mojito/blob/develop/lib/app/middleware/mojito-parser-body.js) is using the express bodyParser there are connect warning during applications startup:

```
connect: multipart: use parser (multiparty, busboy, formidable) directly
connect: limit: Restrict request size at location of read
```

This pull request simply takes the original express.bodyParser [implementation](https://github.com/senchalabs/connect/blob/2.x/lib/middleware/bodyParser.js#L54), without the multipart support. This means that users would have to use their own middleware to process file uploads.
