### PR TITLE
Route annotations in routes.json and hidding routes from the client

### DIFF
--- a/lib/app/addons/ac/deploy.server.js
+++ b/lib/app/addons/ac/deploy.server.js
@@ -69,7 +69,7 @@ YUI.add('mojito-deploy-addon', function (Y, NAME) {
                 initializer, // script for YUI initialization
                 pathToRoot,
                 pageData = this.adapter && this.adapter.page && this.adapter.page.data,
-                pageRoutes = this.adapter && this.adapter.page && this.adapter.page.routes,
+                pageRoutes = this.adapter && this.adapter.page && this.adapter.page.clientRoutes,
                 updateLoaderCount = store._updateLoaderCount,
                 loaderRess,
                 lang = this.ac.context.lang;

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -107,7 +107,7 @@ module.exports = {
     The `command` should be attached to the request.
 
     @protected
-    @method handleRequest 
+    @method handleRequest
     @param {http.ServerRequest} req
         @param {Object} req.command the mojito command to be executed
     @param {http.ServerResponse} res
@@ -135,7 +135,7 @@ module.exports = {
 
         outputHandler.setLogger({ log: Y.log });
 
-        // storing the static app config as well as contextualized 
+        // storing the static app config as well as contextualized
         // app config per request
         outputHandler.page.staticAppConfig = appConfig;
         outputHandler.page.appConfig = store.getAppConfig(context);
@@ -143,9 +143,13 @@ module.exports = {
         // - routes are not contextualized anymore
         if (!CACHE.routes) {
             CACHE.routes = app.getRouteMap();
+            CACHE.clientRoutes = app.getRouteMap({
+                client: true
+            });
         }
 
         outputHandler.page.routes = CACHE.routes;
+        outputHandler.page.clientRoutes = CACHE.clientRoutes;
 
         // HookSystem::StartBlock
         // enabling perf group

--- a/lib/router.js
+++ b/lib/router.js
@@ -18,7 +18,7 @@ Example usage:
 
     app = express();
 
-    app.use(mojito.middleware()); 
+    app.use(mojito.middleware());
     ...
     // or specify app specific paths (preferred)
     app.mojito.attachRoutes(libpath.join(__dirname, 'config', 'routes.json'));
@@ -70,7 +70,7 @@ function readConfigYCB(fullPath) {
 /**
 Normalizes the `routes.json` configuration.
 
-@param {String} name 
+@param {String} name
 @param {Object} route the route object from `routes.json`
 @return {Object} normalized route object
 **/
@@ -162,6 +162,9 @@ module.exports = {
         function registerRoutes(routes) {
             Object.keys(routes).forEach(function (name) {
                 var route = routes[name];
+                route.annotations = route.annotations || {};
+                route.annotations.client = route.annotations.client !== false;
+                app.annotate(route.path, route.annotations);
                 Object.keys(route.verbs).forEach(function (verb) {
                     debug('[%s %s] installing handler', route.call, route.path);
                     verb = verb.toLowerCase();

--- a/tests/unit/lib/app/addons/ac/test-deploy.server.js
+++ b/tests/unit/lib/app/addons/ac/test-deploy.server.js
@@ -20,7 +20,7 @@ YUI().use('mojito-deploy-addon', 'test', 'json-parse', function(Y) {
         setUp: function() {
             addon = new Y.mojito.addons.ac.deploy(
                 {instance: {}}, // command
-                {page: { routes: { 'get': { } } } } // adapter
+                {page: { clientRoutes: { 'get': { } } } } // adapter
             );
             addon.ac = {
                 http: {

--- a/tests/unit/lib/test-router.js
+++ b/tests/unit/lib/test-router.js
@@ -69,7 +69,8 @@ YUI().use('test', function (Y) {
                         // mock expect 'routes01.json'
                         root: ''
                     }
-                }
+                },
+                annotate: function () {}
             };
             router._app = app;
         },


### PR DESCRIPTION
This pull request allows users to specify annotations in routes.json. By default routes in routes.json contain an annotation.client set to true. Setting a route's annotations.client to false prevents the route from being exposed to the client.
