### PR TITLE
Clearer error messages

### DIFF
--- a/lib/app/addons/rs/yui.js
+++ b/lib/app/addons/rs/yui.js
@@ -600,6 +600,11 @@ YUI.add('addon-rs-yui', function(Y, NAME) {
             var store = this.get('host');
 
             this._captureYUIModuleDetails(res);
+
+            if (!res.yui) {
+                // Do not add YUI resources that failed while capturing details.
+                return new Y.Do.Halt();
+            }
         },
 
 

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -322,7 +322,7 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                 actionFunction = '__call';
             } else {
                 // If there is still no joy then die
-                error = new Error("No method '" + command.action + "' on controller type '" + command.instance.type + "'");
+                error = new Error('Action "' + this.action + '" not defined by the controller named "' +  this.instance.controller + '" of the "' + this.type + '" mojit.');
                 error.code = 404;
                 throw error;
             }

--- a/lib/app/autoload/action-context.common.js
+++ b/lib/app/autoload/action-context.common.js
@@ -322,7 +322,8 @@ YUI.add('mojito-action-context', function(Y, NAME) {
                 actionFunction = '__call';
             } else {
                 // If there is still no joy then die
-                error = new Error('Action "' + this.action + '" not defined by the controller named "' +  this.instance.controller + '" of the "' + this.type + '" mojit.');
+                error = new Error('Action "' + this.action + '" not defined by the controller named "'
+                    +  this.instance.controller + '" of the "' + this.type + '" mojit.');
                 error.code = 404;
                 throw error;
             }

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -72,11 +72,8 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                     store: this.store
                 });
             } catch (e) {
-                Y.log('Error from dispatch on instance \'' +
-                    (command.instance.id || '@' + command.instance.type) +
-                    '\':', 'error', NAME);
-                Y.log(e.message, 'error', NAME);
-                Y.log(e.stack, 'error', NAME);
+                Y.log('Error dispatching \'' +
+                    (command.instance.id || '@' + command.instance.type) + '\': \n' + e.stack, 'error', NAME);
                 adapter.error(e);
             }
             // HookSystem::StartBlock
@@ -137,35 +134,36 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
 
             store.expandInstance(command.instance, command.context,
                 function (err, instance) {
+                    var errorMessage;
 
                     // HookSystem::StartBlock
                     Y.mojito.hooks.hook('dispatch', adapter.hook, 'end', command);
                     // HookSystem::EndBlock
 
                     if (err || !instance || !instance.controller) {
-
-                        adapter.error(new Error('Cannot expand instance [' + (command.instance.base || '@' +
-                            command.instance.type) + '], or instance.controller is undefined'));
+                        errorMessage = 'Error expanding instance for "' +
+                            (command.instance.id || command.instance.base || command.instance.type) + '"';
+                        Y.log(errorMessage + (err ? ': \n' + err.stack :
+                                instance && !instance.controller ? ': no valid controller found for the "' + instance.type + '" mojit' : ''), 'error', NAME);
+                        adapter.error(new Error(errorMessage));
                         return;
-
                     }
 
                     // We replace the given instance with the expanded instance.
                     command.instance = instance;
 
                     if (!Y.mojito.controllers[instance.controller]) {
+                        errorMessage = 'Invalid controller for the "' + command.instance.type + '" mojit';
                         // the controller was not found, we should halt
-                        adapter.error(new Error('Invalid controller name [' +
-                            command.instance.controller + '] for mojit [' +
-                            command.instance.type + '].'));
+                        Y.log(errorMessage + '. The controller name "' + instance.controller +
+                            '" did not set its actions under Y.namespace(\'mojito.controllers\')[\'' + instance.controller + '\']', 'error', NAME);
+                        adapter.error(new Error(errorMessage));
                     } else {
                         // dispatching AC
                         my._createActionContext(command, adapter);
                     }
-
                 });
         }
-
     };
 
 }, '0.1.0', {requires: [

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -144,7 +144,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                         errorMessage = 'Error expanding instance for "' +
                             (command.instance.id || command.instance.base || command.instance.type) + '"';
                         Y.log(errorMessage + (err ? ': \n' + err.stack :
-                                instance && !instance.controller ? ': no valid controller found for the "' + instance.type + '" mojit' : ''), 'error', NAME);
+                                instance && !instance.controller ? ': no valid controller found in the "' + instance.type + '" mojit' : ''), 'error', NAME);
                         adapter.error(new Error(errorMessage));
                         return;
                     }
@@ -153,10 +153,10 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
                     command.instance = instance;
 
                     if (!Y.mojito.controllers[instance.controller]) {
-                        errorMessage = 'Invalid controller for the "' + command.instance.type + '" mojit';
+                        errorMessage = 'Invalid controller, named "' + instance.controller + '", in the "' + command.instance.type + '" mojit';
                         // the controller was not found, we should halt
-                        Y.log(errorMessage + '. The controller name "' + instance.controller +
-                            '" did not set its actions under Y.namespace(\'mojito.controllers\')[\'' + instance.controller + '\']', 'error', NAME);
+                        Y.log(errorMessage + '. The controller does not define its actions under Y.namespace(\'mojito.controllers\')[\'' +
+                            instance.controller + '\']', 'error', NAME);
                         adapter.error(new Error(errorMessage));
                     } else {
                         // dispatching AC

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -1653,7 +1653,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             ress = this._mojitRVs[type];
 
             if (!ress) {
-                throw new Error('Cannot find the "' + type + '" mojit. Make sure "' + type + '" exists in the application."');
+                throw new Error('Cannot find the "' + type + '" mojit. Make sure "' + type + '" exists in the application.');
             }
 
             this._mojitDetails[type] = {};

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -586,6 +586,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 spec.config = {};
             }
 
+            if (!spec.type) {
+                return cb(new Error('Instance is missing a mojit type.'));
+            }
+
             // type details
             try {
                 typeDetails = this.getMojitTypeDetails(env, ctx, spec.type);
@@ -658,7 +662,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
                 // if lazyLangs is on then determine the closetLang for this mojit and add the corresponding lang resources
                 // if they havent been added already.
-                if (this.lazyLangs) {
+                if (this._unloadedLangs[mojitType]) {
                     closestLang = Y.mojito.util.findClosestLang(ctx.lang, this._unloadedLangs[mojitType]);
                     newModules = this._loadMojitLangs(mojitType, closestLang) || newModules;
                 }
@@ -1532,7 +1536,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          * You most often don't want to call this directly, but instead to hook
          * into it using the AOP mechanism of `Y.Plugin.Base`:
          *
-         *     this.beforeHostMethod('parseResourceVersion', this._myParseResource, this);
+         *     this.beforeHostMethod('addResourceVersion', this._myAddResourceVersion, this);
          *
          * @method addResourceVersion
          * @param {object} res the resource version
@@ -1647,6 +1651,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             }
 
             ress = this._mojitRVs[type];
+
+            if (!ress) {
+                throw new Error('Cannot find the "' + type + '" mojit. Make sure "' + type + '" exists in the application."');
+            }
 
             this._mojitDetails[type] = {};
 

--- a/lib/output-handler.server.js
+++ b/lib/output-handler.server.js
@@ -54,7 +54,7 @@ OutputHandler.prototype = {
             size,
             memDebug = {};
 
-        this.logger.log('done', 'info', NAME);
+        this.logger.log('done', 'mojito', NAME);
         this._readMeta(meta);
         this._writeHeaders();
         if (!data ||

--- a/tests/unit/lib/app/autoload/test-action-context.common.js
+++ b/tests/unit/lib/app/autoload/test-action-context.common.js
@@ -745,6 +745,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                     instance: {
                         id: 'id',
                         type: 'TypeGeneral',
+                        controller: 'GeneralController',
                         acAddons: [],
                         views: {}
                     }
@@ -764,7 +765,7 @@ YUI().use('mojito-action-context', 'test', function (Y) {
                 error = err;
             }
             A.isNotUndefined(error);
-            A.areSame("No method 'index' on controller type 'TypeGeneral'", error.message.toString());
+            A.areSame('Action "index" not defined by the controller named "GeneralController" of the "TypeGeneral" mojit.', error.message.toString());
         },
 
         'test controller __call': function() {


### PR DESCRIPTION
There are many different kinds of error conditions due to an invalid configured mojit; however mojito usually prints the undescriptive error below:

```
error: (outputhandler.server): { [Error: Cannot expand instance [searchhtmlframe], or instance.controller is undefined] code: 500 }
```

This makes it difficult to trace the actual problem. This commit addresses this problem by giving more useful error messages as shown below:
#### Mojit is missing:

```
error: (mojito-dispatcher): 
Error expanding instance for "searchhtmlframe": 
Error: Cannot find the "ShakerPipelineFrame" mojit. Make sure "ShakerPipelineFrame" exists in the application.
    at ResourceStore.Y.extend.resolveVersion ...
```
#### Mojit controller is missing

This means either the controller doesn't exist, it never called YUI.add, or it had a syntax error.

```
error: (mojito-dispatcher): Error expanding instance for "searchhtmlframe": no valid controller found in the "ShakerPipelineFrame" mojit
```
#### Mojit specs is missing a type:

```
error: (mojito-dispatcher): 
Error expanding instance for "searchhtmlframe": 
Error: Instance is missing a mojit type.
    at ResourceStore.Y.extend.expandInstanceForEnv ...
```
#### Controller did not set Y.mojito.controller[NAME] properly

**Before:**

```
error: (outputhandler.server): { [Error: Invalid controller name [ShakerPipelineFrameMojit] for mojit [ShakerPipelineFrame].] code: 500 }
```

**After:**

```
error: (mojito-dispatcher): Invalid controller, named "ShakerPipelineFrameMojit", in the "ShakerPipelineFrame" mojit. The controller does not define its actions under Y.namespace('mojito.controllers')['ShakerPipelineFrameMojit']
```
