### PR TITLE
Allow mojits to extend YUI modules in other mojits

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,78 @@
+version 0.9.7
+=============
+
+Features
+--------
+
+* Controllers, models, and binders can be defined as a function with a prototype.
+* Support for easily extending YUI modules, including modules in a different mojit, by using `Y.mojito.Util.extend`.
+`Y.mojito.Util.extend`, defined in 'mojito-util' is the equivalent of [Y.extend](http://yuilibrary.com/yui/docs/api/classes/YUI.html#method_extend), and can accept
+object literals in addition to functions.
+* Controllers inherit the addons of any controllers that it lists in its requires array.
+
+Below is an example where the ImageResult controller extends the Result controller.
+
+mojits/Result/controller.server.js
+```js
+YUI.add('ResultController', function (Y, NAME) {
+    Y.namespace('mojito.controllers')[NAME] = {
+        index: function (ac) {
+            var result = this.createResultObject(ac);
+            ac.done({
+                result: result
+            });
+        },
+        createResultObject: function (ac) {
+            return {
+                title: ac.config.get('title'),
+                text: ac.config.get('text)
+            };
+        }
+    };
+}, '0.0.1', {
+    requires: [
+        'mojito-config-addon'
+    ]
+});
+
+```
+
+mojits/ImageResult/controller.server.js
+```js
+YUI.add('ImageResultController', function (Y, NAME) {
+    var ResultController = Y.mojito.controllers.ResultController,
+        // Constructor for this controller.
+        ImageResultController = function () {
+            // Hook into the original createResultObject method, in order
+            // to call this controllers' augmentResult method.
+            Y.Do.after(this.augmentResult, this, 'createResultObject')
+        }
+    Y.namespace('mojito.controllers')[NAME] = ImageResultController;
+
+    // Extend the ResultController, adding the augmentResult custom method.
+    Y.mojito.Util.extend(ImageResultController, ResultController, {
+        augmentResult: function () {
+            Y.Do.currentRetVal.image = {
+                src: 'myImage'
+            };
+        }
+    });
+}, '0.0.1', {
+    requires: [
+        'ResultController',
+        'mojito-util'
+    ]
+});
+```
+
+The ImageResult controller uses `Y.mojito.Util.extend` in order to extend the Result controller and add
+custom methods. The controller is defined as a function that serves as a constructor.
+In this function, the controller hooks into createResultObject in order to call augmentResult after.
+Notice that the ImageResult controller does not have to re-specify the config addon in its requires array since
+this addon is inferred from the required ResultController.
+
+
+
 version 0.9.6
 =============
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,7 +10,7 @@ Features
 object literals in addition to functions.
 * Controllers inherit the addons of any controllers that is listed in its requires array.
 
-Below is an example where the `ImageResult` controller extends the `Result` controller.
+Below is an example where the `ImageResult` controller extends the `Result` controller:
 
 mojits/Result/controller.server.js
 ```js

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,11 +6,11 @@ Features
 
 * Controllers, models, and binders can be defined as a function with a prototype.
 * Support for easily extending YUI modules, including modules in a different mojit, by using `Y.mojito.Util.extend`.
-`Y.mojito.Util.extend`, defined in 'mojito-util' is the equivalent of [Y.extend](http://yuilibrary.com/yui/docs/api/classes/YUI.html#method_extend), and can accept
+`Y.mojito.Util.extend`, defined in 'mojito-util', is the equivalent of [Y.extend](http://yuilibrary.com/yui/docs/api/classes/YUI.html#method_extend), and can accept
 object literals in addition to functions.
-* Controllers inherit the addons of any controllers that it lists in its requires array.
+* Controllers inherit the addons of any controllers that is listed in its requires array.
 
-Below is an example where the ImageResult controller extends the Result controller.
+Below is an example where the `ImageResult` controller extends the `Result` controller.
 
 mojits/Result/controller.server.js
 ```js
@@ -25,7 +25,7 @@ YUI.add('ResultController', function (Y, NAME) {
         createResultObject: function (ac) {
             return {
                 title: ac.config.get('title'),
-                text: ac.config.get('text)
+                text: ac.config.get('text')
             };
         }
     };
@@ -46,7 +46,8 @@ YUI.add('ImageResultController', function (Y, NAME) {
             // Hook into the original createResultObject method, in order
             // to call this controllers' augmentResult method.
             Y.Do.after(this.augmentResult, this, 'createResultObject')
-        }
+        };
+        
     Y.namespace('mojito.controllers')[NAME] = ImageResultController;
 
     // Extend the ResultController, adding the augmentResult custom method.
@@ -65,11 +66,11 @@ YUI.add('ImageResultController', function (Y, NAME) {
 });
 ```
 
-The ImageResult controller uses `Y.mojito.Util.extend` in order to extend the Result controller and add
+The `ImageResult` controller uses `Y.mojito.Util.extend` in order to extend the `Result` controller and add
 custom methods. The controller is defined as a function that serves as a constructor.
-In this function, the controller hooks into createResultObject in order to call augmentResult after.
-Notice that the ImageResult controller does not have to re-specify the config addon in its requires array since
-this addon is inferred from the required ResultController.
+In this function, the controller hooks into `createResultObject` in order to call `augmentResult` after.
+Notice that the `ImageResult` controller does not have to re-specify the config addon in its requires array since
+this addon is inferred from the required `ResultController`.
 
 
 

--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -69,26 +69,10 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
                 initializer, // script for YUI initialization
                 pathToRoot,
                 pageData = this.adapter && this.adapter.page && this.adapter.page.data,
-                pageRoutes = this.adapter && this.adapter.page && this.adapter.page.routes,
-                updateLoaderCount = store._updateLoaderCount,
-                loaderRess,
-                lang = this.ac.context.lang;
+                pageRoutes = this.adapter && this.adapter.page && this.adapter.page.routes;
 
-            if (updateLoaderCount) {
-                // Make and process new loader specific to the current lang.
-                loaderRess = store.yui._makeLoaderResourceVersion(lang);
-                store._processNewResources(loaderRess);
-
-                // Calculate the loader meta data.
-                store.yui._precalcLoaderMeta(lang);
-
-                // Only reset store._updateLoaderCount if nothing has changed the updateLoaderCount at the beginning
-                // of this function. Else we should not reset the count since new unaccounted resources have been
-                // added for a different request.
-                if (store._updateLoaderCount === updateLoaderCount) {
-                    store._updateLoaderCount = 0;
-                }
-            }
+            // Update the loader for this lang if there have been newly added lazy mojits/langs.
+            store._updateLoader(this.ac.context.lang);
 
             contextClient = Y.mojito.util.copy(contextServer);
             contextClient.runtime = 'client';

--- a/lib/app/addons/rs/dispatch-helper.js
+++ b/lib/app/addons/rs/dispatch-helper.js
@@ -37,7 +37,11 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
 
 
         initializer: function (config) {
-            this.modules = {}; // Controllers and ac addons.
+            this.modules = {
+                client: {},
+                server: {},
+                common: {}
+            }; // Controllers and ac addons.
             this.beforeHostMethod('addResourceVersion', this.addResourceVersion, this);
             this.onHostEvent('resolveMojitDetails', this.onResolveMojitDetails, this);
         },
@@ -57,10 +61,11 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 // should be derived from its addons requirements, recursively including the addons of
                 // the controllers and addons it requires.
 
+                var affinity = res.affinity.toString();
                 // Do not overwrite a previous module with the same name; this ensures that
                 // if there are duplicate modules, only the shallowest is considered.
-                if (!this.modules[res.yui.name]) {
-                    this.modules[res.yui.name] = res;
+                if (!this.modules[affinity][res.yui.name]) {
+                    this.modules[affinity][res.yui.name] = res;
                 }
             }
         },
@@ -96,22 +101,25 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
             details.acAddons = [];
             (function getRequiredAddons(requires, seen) {
                 var r,
-                    module;
+                    module,
+                    moduleName;
                 for (r = 0; r < requires.length; r++) {
-                    module = requires[r];
-                    if (seen[module] || !self.modules[module] ||
-                            (self.modules[module].affinity.affinity !== env &&
-                                self.modules[module].affinity.affinity !== 'common')) {
+                    moduleName = requires[r];
+
+                    if (seen[moduleName]) {
                         continue;
                     }
-                    seen[module] = true;
+                    seen[moduleName] = true;
 
-                    getRequiredAddons(self.modules[module].yui.meta.requires, seen);
-                    if (acAddonNames[module]) {
-                        details.acAddons.push(acAddonNames[module]);
+                    module = self.modules[env][moduleName] || self.modules.common[moduleName];
+                    if (module) {
+                        getRequiredAddons(module.yui.meta.requires, seen);
+                        if (acAddonNames[moduleName]) {
+                            details.acAddons.push(acAddonNames[moduleName]);
+                        }
                     }
                 }
-            }(self.modules[details.controller].yui.meta.requires, {}));
+            }([details.controller], {}));
         }
 
     });

--- a/lib/app/addons/rs/dispatch-helper.js
+++ b/lib/app/addons/rs/dispatch-helper.js
@@ -56,7 +56,12 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 // We only care about controllers and AC addons since a mojit's controller's addons
                 // should be derived from its addons requirements, recursively including the addons of
                 // the controllers and addons it requires.
-                this.modules[res.yui.name] = res;
+
+                // Do not overwrite a previous module with the same name; this ensures that
+                // if there are duplicate modules, only the shallowest is considered.
+                if (!this.modules[res.yui.name]) {
+                    this.modules[res.yui.name] = res;
+                }
             }
         },
 

--- a/lib/app/addons/rs/dispatch-helper.js
+++ b/lib/app/addons/rs/dispatch-helper.js
@@ -4,6 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
+/*jslint plusplus: true */
 /*global YUI*/
 
 
@@ -43,13 +44,18 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
 
         /**
          * Using AOP, this is called before the ResourceStore's version, in order
-         * to keep track of all the controllers and ac addons.
+         * to keep track of all the controllers and AC addons. These modules are then
+         * used by onResolveMojitDetails in order to precompute list of AC addons for
+         * a mojit's controller.
          * @method addResourceVersion
          * @param {object} res resource version metadata
          * @return {nothing}
          */
         addResourceVersion: function (res) {
-            if (res.type === 'controller' || res.type === 'addon' && res.subtype === 'ac') {
+            if (res.type === 'controller' || (res.type === 'addon' && res.subtype === 'ac')) {
+                // We only care about controllers and AC addons since a mojit's controller's addons
+                // should be derived from its addons requirements, recursively including the addons of
+                // the controllers and addons it requires.
                 this.modules[res.yui.name] = res;
             }
         },
@@ -89,7 +95,8 @@ YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
                 for (r = 0; r < requires.length; r++) {
                     module = requires[r];
                     if (seen[module] || !self.modules[module] ||
-                        (self.modules[module].affinity.affinity !== env && self.modules[module].affinity.affinity !== 'common')) {
+                            (self.modules[module].affinity.affinity !== env &&
+                                self.modules[module].affinity.affinity !== 'common')) {
                         continue;
                     }
                     seen[module] = true;

--- a/lib/app/addons/rs/dispatch-helper.js
+++ b/lib/app/addons/rs/dispatch-helper.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012-2014, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*global YUI*/
+
+
+/**
+ * @module ResourceStoreAddon
+ */
+
+/**
+ * RS addon that computes AC addon dependencies at startup to be attached
+ * at runtime.
+ *
+ * @class RSAddonDispatchHelper
+ * @extension ResourceStore.server
+ */
+YUI.add('addon-rs-dispatch-helper', function (Y, NAME) {
+
+    'use strict';
+
+    var libpath = require('path');
+
+    function RSAddonDispatchHelper() {
+        RSAddonDispatchHelper.superclass.constructor.apply(this, arguments);
+    }
+
+
+    RSAddonDispatchHelper.NS = 'dispatch-helper';
+
+
+    Y.extend(RSAddonDispatchHelper, Y.Plugin.Base, {
+
+
+        initializer: function (config) {
+            this.modules = {}; // Controllers and ac addons.
+            this.beforeHostMethod('addResourceVersion', this.addResourceVersion, this);
+            this.onHostEvent('resolveMojitDetails', this.onResolveMojitDetails, this);
+        },
+
+        /**
+         * Using AOP, this is called before the ResourceStore's version, in order
+         * to keep track of all the controllers and ac addons.
+         * @method addResourceVersion
+         * @param {object} res resource version metadata
+         * @return {nothing}
+         */
+        addResourceVersion: function (res) {
+            if (res.type === 'controller' || res.type === 'addon' && res.subtype === 'ac') {
+                this.modules[res.yui.name] = res;
+            }
+        },
+
+        /**
+         * This is called when the ResourceStore fires this event.
+         * It precomputes the list of AC addons used by the mojit's controller,
+         * to be used later during onGetMojitTypeDetails.
+         * @method onResolveMojitDetails
+         * @param {object} evt The fired event
+         * @return {nothing}
+         */
+        onResolveMojitDetails: function (evt) {
+            var self = this,
+                store = this.get('host'),
+                env = evt.args.env,
+                mojitType = evt.args.type,
+                details = evt.mojitDetails,
+                addonName,
+                acAddonNames = evt.acAddonNames;
+
+            if ('shared' === mojitType) {
+                return;
+            }
+
+            if (!details.controller) {
+                // It's not an error if a mojit is missing a controller, since
+                // some mojits only run on the server side (or only on the
+                // client side).
+                return;
+            }
+
+            details.acAddons = [];
+            (function getRequiredAddons(requires, seen) {
+                var r,
+                    module;
+                for (r = 0; r < requires.length; r++) {
+                    module = requires[r];
+                    if (seen[module] || !self.modules[module] ||
+                        (self.modules[module].affinity.affinity !== env && self.modules[module].affinity.affinity !== 'common')) {
+                        continue;
+                    }
+                    seen[module] = true;
+
+                    getRequiredAddons(self.modules[module].yui.meta.requires, seen);
+                    if (acAddonNames[module]) {
+                        details.acAddons.push(acAddonNames[module]);
+                    }
+                }
+            }(self.modules[details.controller].yui.meta.requires, {}));
+        }
+
+    });
+
+    Y.namespace('mojito.addons.rs')['dispatch-helper'] = RSAddonDispatchHelper;
+
+}, '0.0.1', { requires: [
+    'addon-rs-yui',
+    'plugin',
+    'oop'
+]});

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
-/*jslint anon:true, nomen:true*/
+/*jslint anon:true, nomen:true, newcap:true */
 /*global YUI*/
 
 
@@ -66,7 +66,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             try {
                 ac = new Y.mojito.ActionContext({
                     command: command,
-                    controller: Y.mojito.util.heir(controller),
+                    controller: Y.Lang.isFunction(controller) ? new controller() : Y.mojito.util.heir(controller),
                     dispatcher: this,         // NOTE passing dispatcher.
                     adapter: adapter,
                     store: this.store

--- a/lib/app/autoload/dispatch.server.js
+++ b/lib/app/autoload/dispatch.server.js
@@ -66,7 +66,7 @@ YUI.add('mojito-dispatcher', function (Y, NAME) {
             try {
                 ac = new Y.mojito.ActionContext({
                     command: command,
-                    controller: Y.Lang.isFunction(controller) ? new controller() : Y.mojito.util.heir(controller),
+                    controller: Y.mojito.util.heir(controller),
                     dispatcher: this,         // NOTE passing dispatcher.
                     adapter: adapter,
                     store: this.store

--- a/lib/app/autoload/output-handler.client.js
+++ b/lib/app/autoload/output-handler.client.js
@@ -5,11 +5,12 @@
  */
 
 
-/*jslint anon:true, sloppy:true, browser:true*/
+/*jslint anon:true, nomen:true, browser:true, plusplus:true*/
 /*global YUI*/
 
 
 YUI.add('mojito-output-handler', function(Y, NAME) {
+    'use strict';
 
     var attachAssets,
         complete,
@@ -27,7 +28,8 @@ YUI.add('mojito-output-handler', function(Y, NAME) {
         },
             done = {},
             blobNode = '',
-            doneChecker;
+            doneChecker,
+            executeInlinedScripts;
 
         Y.Object.each(assets, function(types, location) {
             Y.Object.each(types, function(list, type) {
@@ -49,14 +51,44 @@ YUI.add('mojito-output-handler', function(Y, NAME) {
         });
 
         if (blobNode) {
+            blobNode = Y.Node.create(blobNode);
             Y.one('head').append(blobNode);
         }
+
+        // Any scripts contain in assets.blob must be created using document.createElment('script'),
+        // and then replaced, otherwise the scripts never get executed.
+        executeInlinedScripts = function (node) {
+            var i,
+                child,
+                script;
+
+            if (node.tagName === 'SCRIPT') {
+                script = document.createElement('script');
+                script.text = node.text;
+                for (i = 0; i < node.attributes.length; i++) {
+                    if (node.attributes[i].specified) {
+                        script[node.attributes[i].name] = node.attributes[i].value;
+                    }
+                }
+                node.parentNode.replaceChild(script, node);
+                return;
+            }
+
+            for (i = 0; i < node.children.length; i++) {
+                child = node.children[i];
+                executeInlinedScripts(child);
+            }
+        };
 
         doneChecker = function(type) {
             if (type) {
                 done[type] = true;
             }
             if (done.css && done.js) {
+                if (blobNode) {
+                    // Ensure that any inlined script gets executed.
+                    executeInlinedScripts(blobNode._node);
+                }
                 cb();
             }
         };

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -201,7 +201,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this._mojitDetailsCache = {}; // mojitType+poslString+env: resolved resources
 
             this._unloadedLangs = {};    // mojit, lang mapping to an array of lang resources, when lazyLangs is on.
-            this._unloadedDirs = {};     // mojit mapping to an array of unprocessed directories, when lazyMojits is on.
+            this._unloadedMojits = {};   // mojit mapping to an array of unprocessed mojit directories, when lazyMojits is on.
             this._updateLoaderCount = 0; // count keeping track of newly loaded mojits requiring the loader to be updated.
 
             this.YUI = null; // The runtime YUI object.
@@ -643,8 +643,13 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 cacheValue = this._getMojitTypeDetailsCache[cacheKey],
                 newModules = false,
                 closestLang,
+                dependency,
+                defaults,
+                definition,
+                i,
                 r,
                 ress,
+                mojitRes,
                 details;
 
             if ('shared' === mojitType) {
@@ -653,7 +658,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             if (!cacheValue) {
                 // load the mojit if it hasn't been loaded already.
-                if (this._unloadedDirs[mojitType]) {
+                if (this._unloadedMojits[mojitType]) {
                     this._loadMojit(mojitType);
                     newModules = true;
                     // Update the posl in case the newly loaded mojit contains new dimensions.
@@ -667,11 +672,28 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     newModules = this._loadMojitLangs(mojitType, closestLang) || newModules;
                 }
 
-                // The newModules flag indicates that resolveVersion should not return any cached details.
-                details = this.resolveVersion(mojitType, env, posl, newModules);
+                mojitRes = this.getResourceVersions({type: 'mojit', name: mojitType, selector: '*'})[0];
 
-                details.defaults = this.config.readConfigYCB(this._libs.path.join(details.fullPath, 'defaults.json'), ctx);
-                details.definition = this.config.readConfigYCB(this._libs.path.join(details.fullPath, 'definition.json'), ctx);
+                defaults = this.config.readConfigYCB(this._libs.path.join(mojitRes.source.fs.fullPath, 'defaults.json'), ctx);
+                definition = this.config.readConfigYCB(this._libs.path.join(mojitRes.source.fs.fullPath, 'definition.json'), ctx);
+
+                // If lazyMojits is on then we must load any mojit dependency for this mojit
+                // before getting this mojit's details. This ensures that all of the resources
+                // of the dependencies have been added so that this mojit's YUI modules can
+                // refer to any YUI module belonging to its dependencies.
+                if (this.lazyMojits && defaults && Y.Lang.isArray(defaults.dependencies)) {
+                    for (i = 0; i < defaults.dependencies.length; i++) {
+                        dependency = defaults.dependencies[i];
+                        if (this._unloadedMojits[dependency]) {
+                            this._loadMojit(dependency);
+                        }
+                    }
+                }
+
+                // The newModules flag indicates that resolveVersion should not return any cached details.
+                details = this.resolveVersion(mojitType, env, posl, mojitRes, newModules);
+                details.defaults = defaults;
+                details.definition = definition;
                 if (details.defaults && details.defaults.config) {
                     details.config = Y.mojito.util.blend(details.defaults.config, details.config);
                 }
@@ -726,7 +748,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 },
                 template,
                 specPath,
-                modules = {},
                 controller,
                 required = {},
                 addonName,
@@ -802,7 +823,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 }
 
                 if ('addon' === res.type && 'ac' === res.subtype) {
-                    modules[res.yui.name] = this.yui._makeYUIModuleConfig(env, res);
                     // HACK/TODO: we are assuming the name of the filename will be
                     // the same as the addon namespace. This is a bold assumption
                     // and we will do the right thing eventually.
@@ -810,29 +830,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 }
             }
 
-            if (controller) {
-                details.acAddons = [];
-                (function getRequiredAddons(requires, seen) {
-                    var r,
-                        module;
-                    for (r = 0; r < requires.length; r++) {
-                        module = requires[r];
-                        if (!modules[module] || seen[module]) {
-                            continue;
-                        }
-                        seen[module] = true;
-                        getRequiredAddons(modules[module].requires, seen);
-                        if (acAddonNames[module]) {
-                            details.acAddons.push(acAddonNames[module]);
-                        }
-                    }
-                }(controller.requires, {}));
-            }
-
             // Since the binders are not part of the server runtime, but are needed
             // to define the binders map, we need to synthetically build this.
             if (env !== 'client') {
-                clientDetails = this.resolveVersion(type, 'client', posl);
+                clientDetails = this.resolveVersion(type, 'client', posl, mojitRes);
                 details.binders = clientDetails.binders;
             }
 
@@ -844,6 +845,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                     ress: ress,
                     mojitRes: mojitRes
                 },
+                acAddonNames: acAddonNames,
                 mojitDetails: details
             });
 
@@ -1586,6 +1588,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          */
         resolveResourceVersions: function () {
             var mojitType,
+                mojitRes,
                 ress,
                 r,
                 res,
@@ -1610,7 +1613,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                                 continue;
                             }
 
-                            this.resolveVersion(mojitType, envs[e], posls[p]);
+                            mojitRes = this.getResourceVersions({type: 'mojit', name: mojitType, selector: '*'})[0];
+                            this.resolveVersion(mojitType, envs[e], posls[p], mojitRes);
                         }
                     }
                 }
@@ -1623,9 +1627,11 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          * @param  {String} type the mojit type
          * @param  {String} env  the environment: {'client', 'server'}
          * @param  {Array} posl the ordered list of selectors to look resources with
+         * @param  {object} mojitRes resource for the mojit itself
+         * @param  {boolean} update Whether to ignore the mojit details cache since new resource have been added.
          * @return {Object} a mojit details
          */
-        resolveVersion: function (type, env, posl, update) {
+        resolveVersion: function (type, env, posl, mojitRes, update) {
             var s,
                 currentSelector,
                 r,
@@ -1639,7 +1645,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 poslString = posl.toString(),
                 sharedResources,
                 resolvedResources = {},
-                mojitRes,
                 result,
                 // Ignore the cache if update is true.
                 // Update is set to true whenever new resources has been added to this mojit
@@ -1699,9 +1704,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             for (r in sharedResources) {
                 resolvedResources[r] = resolvedResources[r] || sharedResources[r];
             }
-
-            // TODO: should we resolve mojitDetails if there is no corresponding controller?
-            mojitRes = this.getResourceVersions({type: 'mojit', name: type, selector: '*'})[0];
 
             result = this.resolveMojitDetails(env, posl, type, resolvedResources, mojitRes);
             this._mojitDetailsCache[type + poslString + env] = JSON.stringify(result);
@@ -2050,8 +2052,8 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             // If lazy loading mojits and we are currently preloading,
             // then don't process this mojit now unless it is set to false lazyMojits.
             if (this.lazyMojits && !this.preloaded && this.lazyMojits[mojitType] !== false) {
-                this._unloadedDirs[mojitType] = this._unloadedDirs[mojitType] || [];
-                this._unloadedDirs[mojitType].push({
+                this._unloadedMojits[mojitType] = this._unloadedMojits[mojitType] || [];
+                this._unloadedMojits[mojitType].push({
                     dir: dir,
                     dirType: dirType,
                     pkg: pkg
@@ -2117,10 +2119,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             var i;
 
             // Load all directories of the mojit type.
-            for (i = 0; i < this._unloadedDirs[mojitType].length; i++) {
-                this._preloadDirMojit(this._unloadedDirs[mojitType][i].dir,
-                    this._unloadedDirs[mojitType][i].dirType,
-                    this._unloadedDirs[mojitType][i].pkg);
+            for (i = 0; i < this._unloadedMojits[mojitType].length; i++) {
+                this._preloadDirMojit(this._unloadedMojits[mojitType][i].dir,
+                    this._unloadedMojits[mojitType][i].dirType,
+                    this._unloadedMojits[mojitType][i].pkg);
             }
 
             // Let the url addon process the new mojit resource itself.
@@ -2131,7 +2133,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
             // This mojit has now been loaded.
             // The loader now needs to be updated due to the new mojit.
-            delete this._unloadedDirs[mojitType];
+            delete this._unloadedMojits[mojitType];
         },
 
 

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -674,6 +674,10 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
                 mojitRes = this.getResourceVersions({type: 'mojit', name: mojitType, selector: '*'})[0];
 
+                if (!mojitRes) {
+                    throw new Error('Cannot find the "' + mojitType + '" mojit. Make sure "' + mojitType + '" exists in the application.');
+                }
+
                 defaults = this.config.readConfigYCB(this._libs.path.join(mojitRes.source.fs.fullPath, 'defaults.json'), ctx);
                 definition = this.config.readConfigYCB(this._libs.path.join(mojitRes.source.fs.fullPath, 'definition.json'), ctx);
 
@@ -2227,42 +2231,80 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
 
                 this._updateLoaderCount++;
             } else {
-                // If this mojit is lazy loaded and requested from the client side,
-                // then the client side needs to know about its yui modules.
+                // When a mojit is lazy loaded and is requested from the client side,
+                // we need to list any client side YUI modules under details.modules since
+                // the loader meta data on the page may not include some of these newly discovered modules.
+                // This ensures that the client side knows how load these modules.
+
                 poslString = posl.toString();
                 mojitDetails = (this._mojitDetails[mojitType] && this._mojitDetails[mojitType][poslString]) || {};
+
                 ress = mojitDetails.client || [];
                 Array.prototype.push.apply(ress, mojitDetails.common || []);
 
-                details.modules = {};
-                for (r = 0; r < ress.length; r++) {
-                    res = ress[r];
-                    if (!res.yui || !res.yui.name) {
-                        continue;
+                if (ress.length > 0) {
+                    details.modules = {};
+                    for (r = 0; r < ress.length; r++) {
+                        res = ress[r];
+                        if (!res.yui || !res.yui.name) {
+                            continue;
+                        }
+                        details.modules[res.yui.name] = {
+                            path: res.url.replace('/static/', ''),
+                            requires: (res.yui.meta && res.yui.meta.requires) || []
+                        };
+                        if (res.type === 'yui-lang') {
+                            details.modules[res.yui.name].langPack = res.yui.lang || '*';
+                        } else if (res.type === 'controller') {
+                            details.modules[res.yui.name].lang = Object.keys(details.langs);
+                        }
                     }
-                    details.modules[res.yui.name] = {
-                        path: res.url.replace('/static/', ''),
-                        requires: (res.yui.meta && res.yui.meta.requires) || []
-                    };
-                    if (res.type === 'yui-lang') {
-                        details.modules[res.yui.name].langPack = res.yui.lang || '*';
-                    } else if (res.type === 'controller') {
-                        details.modules[res.yui.name].lang = Object.keys(details.langs);
-                    }
-                }
 
-                // Determine the mojit's dependencies.
-                dependencies = details.defaults && details.defaults.dependencies;
-                dependencies = Y.Lang.isArray(dependencies) ? dependencies : [];
-                // Populate details.modules with all the modules of this mojit's dependencies.
-                for (i = 0; i < dependencies.length; i++) {
-                    dependency = dependencies[i];
-                    dependencyDetails = this.getMojitTypeDetails(env, ctx, dependency);
-                    if (dependencyDetails) {
-                        Y.mix(details.modules, dependencyDetails.modules);
+                    // Determine the mojit's dependencies.
+                    dependencies = details.defaults && details.defaults.dependencies;
+                    dependencies = Y.Lang.isArray(dependencies) ? dependencies : [];
+
+                    // Populate details.modules with all the modules of this mojit's dependencies.
+                    for (i = 0; i < dependencies.length; i++) {
+                        dependency = dependencies[i];
+                        dependencyDetails = this.getMojitTypeDetails(env, ctx, dependency);
+                        if (dependencyDetails) {
+                            Y.mix(details.modules, dependencyDetails.modules);
+                        }
                     }
                 }
             }
+        },
+
+
+        /**
+         * Updates the lang specific loader if there have been newly lazy loaded mojits/langs.
+         * @method _updateLoader
+         * @param {string} lang the current context lang
+         * @return whether the loader was updated
+         */
+        _updateLoader: function (lang) {
+            var loaderRess,
+                updateLoaderCount = this._updateLoaderCount;
+
+            if (!updateLoaderCount) {
+                return false;
+            }
+
+            // Make and process new loader specific to the current lang.
+            loaderRess = this.yui._makeLoaderResourceVersion(lang);
+            this._processNewResources(loaderRess);
+
+            // Calculate the loader meta data.
+            this.yui._precalcLoaderMeta(lang);
+
+            // Only reset store._updateLoaderCount if nothing has changed the updateLoaderCount at the beginning
+            // of this function. Else we should not reset the count since new unaccounted resources have been
+            // added for a different request.
+            if (this._updateLoaderCount === updateLoaderCount) {
+                this._updateLoaderCount = 0;
+            }
+            return true;
         },
 
 

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -259,10 +259,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this.lazyLangs = this._appConfigStatic.resourceStore && this._appConfigStatic.resourceStore.lazyLangs;
             this.lazyMojits = this._appConfigStatic.resourceStore && this._appConfigStatic.resourceStore.lazyMojits;
 
-            if (this.lazyMojits && typeof this.lazyMojits !== 'object') {
-                this.lazyMojits = {};
-            }
-
             this.fire('loadConfigs');
         },
 
@@ -2182,7 +2178,9 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
             this.yui._processResources(ress);
 
             // Add new static details.
-            this.getURLDetails(ress, this._staticDetails);
+            if (this._staticDetails) {
+                this.getURLDetails(ress, this._staticDetails);
+            }
         },
 
 

--- a/lib/app/autoload/store.server.js
+++ b/lib/app/autoload/store.server.js
@@ -681,11 +681,14 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 // before getting this mojit's details. This ensures that all of the resources
                 // of the dependencies have been added so that this mojit's YUI modules can
                 // refer to any YUI module belonging to its dependencies.
+                // Note that circular dependencies are allowed and will not result in an infinite loop.
                 if (this.lazyMojits && defaults && Y.Lang.isArray(defaults.dependencies)) {
                     for (i = 0; i < defaults.dependencies.length; i++) {
                         dependency = defaults.dependencies[i];
                         if (this._unloadedMojits[dependency]) {
-                            this._loadMojit(dependency);
+                            // Only get mojit details if the mojit hasn't been loaded;
+                            // this prevents an infinite loop if there are circular dependencies.
+                            this.getMojitTypeDetails(env, ctx, dependency);
                         }
                     }
                 }
@@ -705,7 +708,7 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                 }
 
                 if (newModules) {
-                    this._loadMojitModules(mojitType, details, env, posl);
+                    this._loadMojitModules(mojitType, details, env, ctx, posl);
                 } else if (this.lazyMojits && !this.yui._langLoaderCreated[ctx.lang]) {
                     // if no new modules were added but we still dont have a loader for the current lang,
                     // then we should update the loader.
@@ -1578,7 +1581,6 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
         },
 
 
-
         /**
          * For each resource, stuff it in a map mojitType->selector->affinity
          * that will make it easy to retrieve it later. Then if the lazyResolve config
@@ -2186,14 +2188,21 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
          * @method _loadMojit
          * @param {string} mojitType mojit type
          * @param {object} details about the mojit type
+         * @param {string} env the runtime environment (either `client` or `server`)
+         * @param {object} ctx the context
+         * @param  {Array} posl the ordered list of selectors to look resources with
          */
-        _loadMojitModules: function (mojitType, details, env, posl) {
+        _loadMojitModules: function (mojitType, details, env, ctx, posl) {
             var m,
+                i,
                 r,
                 res,
                 ress,
                 poslString,
                 mojitDetails,
+                dependency,
+                dependencyDetails,
+                dependencies,
                 modules = {};
 
             if (env === 'server') {
@@ -2239,6 +2248,18 @@ YUI.add('mojito-resource-store', function(Y, NAME) {
                         details.modules[res.yui.name].langPack = res.yui.lang || '*';
                     } else if (res.type === 'controller') {
                         details.modules[res.yui.name].lang = Object.keys(details.langs);
+                    }
+                }
+
+                // Determine the mojit's dependencies.
+                dependencies = details.defaults && details.defaults.dependencies;
+                dependencies = Y.Lang.isArray(dependencies) ? dependencies : [];
+                // Populate details.modules with all the modules of this mojit's dependencies.
+                for (i = 0; i < dependencies.length; i++) {
+                    dependency = dependencies[i];
+                    dependencyDetails = this.getMojitTypeDetails(env, ctx, dependency);
+                    if (dependencyDetails) {
+                        Y.mix(details.modules, dependencyDetails.modules);
                     }
                 }
             }

--- a/lib/app/autoload/util.common.js
+++ b/lib/app/autoload/util.common.js
@@ -5,7 +5,7 @@
  */
 
 
-/*jslint anon:true, sloppy:true, nomen:true*/
+/*jslint anon:true, sloppy:true, nomen:true, newcap:true*/
 /*global YUI*/
 
 
@@ -82,8 +82,27 @@ YUI.add('mojito-util', function(Y, NAME) {
             return newObj;
         },
 
+        extend: function (r, s, px, sx) {
+            var o;
+            if (r && typeof r === 'object') {
+                o = r;
+                r = function () {};
+                r.prototype = o;
+            }
+            if (s && typeof s === 'object') {
+                o = s;
+                s = function () {};
+                s.prototype = o;
+            }
+
+            return Y.extend(r, s, px, sx);
+        },
+
 
         heir: function(o) {
+            if (typeof o === 'function') {
+                return new o();
+            }
             function F() {}
             F.prototype = o;
             return new F();
@@ -512,6 +531,7 @@ YUI.add('mojito-util', function(Y, NAME) {
     };
 
 }, '0.1.0', {requires: [
+    'oop',
     'array-extras',
     'json-stringify',
     'mojito'

--- a/lib/app/mojits/TunnelProxy/controller.server.js
+++ b/lib/app/mojits/TunnelProxy/controller.server.js
@@ -38,6 +38,26 @@ YUI.add('TunnelProxy', function(Y, NAME) {
                     return;
                 }
 
+                var store = ac.dispatcher.store,
+                    yuiConfig;
+
+                // If the loader was updated, due to newly loaded lazy mojits/langs,
+                // then we need to make sure the client has the new loader meta.
+                // We do so by adding the updated loader meta to the assets
+                // and using the 'loader-app' module.
+                if (store._updateLoader(ac.context.lang)) {
+                    yuiConfig = store.yui.getYUIConfig(Y.mix({runtime: 'client'}, ac.context));
+
+                    // Add the YUI loader meta to the assets.
+                    meta.assets.top = meta.assets.top || {};
+                    meta.assets.top.js = meta.assets.top.js || [];
+                    // Append the current time to ensure that the loader meta is updated on the client side.
+                    meta.assets.top.js.push(yuiConfig.seed[yuiConfig.seed.length - 1] + '?' + new Date().getTime());
+                    meta.assets.top.blob = meta.assets.top.blob || [];
+                    // Use the loader-app module, to ensure the new loader meta gets applied.
+                    meta.assets.top.blob.push('<script>YUI().use("loader-app");</script>');
+                }
+
                 ac.done({
                     status: meta.http.code,
                     data: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mojito",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "description": "Mojito provides an architecture, components and tools for developers to build complex web applications faster.",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [

--- a/tests/func/applications/frameworkapp/common/application.json
+++ b/tests/func/applications/frameworkapp/common/application.json
@@ -4,6 +4,10 @@
     "staticHandling": {
       "forceUpdate": true
     },
+    "resourceStore": {
+        "lazyMojits": true,
+        "lazyLangs": true
+    },
     "config": {
       "myconfig0": "This is myconfig0 from top application.json",
       "myconfig1": "This is myconfig1 from top application.json",
@@ -154,6 +158,9 @@
                           },
                           "sad": {
                             "type": "GreenChild"
+                          },
+                          "grape": {
+                            "type": "PurpleChild"
                           }
                         }
                       }
@@ -235,7 +242,7 @@
                 "bottom": {
                   "js": [
                     "/static/TestsLayout/assets/main.js"
-                    ] 
+                    ]
                 }
               }
             }

--- a/tests/func/applications/frameworkapp/common/mojits/BlueChild/binders/index.js
+++ b/tests/func/applications/frameworkapp/common/mojits/BlueChild/binders/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('BlueChildBinderIndex', function(Y, NAME) {
 
@@ -18,47 +18,6 @@ YUI.add('BlueChildBinderIndex', function(Y, NAME) {
      * @class Binder
      * @constructor
      */
-    Y.namespace('mojito.binders')[NAME] = {
+    Y.namespace('mojito.binders')[NAME] = Y.mojito.util.extend({}, Y.mojito.binders.ColorChildBinderIndex);
 
-        /**
-         * Binder initialization method, invoked after all binders on the page
-         * have been constructed.
-         */
-        init: function(mojitProxy) {
-            this.mp = mojitProxy;
-            var self = this;
-            this.mp.listen('notify', function(payload) {
-                var data = payload.data,
-                    source = payload.source,
-                    msg = 'Recieved message "' + data.message + '" from ' + source;
-                self.node.one('p').setContent(msg);
-            });
-            this.mp.listen('explode', function(payload) {
-                self.node.one('p').setContent('ASPLODE!');
-            });
-            this.mp.listen('recover', function(payload) {
-                self.node.one('p').setContent('<span style="font-size:20pt">bunny</span>');
-            });
-        },
-
-        /**
-         * The binder method, invoked to allow the mojit to attach DOM event
-         * handlers.
-         *
-         * @param node {Node} The DOM node to which this mojit is attached.
-         */
-        bind: function(node) {
-            this.node = node;
-            var mp = this.mp;
-            node.on('mouseover', function() {
-                node.addClass('hover');
-                mp.broadcast('hover');
-            });
-            node.on('mouseout', function() {
-                node.removeClass('hover');
-            });
-        }
-
-    };
-
-}, '0.0.1', {requires: ['mojito-client']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildBinderIndex']});

--- a/tests/func/applications/frameworkapp/common/mojits/BlueChild/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/BlueChild/controller.common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('BlueChild', function(Y, NAME) {
 
@@ -15,18 +15,6 @@ YUI.add('BlueChild', function(Y, NAME) {
      * @class Controller
      * @constructor
      */
-    Y.namespace('mojito.controllers')[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = Y.mojito.util.extend({}, Y.mojito.controllers.ColorChild);
 
-        /**
-         * Method corresponding to the 'index' action.
-         *
-         * @param ac {Object} The action context that provides access
-         *        to the Mojito API.
-         */
-        index: function(ac) {
-            ac.done({id: ac.config.get('id')});
-        }
-
-    };
-
-}, '0.0.1', {requires: ['mojito', 'mojito-config-addon']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChild', 'BlueChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/BlueChild/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/BlueChild/models/model.common.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
-YUI.add('BlueChildModel', function(Y) {
+YUI.add('BlueChildModel', function(Y, NAME) {
 
 /**
  * The BlueChildModel module.
@@ -15,22 +15,10 @@ YUI.add('BlueChildModel', function(Y) {
      * @class Model
      * @constructor
      */
-    Y.mojito.models.BlueChild = {
+    function BlueModel() {
+        this.color = 'blue';
+    }
+    Y.mojito.models[NAME] = Y.mojito.util.extend(BlueModel, Y.mojito.models.ColorChildModel);
 
-        init: function(config) {
-            this.config = config;
-        },
 
-        /**
-         * Method that will be invoked by the mojit controller to obtain data.
-         *
-         * @param callback {Function} The callback function to call when the
-         *        data has been retrieved.
-         */
-        getData: function(callback) {
-            callback({some:'data'});
-        }
-
-    };
-
-}, '0.0.1', {requires: []});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/BlueChild/views/index.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/BlueChild/views/index.mu.html
@@ -1,3 +1,3 @@
 <div id="{{mojit_view_id}}" class="blue child">
-    <p id="childblue">I'm a blue child.</p>
+    <p id="childblue">I'm a {{color}} child.</p>
 </div>

--- a/tests/func/applications/frameworkapp/common/mojits/BroadCast/assets/static.css
+++ b/tests/func/applications/frameworkapp/common/mojits/BroadCast/assets/static.css
@@ -7,6 +7,9 @@
 .green {
     background-color: #00FF00;
 }
+.purple {
+    background-color: #DBA4DB;
+}
 .child {
     border:  solid 1px red;
 }

--- a/tests/func/applications/frameworkapp/common/mojits/BroadCast/views/static.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/BroadCast/views/static.mu.html
@@ -28,4 +28,9 @@
     <h2 id="childsad">sad</h2>
     {{{sad}}}
 
+    <hr/>
+
+    <h2 id="childgrape">grape</h2>
+    {{{grape}}}
+
 </div>

--- a/tests/func/applications/frameworkapp/common/mojits/ColorChild/binders/index.js
+++ b/tests/func/applications/frameworkapp/common/mojits/ColorChild/binders/index.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('ColorChildBinderIndex', function(Y, NAME) {
+
+/**
+ * The ColorChildBinderIndex module.
+ *
+ * @module ColorChildBinderIndex
+ */
+
+    /**
+     * Constructor for the Binder class.
+     *
+     * @param mojitProxy {Object} The proxy to allow the binder to interact
+     *        with its owning mojit.
+     *
+     * @class Binder
+     * @constructor
+     */
+    Y.namespace('mojito.binders')[NAME] = {
+
+        /**
+         * Binder initialization method, invoked after all binders on the page
+         * have been constructed.
+         */
+        init: function(mojitProxy) {
+            this.mp = mojitProxy;
+            var self = this;
+            this.mp.listen('notify', function(payload) {
+                var data = payload.data,
+                    source = payload.source,
+                    msg = 'Recieved message "' + data.message + '" from ' + source;
+                self.node.one('p').setContent(msg);
+            });
+            this.mp.listen('explode', function(payload) {
+                self.node.one('p').setContent('ASPLODE!');
+            });
+            this.mp.listen('recover', function(payload) {
+                self.node.one('p').setContent('<span style="font-size:20pt">bunny</span>');
+            });
+        },
+
+        /**
+         * The binder method, invoked to allow the mojit to attach DOM event
+         * handlers.
+         *
+         * @param node {Node} The DOM node to which this mojit is attached.
+         */
+        bind: function(node) {
+            this.node = node;
+            var mp = this.mp;
+            node.on('mouseover', function() {
+                node.addClass('hover');
+                mp.broadcast('hover');
+            });
+            node.on('mouseout', function() {
+                node.removeClass('hover');
+            });
+        }
+
+    };
+
+}, '0.0.1', {requires: ['mojito-client']});

--- a/tests/func/applications/frameworkapp/common/mojits/ColorChild/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/ColorChild/controller.common.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('ColorChild', function(Y, NAME) {
+
+/**
+ * The ColorChild module.
+ *
+ * @module ColorChild
+ */
+
+    /**
+     * Constructor for the Controller class.
+     *
+     * @class Controller
+     * @constructor
+     */
+    Y.namespace('mojito.controllers')[NAME] = {
+
+        /**
+         * Method corresponding to the 'index' action.
+         *
+         * @param ac {Object} The action context that provides access
+         *        to the Mojito API.
+         */
+        index: function(ac) {
+            ac.models.get('model').getData(function (data) {
+                ac.done({
+                    id: ac.config.get('id'),
+                    color: data.color
+                });
+            });
+        }
+
+    };
+
+}, '0.0.1', {requires: ['mojito', 'mojito-config-addon', 'mojito-models-addon', 'ColorChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/ColorChild/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/ColorChild/models/model.common.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('ColorChildModel', function (Y, NAME) {
+
+/**
+ * The ColorChildModel module.
+ *
+ * @module ColorChildModel
+ */
+
+    /**
+     * Constructor for the Model class.
+     *
+     * @class Model
+     * @constructor
+     */
+    Y.mojito.models[NAME] = {
+
+        init: function(config) {
+            this.config = config;
+        },
+
+        /**
+         * Method that will be invoked by the mojit controller to obtain data.
+         *
+         * @param callback {Function} The callback function to call when the
+         *        data has been retrieved.
+         */
+        getData: function(callback) {
+            callback({color: this.color});
+        }
+
+    };
+
+}, '0.0.1', {requires: []});

--- a/tests/func/applications/frameworkapp/common/mojits/ColorChild/view/index.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/ColorChild/view/index.mu.html
@@ -1,0 +1,3 @@
+<div id="{{mojit_view_id}}" class="color child">
+    <p id="childcolor">I'm a colorful child.</p>
+</div>

--- a/tests/func/applications/frameworkapp/common/mojits/GreenChild/binders/index.js
+++ b/tests/func/applications/frameworkapp/common/mojits/GreenChild/binders/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('GreenChildBinderIndex', function(Y, NAME) {
 
@@ -18,48 +18,11 @@ YUI.add('GreenChildBinderIndex', function(Y, NAME) {
      * @class Binder
      * @constructor
      */
-    Y.namespace('mojito.binders')[NAME] = {
-
-        /**
-         * Binder initialization method, invoked after all binders on the page
-         * have been constructed.
-         */
-        init: function(mojitProxy) {
-            this.mp = mojitProxy;
-            var self = this;
-
-            this.mp.listen('notify', function(payload) {
-                var data = payload.data,
-                    source = payload.source,
-                    msg = 'Recieved message "' + data.message + '" from ' + source;
-                self.node.one('p').setContent(msg);
-            });
-            this.mp.listen('explode', function(payload) {
-                self.node.one('p').setContent('ASPLODE!');
-            });
-            this.mp.listen('recover', function(payload) {
-                self.node.one('p').setContent('<span style="font-size:20pt">bunny</span>');
-            });
+    function GreenChildBinder() {
+        Y.Do.after(function () {
             this.mp.unlisten();
-        },
+        }, this, 'init');
+    }
+    Y.namespace('mojito.binders')[NAME] = Y.mojito.util.extend(GreenChildBinder, Y.mojito.binders.ColorChildBinderIndex);
 
-        /**
-         * The binder method, invoked to allow the mojit to attach DOM event
-         * handlers.
-         *
-         * @param node {Node} The DOM node to which this mojit is attached.
-         */
-        bind: function(node) {
-            var mp = this.mp;
-            this.node = node;
-            node.on('mouseover', function() {
-                node.addClass('hover');
-                mp.broadcast('hover');
-            });
-            node.on('mouseout', function() {
-                node.removeClass('hover');
-            });
-        }
-    };
-
-}, '0.0.1', {requires: ['mojito-client']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildBinderIndex']});

--- a/tests/func/applications/frameworkapp/common/mojits/GreenChild/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/GreenChild/controller.common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('GreenChild', function(Y, NAME) {
 
@@ -15,18 +15,6 @@ YUI.add('GreenChild', function(Y, NAME) {
      * @class Controller
      * @constructor
      */
-    Y.namespace('mojito.controllers')[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = Y.mojito.util.extend({}, Y.mojito.controllers.ColorChild);
 
-        /**
-         * Method corresponding to the 'index' action.
-         *
-         * @param ac {Object} The action context that provides access
-         *        to the Mojito API.
-         */
-        index: function(ac) {
-            ac.done({id: ac.config.get('id')});
-        }
-
-    };
-
-}, '0.0.1', {requires: ['mojito', 'mojito-config-addon']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChild', 'GreenChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/GreenChild/defaults.json
+++ b/tests/func/applications/frameworkapp/common/mojits/GreenChild/defaults.json
@@ -1,7 +1,6 @@
 [
     {
         "settings": [ "master" ],
-        "config": {
-        }
+        "dependencies": [ "ColorChild" ]
     }
 ]

--- a/tests/func/applications/frameworkapp/common/mojits/GreenChild/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/GreenChild/models/model.common.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
-YUI.add('GreenChildModel', function(Y) {
+YUI.add('GreenChildModel', function(Y, NAME) {
 
 /**
  * The GreenChildModel module.
@@ -15,22 +15,10 @@ YUI.add('GreenChildModel', function(Y) {
      * @class Model
      * @constructor
      */
-    Y.mojito.models.GreenChild = {
+    function GreenModel() {
+        this.color = 'green';
+    }
+    Y.mojito.models[NAME] = Y.mojito.util.extend(GreenModel, Y.mojito.models.ColorChildModel);
 
-        init: function(config) {
-            this.config = config;
-        },
 
-        /**
-         * Method that will be invoked by the mojit controller to obtain data.
-         *
-         * @param callback {Function} The callback function to call when the
-         *        data has been retrieved.
-         */
-        getData: function(callback) {
-            callback({some:'data'});
-        }
-
-    };
-
-}, '0.0.1', {requires: []});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/GreenChild/views/index.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/GreenChild/views/index.mu.html
@@ -1,3 +1,3 @@
 <div id="{{mojit_view_id}}" class="green child">
-    <p id="childgreen">I'm a green child.</p>
+    <p id="childgreen">I'm a {{color}} child.</p>
 </div>

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/binders/index.js
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/binders/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('PurpleChildBinderIndex', function(Y, NAME) {
+
+/**
+ * The PurpleChildBinderIndex module.
+ *
+ * @module PurpleChildBinderIndex
+ */
+
+    /**
+     * Constructor for the Binder class.
+     *
+     * @param mojitProxy {Object} The proxy to allow the binder to interact
+     *        with its owning mojit.
+     *
+     * @class Binder
+     * @constructor
+     */
+    Y.namespace('mojito.binders')[NAME] = Y.mojito.util.extend({}, Y.mojito.binders.BlueChildBinderIndex);
+
+}, '0.0.1', {requires: ['mojito-util', 'BlueChildBinderIndex']});

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/controller.common.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('PurpleChild', function(Y, NAME) {
+
+/**
+ * The PurpleChild module.
+ *
+ * @module PurpleChild
+ */
+
+    /**
+     * Constructor for the Controller class.
+     *
+     * @class Controller
+     * @constructor
+     */
+    Y.namespace('mojito.controllers')[NAME] = Y.mojito.util.extend({}, Y.mojito.controllers.RedChild);
+
+}, '0.0.1', {requires: ['mojito-util', 'RedChild', 'PurpleChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/defaults.yaml
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/defaults.yaml
@@ -1,0 +1,9 @@
+[
+    {
+        "settings": [ "master" ],
+        # Depends on ColorChild for its model
+        # Depends on RedChild for its controller
+        # Depends on BlueChild for its binder
+        "dependencies": [ "ColorChild", "RedChild", "BlueChild" ]
+    }
+]

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/definition.json
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/definition.json
@@ -1,0 +1,5 @@
+[
+    {
+        "settings": [ "master" ]
+    }
+]

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/models/model.common.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
+ */
+YUI.add('PurpleChildModel', function(Y, NAME) {
+
+/**
+ * The PurpleChildModel module.
+ *
+ * @module PurpleChildModel
+ */
+
+    /**
+     * Constructor for the Model class.
+     *
+     * @class Model
+     * @constructor
+     */
+    function PurpleModel() {
+        this.color = 'purple';
+    }
+    Y.mojito.models[NAME] = Y.mojito.util.extend(PurpleModel, Y.mojito.models.ColorChildModel);
+
+
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/PurpleChild/views/index.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/PurpleChild/views/index.mu.html
@@ -1,0 +1,3 @@
+<div id="{{mojit_view_id}}" class="purple child">
+    <p id="childpurple">I'm a {{color}} child.</p>
+</div>

--- a/tests/func/applications/frameworkapp/common/mojits/RedChild/binders/index.js
+++ b/tests/func/applications/frameworkapp/common/mojits/RedChild/binders/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('RedChildBinderIndex', function(Y, NAME) {
 
@@ -18,48 +18,11 @@ YUI.add('RedChildBinderIndex', function(Y, NAME) {
      * @class Binder
      * @constructor
      */
-    Y.namespace('mojito.binders')[NAME] = {
-
-        /**
-         * Binder initialization method, invoked after all binders on the page
-         * have been constructed.
-         */
-        init: function(mojitProxy) {
-            this.mp = mojitProxy;
-            var self = this;
-            this.mp.listen('notify', function(payload) {
-                var data = payload.data,
-                    source = payload.source,
-                    msg = 'Recieved message "' + data.message + '" from ' + source;
-                self.node.one('p').setContent(msg);
-            });
-            this.mp.listen('explode', function(payload) {
-                self.node.one('p').setContent('ASPLODE!');
-            });
-            this.mp.listen('recover', function(payload) {
-                self.node.one('p').setContent('<span style="font-size:20pt">bunny</span>');
-            });
+    function RedChildBinder() {
+        Y.Do.after(function () {
             this.mp.unlisten('notify');
-        },
+        }, this, 'init');
+    }
+    Y.namespace('mojito.binders')[NAME] = Y.mojito.util.extend(RedChildBinder, Y.mojito.binders.ColorChildBinderIndex);
 
-        /**
-         * The binder method, invoked to allow the mojit to attach DOM event
-         * handlers.
-         *
-         * @param node {Node} The DOM node to which this mojit is attached.
-         */
-        bind: function(node) {
-            var mp = this.mp;
-            this.node = node;
-            node.on('mouseover', function() {
-                node.addClass('hover');
-                mp.broadcast('hover');
-            });
-            node.on('mouseout', function() {
-                node.removeClass('hover');
-            });
-        }
-
-    };
-
-}, '0.0.1', {requires: ['mojito-client']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildBinderIndex']});

--- a/tests/func/applications/frameworkapp/common/mojits/RedChild/controller.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/RedChild/controller.common.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
 YUI.add('RedChild', function(Y, NAME) {
 
@@ -15,18 +15,6 @@ YUI.add('RedChild', function(Y, NAME) {
      * @class Controller
      * @constructor
      */
-    Y.namespace('mojito.controllers')[NAME] = {
+    Y.namespace('mojito.controllers')[NAME] = Y.mojito.util.extend({}, Y.mojito.controllers.ColorChild);
 
-        /**
-         * Method corresponding to the 'index' action.
-         *
-         * @param ac {Object} The action context that provides access
-         *        to the Mojito API.
-         */
-        index: function(ac) {
-            ac.done({id: ac.config.get('id')});
-        }
-
-    };
-
-}, '0.0.1', {requires: ['mojito', 'mojito-config-addon']});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChild', 'RedChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/RedChild/defaults.json
+++ b/tests/func/applications/frameworkapp/common/mojits/RedChild/defaults.json
@@ -1,7 +1,6 @@
 [
     {
         "settings": [ "master" ],
-        "config": {
-        }
+        "dependencies": [ "ColorChild" ]
     }
 ]

--- a/tests/func/applications/frameworkapp/common/mojits/RedChild/models/model.common.js
+++ b/tests/func/applications/frameworkapp/common/mojits/RedChild/models/model.common.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2011 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2011-2014 Yahoo! Inc. All rights reserved.
  */
-YUI.add('RedChildModel', function(Y) {
+YUI.add('RedChildModel', function(Y, NAME) {
 
 /**
  * The RedChildModel module.
@@ -15,22 +15,10 @@ YUI.add('RedChildModel', function(Y) {
      * @class Model
      * @constructor
      */
-    Y.mojito.models.RedChild = {
+    function RedModel() {
+        this.color = 'red';
+    }
+    Y.mojito.models[NAME] = Y.mojito.util.extend(RedModel, Y.mojito.models.ColorChildModel);
 
-        init: function(config) {
-            this.config = config;
-        },
 
-        /**
-         * Method that will be invoked by the mojit controller to obtain data.
-         *
-         * @param callback {Function} The callback function to call when the
-         *        data has been retrieved.
-         */
-        getData: function(callback) {
-            callback({some:'data'});
-        }
-
-    };
-
-}, '0.0.1', {requires: []});
+}, '0.0.1', {requires: ['mojito-util', 'ColorChildModel']});

--- a/tests/func/applications/frameworkapp/common/mojits/RedChild/views/index.mu.html
+++ b/tests/func/applications/frameworkapp/common/mojits/RedChild/views/index.mu.html
@@ -1,3 +1,3 @@
 <div id="{{mojit_view_id}}" class="red child">
-    <p id="childred">I'm a red child.</p>
+    <p id="childred">I'm a {{color}} child.</p>
 </div>

--- a/tests/func/common/testmojitproxybroadcaststaticlisten.js
+++ b/tests/func/common/testmojitproxybroadcaststaticlisten.js
@@ -6,7 +6,7 @@ YUI({
     useBrowserConsole: true,
     logInclude: { TestRunner: true }
 }).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
-   
+
     var suite = new Y.Test.Suite("Common: broadcaststaticlisten");
 
     suite.add(new Y.Test.Case({
@@ -20,6 +20,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
                 Y.one('#message').set('value', "helloone");
                 Y.one('#child').set('value', "jeans");
             } else {
@@ -30,6 +31,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+
             };
         }
 

--- a/tests/func/common/testmojitproxybroadcaststaticlisten1.js
+++ b/tests/func/common/testmojitproxybroadcaststaticlisten1.js
@@ -6,7 +6,7 @@ YUI({
     useBrowserConsole: true,
     logInclude: { TestRunner: true }
 }).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
-   
+
     var suite = new Y.Test.Suite("Common: broadcaststaticunlisten1");
 
     suite.add(new Y.Test.Case({
@@ -20,6 +20,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
                 Y.one('#message').set('value', "two");
                 Y.one('#child').set('value', "devil");
             } else {
@@ -30,6 +31,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
             };
         }
 

--- a/tests/func/common/testmojitproxybroadcaststaticlisten2.js
+++ b/tests/func/common/testmojitproxybroadcaststaticlisten2.js
@@ -6,7 +6,7 @@ YUI({
     useBrowserConsole: true,
     logInclude: { TestRunner: true }
 }).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
-   
+
     var suite = new Y.Test.Suite("Common: broadcaststaticunlisten2");
 
     suite.add(new Y.Test.Case({
@@ -20,6 +20,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
                 Y.one('#message').set('value', "three");
                 Y.one('#child').set('value', "happy");
             } else {
@@ -30,6 +31,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
             };
         }
 

--- a/tests/func/common/testmojitproxybroadcaststaticlistenall.js
+++ b/tests/func/common/testmojitproxybroadcaststaticlistenall.js
@@ -6,7 +6,7 @@ YUI({
     useBrowserConsole: true,
     logInclude: { TestRunner: true }
 }).use('node', 'node-event-simulate', 'test', 'console', function (Y) {
-   
+
     var suite = new Y.Test.Suite("Common: broadcaststaticlistenall");
 
     suite.add(new Y.Test.Case({
@@ -20,6 +20,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a blue child.', Y.all('#childblue').item(1).get('innerHTML').match(/I\'m a blue child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
+                Y.Assert.areEqual('I\'m a purple child.', Y.all('#childpurple').item(0).get('innerHTML').match(/I\'m a purple child./gi));
                 Y.one('#message').set('value', "hellofour");
                 Y.one('#child').set('value', "all");
                 Y.one('#sendbutton').simulate('click');
@@ -29,6 +30,7 @@ YUI({
                 Y.Assert.areEqual('I\'m a red child.', Y.all('#childred').item(1).get('innerHTML').match(/I\'m a red child./gi));
                 Y.Assert.areEqual('Recieved message "hellofour" from yui_', Y.all('#childblue').item(0).get('innerHTML').match(/Recieved message "hellofour" from yui_/gi));
                 Y.Assert.areEqual('Recieved message "hellofour" from yui_', Y.all('#childblue').item(1).get('innerHTML').match(/Recieved message "hellofour" from yui_/gi));
+                Y.Assert.areEqual('Recieved message "hellofour" from yui_', Y.all('#childpurple').item(0).get('innerHTML').match(/Recieved message "hellofour" from yui_/gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(0).get('innerHTML').match(/I\'m a green child./gi));
                 Y.Assert.areEqual('I\'m a green child.', Y.all('#childgreen').item(1).get('innerHTML').match(/I\'m a green child./gi));
             };

--- a/tests/func/usecases/usecasestest_descriptor.json
+++ b/tests/func/usecases/usecasestest_descriptor.json
@@ -225,7 +225,7 @@
                            }
                         },
                         {
-                           "test" : "testpagedflickr.js?device=iphone"
+                           "test" : "testpagedflickr.js"
                         }
                     ]
                 }

--- a/tests/unit/lib/app/addons/ac/test-deploy.server.js
+++ b/tests/unit/lib/app/addons/ac/test-deploy.server.js
@@ -61,6 +61,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 getAppConfig: function() {
                     return {};
                 },
+                _updateLoader: function () {
+                    return true;
+                },
                 yui: {
                     getYUIConfig: function() {
                         return {
@@ -117,6 +120,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 getRoutes: function() {
                     return ['routes'];
                 },
+                _updateLoader: function () {
+                    return true;
+                },
                 yui: {
                     getYUIConfig: function() {
                         return {
@@ -168,6 +174,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 },
                 getRoutes: function() {
                     return ['routes'];
+                },
+                _updateLoader: function () {
+                    return true;
                 },
                 yui: {
                     getYUIConfig: function() {
@@ -223,6 +232,9 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
                 },
                 getRoutes: function() {
                     return ['routes'];
+                },
+                _updateLoader: function () {
+                    return true;
                 },
                 yui: {
                     getYUIConfig: function() {

--- a/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
+++ b/tests/unit/lib/app/addons/rs/rs_test_descriptor.json
@@ -16,6 +16,14 @@
                 },
                 "group": "fw,server"
             },
+            "dispatch-helper.server": {
+                "params": {
+                    "lib": "$$config.lib$$/app/addons/rs/dispatch-helper.js,$$config.lib$$/app/addons/rs/config.js,$$config.lib$$/app/addons/rs/selector.js,$$config.lib$$/app/addons/rs/yui.js,$$config.lib$$/app/autoload/store.server.js,$$config.lib$$/app/addons/rs/url.js",
+                    "test": "./test-dispatch-helper.js",
+                    "driver": "nodejs"
+                },
+                "group": "fw,server"
+            },
             "mime.server": {
                 "params": {
                     "lib": "$$config.lib$$/app/addons/rs/mime.js",

--- a/tests/unit/lib/app/addons/rs/test-dispatch-helper.js
+++ b/tests/unit/lib/app/addons/rs/test-dispatch-helper.js
@@ -30,9 +30,10 @@ YUI().use(
             store.preload();
 
             var details = store.getMojitTypeDetails('server', {}, 'PagedFlickr');
+
             // order matters
-            A.areSame(4, details.acAddons.length, 'number of AC addons');
-            A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(details.acAddons), 'correct order');
+            A.areSame(5, details.acAddons.length, 'number of AC addons');
+            A.areSame(JSON.stringify(['config','intl','params','url','models']), JSON.stringify(details.acAddons), 'correct order');
         }
 
 

--- a/tests/unit/lib/app/addons/rs/test-dispatch-helper.js
+++ b/tests/unit/lib/app/addons/rs/test-dispatch-helper.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2014, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+YUI().use(
+    'base',
+    'oop',
+    'mojito-resource-store',
+    'addon-rs-yui',
+    'addon-rs-dispatch-helper',
+    'json',
+    'test',
+    function(Y) {
+
+    var suite = new YUITest.TestSuite('mojito-addon-rs-dispatch-helper-tests'),
+        libpath = require('path'),
+        mojitoRoot = libpath.join(__dirname, '../../../../../../lib'),
+        A = Y.Assert;
+
+
+    suite.add(new YUITest.TestCase({
+
+        name: 'dispatch-helper rs addon tests',
+
+
+        'augment getMojitTypeDetails with AC addons': function() {
+            var fixtures = libpath.join(__dirname, '../../../../../fixtures/gsg5');
+            var store = new Y.mojito.ResourceStore({ root: fixtures, mojitoRoot: mojitoRoot });
+            store.preload();
+
+            var details = store.getMojitTypeDetails('server', {}, 'PagedFlickr');
+            // order matters
+            A.areSame(4, details.acAddons.length, 'number of AC addons');
+            A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(details.acAddons), 'correct order');
+        }
+
+
+    }));
+
+    Y.Test.Runner.add(suite);
+
+});

--- a/tests/unit/lib/app/autoload/test-store.server.js
+++ b/tests/unit/lib/app/autoload/test-store.server.js
@@ -403,13 +403,6 @@ YUI().use(
                 store.expandInstance(spec, ctx, function(err, instance) {
                     A.areSame(libpath.join(fixtures, 'mojits/PagedFlickr/views/index.iphone.hb.html'), instance.views.index['content-path']);
                 });
-            },
-
-            'augment getMojitTypeDetails with AC addons': function() {
-                var details = store.getMojitTypeDetails('server', {}, 'PagedFlickr');
-                // order matters
-                A.areSame(4, details.acAddons.length, 'number of AC addons');
-                A.areSame(JSON.stringify(['config','intl','params','url']), JSON.stringify(details.acAddons), 'correct order');
             }
 
         }));


### PR DESCRIPTION
This pull request allows mojits to easily extend YUI modules of other mojits. For example:

mojits/Vehicle/controller.server.js

``` js
YUI.add('VehicleController', function (Y, NAME) {
    var Vehicle = function () {
        this.type = 'Vehicle';
        this.transmission = 'automatic';
    };

    Y.namespace('mojito.controllers')[NAME] = Vehicle;
    Y.extend(Vehicle, Y.Base, {
        index: function () {
            ac.done(ac.params.body('brand') + ' ' + this.getType());
        },
        getType: function () {
            return this.type;
        }
    });
}, '0.0.1', {
    requires: {
        'oop',
        'mojito-params-addon'
    }
});
```

mojits/Motorcycle/controller.server.js

``` js
YUI.add('MotorcycleController', function (Y, NAME) {
    var Vehicle = Y.mojito.controllers.VehicleController,
        Motorcycle = function () {
            Motorcycle.superclass.constructor.call(this);
            this.type = 'Motorcycle';
            this.transmission = 'manual';
        };

    Y.namespace('mojito.controllers')[NAME] = Motorcycle;
    Y.mojito.util.extend(Motorcycle, Vehicle);
}, '0.0.1', {
    requires: {
        'mojito-util',
        'VehicleController'
    }
});
```

In this example, the Motorcycle mojit extends the Vehicle mojit, which extends the Y.Base class (extending Y.Base is not a requirement, the example just illustrates multiple level of extensions). Notice that the controllers can be defined as a function; this allows mojits to extend using Y.extend, which ensures that the prototype chain is maintained regardless of how many levels of extensions. Also notice that the Motorcycle controller does not have to re-specify the 'mojito-params-addon' requirement; it just has to specify the Vehicle controller requirement, and its addon will automatically include any addon required by Vehicle controller.

To ensure that mojit dependencies work with resourceStore > lazyMojits on, mojits depending on other mojits should specify their dependencies in defaults.json:

mojits/Motorcycle/defaults.json

``` js
[{
    "settings": [ "master" ],
    "dependencies": [ "Vehicle" ]
}]
```
