### PR TITLE
Fix configuration loading on Node v0.12.x and io.js.

### DIFF
--- a/lib/app/addons/rs/config.js
+++ b/lib/app/addons/rs/config.js
@@ -145,7 +145,7 @@ YUI.add('addon-rs-config', function(Y, NAME) {
                             throw new Error(parseErr);
                         }
                     } catch (err) {
-                        if (err.errno !== 34) { // if the error was not "no such file or directory" report it
+                        if (err.code !== "ENOENT") { // if the error was not "no such file or directory" report it
                             throw new Error("Error parsing file: " + fullPath + "\n" + err);
                         }
                     }


### PR DESCRIPTION
Use `err.code` for Node forward compatibility.

The `errno` property of errors varies between Node v0.10.x and v0.12.x.
Use the property `code` instead, which is the same across both versions
and io.js.
