### PR TITLE
Catching and printing exceptions in binders' init/bind methods

### DIFF
--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -140,7 +140,7 @@ YUI.add('mojito-client', function(Y, NAME) {
             try {
                 binder.bind(node, element);
             } catch (e) {
-                Y.log(e.stack || e.message, 'error');
+                Y.log(e.stack || e.message, 'error', NAME);
             }
         }
         // all automatic event delegation
@@ -648,7 +648,7 @@ YUI.add('mojito-client', function(Y, NAME) {
                         try {
                             binder.init(mojitProxy);
                         } catch (e) {
-                            Y.log(e.stack || e.message, 'error');
+                            Y.log(e.stack || e.message, 'error', NAME);
                         }
                     }
 
@@ -1028,7 +1028,7 @@ YUI.add('mojito-client', function(Y, NAME) {
                         try {
                             childBinder.bind(childNode, childElement);
                         } catch (e) {
-                            Y.log(e.stack || e.message, 'error');
+                            Y.log(e.stack || e.message, 'error', NAME);
                         }
                     }
                 });

--- a/lib/app/autoload/mojito-client.client.js
+++ b/lib/app/autoload/mojito-client.client.js
@@ -137,7 +137,11 @@ YUI.add('mojito-client', function(Y, NAME) {
 
         if (Y.Lang.isFunction(binder.bind)) {
             // Pass the "node" to the bind method
-            binder.bind(node, element);
+            try {
+                binder.bind(node, element);
+            } catch (e) {
+                Y.log(e.stack || e.message, 'error');
+            }
         }
         // all automatic event delegation
         if (Y.Lang.isFunction(binder.handleClick)) {
@@ -641,11 +645,14 @@ YUI.add('mojito-client', function(Y, NAME) {
                     });
 
                     if (Y.Lang.isFunction(binder.init)) {
-                        binder.init(mojitProxy);
+                        try {
+                            binder.init(mojitProxy);
+                        } catch (e) {
+                            Y.log(e.stack || e.message, 'error');
+                        }
                     }
 
                     onBinderComplete();
-
                 });
 
             }, this);
@@ -1018,7 +1025,11 @@ YUI.add('mojito-client', function(Y, NAME) {
                     if (Y.Lang.isFunction(childBinder.onRefreshView)) {
                         childBinder.onRefreshView(childNode, childElement);
                     } else if (Y.Lang.isFunction(childBinder.bind)) {
-                        childBinder.bind(childNode, childElement);
+                        try {
+                            childBinder.bind(childNode, childElement);
+                        } catch (e) {
+                            Y.log(e.stack || e.message, 'error');
+                        }
                     }
                 });
 


### PR DESCRIPTION
It is important to catch these exceptions, otherwise if a binder has an exception then the mojito-client will stop its execution. This results in other binders not getting called and also leaves the mojito-client in an erroneous state, which can result in the mojito-client always remaining paused, and calls to mp.invoke would never work.
